### PR TITLE
Add Type field to table in README

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -10,173 +10,207 @@ Those proposing changes should consider that ultimately consent may rest with th
 !Number
 !Title
 !Owner
+!Type
 !Status
 |- style="background-color: #cfffcf"
 | [[bip-0001.mediawiki|1]]
 | BIP Purpose and Guidelines
 | Amir Taaki
+| Standard
 | Active
 |-
 | [[bip-0010.mediawiki|10]]
 | Multi-Sig Transaction Distribution
 | Alan Reiner
+| Informational
 | Draft
 |- style="background-color: #cfffcf"
 | [[bip-0011.mediawiki|11]]
 | M-of-N Standard Transactions
 | Gavin Andresen
+| Standard
 | Accepted
 |- style="background-color: #ffcfcf"
 | [[bip-0012.mediawiki|12]]
 | OP_EVAL
 | Gavin Andresen
+| Standard
 | Withdrawn
 |- style="background-color: #cfffcf"
 | [[bip-0013.mediawiki|13]]
 | Address Format for pay-to-script-hash
 | Gavin Andresen
+| Standard
 | Final
 |- style="background-color: #cfffcf"
 | [[bip-0014.mediawiki|14]]
 | Protocol Version and User Agent
 | Amir Taaki, Patrick Strateman
+| Standard
 | Accepted
 |- style="background-color: #ffcfcf"
 | [[bip-0015.mediawiki|15]]
 | Aliases
 | Amir Taaki
+| Standard
 | Withdrawn
 |- style="background-color: #cfffcf"
 | [[bip-0016.mediawiki|16]]
 | Pay To Script Hash
 | Gavin Andresen
+| Standard
 | Accepted
 |- style="background-color: #ffcfcf"
 | [[bip-0017.mediawiki|17]]
 | OP_CHECKHASHVERIFY (CHV)
 | Luke Dashjr
 | Withdrawn
+| Draft
 |-
 | [[bip-0018.mediawiki|18]]
 | hashScriptCheck
 | Luke Dashjr
+| Standard
 | Draft
 |-
 | [[bip-0019.mediawiki|19]]
 | M-of-N Standard Transactions (Low SigOp)
 | Luke Dashjr
+| Standard
 | Draft
 |- style="background-color: #ffcfcf"
 | [[bip-0020.mediawiki|20]]
 | URI Scheme
 | Luke Dashjr
+| Standard
 | Replaced
 |- style="background-color: #cfffcf"
 | [[bip-0021.mediawiki|21]]
 | URI Scheme
 | Nils Schneider, Matt Corallo
+| Standard
 | Accepted
 |- style="background-color: #cfffcf"
 | [[bip-0022.mediawiki|22]]
 | getblocktemplate - Fundamentals
 | Luke Dashjr
+| Standard
 | Accepted
 |- style="background-color: #cfffcf"
 | [[bip-0023.mediawiki|23]]
 | getblocktemplate - Pooled Mining
 | Luke Dashjr
+| Standard
 | Accepted
 |- style="background-color: #cfffcf"
 | [[bip-0030.mediawiki|30]]
 | Duplicate transactions
 | Pieter Wuille
+| Standard
 | Accepted
 |- style="background-color: #cfffcf"
 | [[bip-0031.mediawiki|31]]
 | Pong message
 | Mike Hearn
+| Standard
 | Accepted
 |- style="background-color: #cfffcf"
 | [[bip-0032.mediawiki|32]]
 | Hierarchical Deterministic Wallets
 | Pieter Wuille
+| Informational
 | Accepted
 |-
 | [[bip-0033.mediawiki|33]]
 | Stratized Nodes
 | Amir Taaki
+| Standard
 | Draft
 |- style="background-color: #cfffcf"
 | [[bip-0034.mediawiki|34]]
 | Block v2, Height in coinbase
 | Gavin Andresen
+| Standard
 | Accepted
 |- style="background-color: #cfffcf"
 | [[bip-0035.mediawiki|35]]
 | mempool message
 | Jeff Garzik
+| Standard
 | Accepted
 |-
 | [[bip-0036.mediawiki|36]]
 | Custom Services
 | Stefan Thomas
+| Standard
 | Draft
 |- style="background-color: #cfffcf"
 | [[bip-0037.mediawiki|37]]
 | Bloom filtering
 | Mike Hearn and Matt Corallo
+| Standard
 | Accepted
 |-
 | [[bip-0038.mediawiki|38]]
 | Passphrase-protected private key
 | Mike Caldwell
+| Standard
 | Draft
 |-
 | [[bip-0039.mediawiki|39]]
 | Mnemonic code for generating deterministic keys
 | Slush
+| Standard
 | Draft
 |-
 | 40
 | Stratum wire protocol
 | Slush
+| Standard
 | BIP number allocated
 |-
 | 41
 | Stratum mining protocol
 | Slush
+| Standard
 | BIP number allocated
 <!-- 42-49 reserved for stratum extensions -->
 |-
 | [[bip-0050.mediawiki|50]]
 | March 2013 Chain Fork Post-Mortem
 | Gavin Andresen
+| Informational
 | Draft
 <!-- 50 series reserved for a group of post-mortems -->
 |-
 | [[bip-0060.mediawiki|60]]
 | Fixed Length "version" Message (Relay-Transactions Field)
 | Amir Taaki
+| Standard
 | Draft
 |-
 | [[bip-0070.mediawiki|70]]
 | Payment protocol
 | Gavin Andresen
+| Standard
 | Draft
 |-
 | [[bip-0071.mediawiki|71]]
 | Payment protocol MIME types
 | Gavin Andresen
+| Standard
 | Draft
 |-
 | [[bip-0072.mediawiki|72]]
 | Payment protocol URIs
 | Gavin Andresen
+| Standard
 | Draft
 |-
 | [[bip-0073.mediawiki|73]]
 | Use "Accept" header with Payment Request URLs
 | Stephen Pair
+| Standard
 | Draft
 |}
 


### PR DESCRIPTION
I thought it would be nice to enable people browsing BIPs to be able to
tell at a glance which ones are standards track and which are
informational.
