### PR TITLE
Adding link to Ruby implementation of BIP0032

### DIFF
--- a/bip-0032.mediawiki
+++ b/bip-0032.mediawiki
@@ -236,6 +236,8 @@ A Java implementation is available at https://github.com/bitsofproof/supernode/b
 
 A C++ implementation is available at https://github.com/CodeShark/CoinClasses/tree/master/tests/hdwallets
 
+A Ruby implementation is available at https://github.com/wink/money-tree
+
 ==Acknowledgements==
 
 * Gregory Maxwell for the original idea of type-2 deterministic wallets, and many discussions about it.


### PR DESCRIPTION
I had added this link on the wiki, but when the page got moved over to GitHub, the link disappeared.
