### PR TITLE
Link to PHP implementation of BIP32- Passes test vectors.

### DIFF
--- a/bip-0032.mediawiki
+++ b/bip-0032.mediawiki
@@ -269,6 +269,8 @@ A Go implementation is available at https://github.com/WeMeetAgain/go-hdwallet
 
 A JavaScript implementation is available at https://github.com/sarchar/brainwallet.github.com/tree/bip32
 
+A PHP implemetation is available at https://github.com/Bit-Wasp/bitcoin-lib-php
+
 ==Acknowledgements==
 
 * Gregory Maxwell for the original idea of type-2 deterministic wallets, and many discussions about it.


### PR DESCRIPTION
Adding a link to my PHP implementation of BIP32. Passes test vectors from github. 
