### PR TITLE
Fix typos in BIP 14

### DIFF
--- a/bip-0014.mediawiki
+++ b/bip-0014.mediawiki
@@ -66,7 +66,7 @@ Here bitcoin-qt and Spesmilo may use protocol version 5.0, however the internal 
 * Version numbers in the form of Major.Minor.Revision (2.6.41)
 * Repository builds using a date in the format of YYYYMMDD (20110128)
 
-For git repository builds, implementations are free to use the git commitish. However the issue lies in that it is not immediately obvious without the repository which version proceeds another. For this reason, we lightly recommend dates in the format specified above, although this is by no means a requirement.
+For git repository builds, implementations are free to use the git commitish. However the issue lies in that it is not immediately obvious without the repository which version precedes another. For this reason, we lightly recommend dates in the format specified above, although this is by no means a requirement.
 
 Optional -r1, -r2, ... can be appended to user agent version numbers. This is another light recommendation, but not a requirement. Implementations are free to specify version numbers in whatever format needed insofar as it does not include (, ), : or / to interfere with the user agent syntax.
 
@@ -80,7 +80,7 @@ Reserved symbols are therefore: / : ( )
 
 They should not be misused beyond what is specified in this section.
 
-* / seperates the code-stack
+* / separates the code-stack
 * : specifies the implementation version of the particular stack
 * ( and ) delimits a comment which optionally separates data using ;
 


### PR DESCRIPTION
proceeds -> precedes
seperate -> separate
