### PR TITLE
Add transactions to BIP 0070

### DIFF
--- a/bip-0070.mediawiki
+++ b/bip-0070.mediawiki
@@ -97,8 +97,7 @@ about the merchant and a digital signature.
 {|
 | network || Either "main" for payments on the production Bitcoin network, or "test" for payments on test network. If a client receives a PaymentRequest for a network it does not support it must reject the request.
 |-
-|  in accordance
-with the protocol]].outputs || One or more outputs where Bitcoins are to be sent. If the sum of outputs.amount is zero, the customer will be asked how much to pay, and the bitcoin client may choose any or all of the Outputs (if there are more than one) for payment. If the sum of outputs.amount is non-zero, then the customer will be asked to pay the sum, and the payment shall be split among the Outputs with non-zero amounts (if there are more than one; Outputs with zero amounts shall be ignored).
+| outputs || One or more outputs where Bitcoins are to be sent. If the sum of outputs.amount is zero, the customer will be asked how much to pay, and the bitcoin client may choose any or all of the Outputs (if there are more than one) for payment. If the sum of outputs.amount is non-zero, then the customer will be asked to pay the sum, and the payment shall be split among the Outputs with non-zero amounts (if there are more than one; Outputs with zero amounts shall be ignored).
 |-
 | transactions || One or more transactions specifying how Bitcoins are to be spent. May be used in place of specifying outputs. These transactions are required to be neither valid nor signed and may act as a template or suggestion for the client when creating transactions for payment.
 |-


### PR DESCRIPTION
Hello. I hope this is the right way to introduce this...
If we allow full transactions in addition to outputs as methods of specifying payment,
the protocol could handle more complex types of transactions including contracts.
For example, during a negotiation involving rapidly adjusting micro-payments (https://en.bitcoin.it/wiki/Contracts#Example_7:_Rapidly-adjusted_.28micro.29payments_to_a_pre-determined_party), a merchant may want to continuously send an updated version of a transaction to the client in a payment request rather than a new list of outputs every time. 
Any thoughts?
