### PR TITLE
Multisig transactions standard for large M or N

### DIFF
--- a/bip-0016.mediawiki
+++ b/bip-0016.mediawiki
@@ -29,7 +29,7 @@ This new transaction type is redeemed by a standard scriptSig:
 
     ...signatures... {serialized script}
 
-Transactions that redeem these pay-to-script outpoints are only considered standard if the ''serialized script'' - also referred to as the ''redeemScript'' - is, itself, one of the other standard transaction types.
+Transactions that redeem these pay-to-script outpoints are only considered standard if the ''serialized script'' - also referred to as the ''redeemScript'' - is, itself, one of the other standard transaction types. A special exception is made for M-of-N multisignature transactions: the limit of 3 on the number of pubkeys to redeem, i.e. on M and N, is lifted. See [[#520-byte limitation on serialized script size|the section below]] on limits imposed by maximum script size.
 
 The rules for validating these outpoints when relaying transactions or considering them for inclusion in a new block are as follows:
 


### PR DESCRIPTION
Spends of BIP16 transactions where the serialized script is a multisignature transaction are treated as standard whatever the value of M or N, subject to the limits imposed by maximum serialized script size.
