### PR TITLE
Documenting the timestamp for BIP-0030

### DIFF
--- a/bip-0030.mediawiki
+++ b/bip-0030.mediawiki
@@ -17,7 +17,7 @@ So far, the Bitcoin reference implementation always assumed duplicate transactio
 To counter this problem, the following network rule is introduced:
 *Blocks are not allowed to contain a transaction whose identifier matches that of an earlier, not-fully-spent transaction in the same chain.
 
-This rule is to be applied to all blocks whose timestamp is after March 15, 2012, 00:00 UTC (testnet: February 20, 2012 00:00 UTC).
+This rule initially applied to all blocks whose timestamp is after March 15, 2012, 00:00 UTC (testnet: February 20, 2012 00:00 UTC). It was later extended by Commit [https://github.com/bitcoin/bitcoin/commit/ab91bf39b7c11e9c86bb2043c24f0f377f1cf514 Apply BIP30 checks to all blocks except the two historic violations.] to apply to all blocks except the two historic blocks at heights 91842 and 91880 on the main chain that had to be grandfathered in.
 
 ==Rationale==
 Whatever solution is used, the following law must be obeyed to guarantee sane behaviour: the set of usable


### PR DESCRIPTION
Per the linked commit, this rule became active for blocks with timestamps after on March 15, 2012 at 00:00 UTC (February 20, 2012 at 00:00 UTC for testnet).
