### PR TITLE
Fix typo for size of derivedhalf1 and derivedhalf2

### DIFF
--- a/bip-0038.mediawiki
+++ b/bip-0038.mediawiki
@@ -139,7 +139,7 @@ Steps to create new encrypted private keys given ''intermediate_passphrase_strin
 # Take the first four bytes of SHA256(SHA256(''generatedaddress'')) and call it ''addresshash''.
 # Now we will encrypt ''seedb''.  Derive a second key from ''passpoint'' using scrypt
 #*Parameters: ''passphrase'' is ''passpoint'' provided from the first party (expressed in binary as 33 bytes).  ''salt'' is ''addresshash'' + ''ownerentropy'', n=1024, r=1, p=1, length=64.  The "+" operator is concatenation.
-#*Split the result into two 16-byte halves and call them ''derivedhalf1'' and ''derivedhalf2''.
+#*Split the 64-byte scrypt result into two 32-byte halves and call them ''derivedhalf1'' and ''derivedhalf2''.
 # Do AES256Encrypt(seedb[0...15]] xor derivedhalf1[0...15], derivedhalf2), call the 16-byte result ''encryptedpart1''
 # Do AES256Encrypt((encryptedpart1[8...15] + seedb[16...23]) xor derivedhalf1[16...31], derivedhalf2), call the 16-byte result ''encryptedseedb''.  The "+" operator is concatenation.
 


### PR DESCRIPTION
The output of scrypt is 64 bytes; so each derivedhalf should be 32 bytes.
