### PR TITLE
Fix URL spec's handling of parameter separators.

### DIFF
--- a/bip-0021.mediawiki
+++ b/bip-0021.mediawiki
@@ -39,7 +39,7 @@ Graphical bitcoin clients SHOULD register themselves as the handler for the "bit
  messageparam   = "message=" *pchar
  otherparam     = pchar *pchar "=" *pchar
  reqparam       = "req-" pchar *pchar "=" *pchar
- paramsep       = "?" | "&"
+ paramsep       = "&" | ";"
 
 === Query Keys ===
 
@@ -85,7 +85,7 @@ Please see the BNF grammar above for the normative syntax.
 
 [foo] means optional, &lt;bar&gt; are placeholders
 
- <nowiki>bitcoin:<address>[?amount=<amount>][?label=<label>][?message=<message>]</nowiki>
+ <nowiki>bitcoin:<address>[?amount=<amount>][&label=<label>][&message=<message>]</nowiki>
 
 === Examples ===
 


### PR DESCRIPTION
Ensure that the bitcoin URL spec includes the `?` or `&` which separate multiple `bitcoinparam`.  Based on the examples in the rest of the spec, we assume that `?` is always a reasonable separator. The `&` character is also allowed in non-initial positions.
