### PR TITLE
Fixed table cell truncation in BIP 70

### DIFF
--- a/bip-0070.mediawiki
+++ b/bip-0070.mediawiki
@@ -84,15 +84,15 @@ about the merchant and a digital signature.
 {|
 | network || either "main" for payments on the production Bitcoin network, or "test" for payments on test network. If a client receives a PaymentRequest for a network it does not support it must reject the request.
 |-
-| outputs|| one or more outputs where Bitcoins are to be sent. If the sum of outputs.amount is zero, the customer will be asked how much to pay, and the bitcoin client may choose any or all of the Outputs (if there are more than one) for payment. If the sum of outputs.amount is non-zero, then the customer will be asked to pay the sum, and the payment shall be split among the Outputs with non-zero amounts (if there are more than one; Outputs with zero amounts shall be ignored).
+| outputs || one or more outputs where Bitcoins are to be sent. If the sum of outputs.amount is zero, the customer will be asked how much to pay, and the bitcoin client may choose any or all of the Outputs (if there are more than one) for payment. If the sum of outputs.amount is non-zero, then the customer will be asked to pay the sum, and the payment shall be split among the Outputs with non-zero amounts (if there are more than one; Outputs with zero amounts shall be ignored).
 |-
-| time|| Unix timestamp (seconds since 1-Jan-1970) when the PaymentRequest was created.
+| time || Unix timestamp (seconds since 1-Jan-1970) when the PaymentRequest was created.
 |-
-| expires|| Unix timestamp after which the PaymentRequest should be considered invalid.
+| expires || Unix timestamp after which the PaymentRequest should be considered invalid.
 |-
-| memo|| UTF-8 encoded, plain-text (no formatting) note that should be displayed to the customer, explaining what this PaymentRequest is for.
+| memo || UTF-8 encoded, plain-text (no formatting) note that should be displayed to the customer, explaining what this PaymentRequest is for.
 |-
-| payment_url|| Secure (usually https) location where a Payment message (see below) may be sent to obtain a PaymentACK.
+| payment_url || Secure (usually https) location where a Payment message (see below) may be sent to obtain a PaymentACK.
 |-
 | merchant_data || Arbitrary data that may be used by the merchant to identify the PaymentRequest. May be omitted if the merchant does not need to associate Payments with PaymentRequest or if they associate each PaymentRequest with a separate payment address.
 |}


### PR DESCRIPTION
Added spaces after cells in the first column of the `PaymentDetails` table because their contents were being truncated by GitHub's markdown renderer.
