### PR TITLE
Assign BIP63 for Stealth Addresses

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -201,6 +201,12 @@ Those proposing changes should consider that ultimately consent may rest with th
 | Standard
 | Draft
 |-
+| 63
+| Stealth Addresses
+| Peter Todd
+| Standard
+| BIP number allocated
+|-
 | [[bip-0070.mediawiki|70]]
 | Payment protocol
 | Gavin Andresen


### PR DESCRIPTION
People are starting to come out of the woodwork and implement this; good to have something to point them to.

I'll do up an initial full-node-only draft.
