### PR TITLE
Clarification of how to construct the PaymentRequest signature

### DIFF
--- a/bip-0070.mediawiki
+++ b/bip-0070.mediawiki
@@ -118,7 +118,7 @@ A PaymentRequest is PaymentDetails optionally tied to a merchant's identity:
 |-
 | serialized_payment_details || A protocol-buffer serialized PaymentDetails message.
 |-
-| signature || digital signature over a hash of the protocol buffer serialized variation of the PaymentRequest message, with all fields serialized in numerical order (all current protocol buffer implementations serialize fields in numerical order) and signed using the public key in pki_data.  Before serialization, the signature field must be set to an empty string.
+| signature || digital signature over a hash of the protocol buffer serialized variation of the PaymentRequest message, with all fields serialized in numerical order (all current protocol buffer implementations serialize fields in numerical order) and signed using the public key in pki_data.  Before serialization, the signature field must be set to an empty value so that the field is included in the signed PaymentRequest hash but contains no data.
 |}
 When a Bitcoin wallet application receives a PaymentRequest, it must authorize payment by doing the following:
 


### PR DESCRIPTION
Slightly re-worded description of the signature field in PaymentRequest

The previous phrasing confused me and I had to check the Bitcoin Core source code to see what it was expecting for a signature.
