### PR TITLE
Update bip-0013.mediawiki

### DIFF
--- a/bip-0013.mediawiki
+++ b/bip-0013.mediawiki
@@ -25,7 +25,7 @@ The new bitcoin address type is constructed in the same manner as existing bitco
 
 Version byte is 5 for a main-network address, 196 for a testnet address.
 The 20-byte hash is the hash of the script that will be used to redeem the coins.
-And the 4-byte checksum is the first four bytes of the SHA256 hash of the version and hash.
+And the 4-byte checksum is the first four bytes of the double SHA256 hash of the version and hash.
 
 ==Rationale==
 


### PR DESCRIPTION
Clarified that the 4-byte checksum is from double SHA256 rounds
