### PR TITLE
Fix missing word in pki_data description

### DIFF
--- a/bip-0070.mediawiki
+++ b/bip-0070.mediawiki
@@ -112,7 +112,7 @@ A PaymentRequest is PaymentDetails optionally tied to a merchant's identity:
 |-
 | pki_type  || public-key infrastructure (PKI) system being used to identify the merchant. All implementation should support "none", "x509+sha256" and "x509+sha1".
 |-
-| pki_data || PKI-system data that identifies the merchant and can be used to create a digital signature. In the case of X.509 certificates, pki_data one or more X.509 certificates (see Certificates section below).
+| pki_data || PKI-system data that identifies the merchant and can be used to create a digital signature. In the case of X.509 certificates, pki_data contains one or more X.509 certificates (see Certificates section below).
 |-
 | serialized_payment_details || A protocol-buffer serialized PaymentDetails message.
 |-


### PR DESCRIPTION
I guess this should be uncontroversial.
