### PR TITLE
Change date format to ISO 8601

### DIFF
--- a/bip-0001.mediawiki
+++ b/bip-0001.mediawiki
@@ -3,7 +3,7 @@
   Title: BIP Purpose and Guidelines
   Status: Accepted
   Type: Standards Track
-  Created: 19-08-2011
+  Created: 2011-08-19
 </pre>
 
 ==What is a BIP?==
@@ -100,7 +100,7 @@ Each BIP must begin with an RFC 822 style header preamble. The headers must appe
   Status: <Draft | Active | Accepted | Deferred | Rejected |
            Withdrawn | Final | Superseded>
   Type: <Standards Track | Informational | Process>
-  Created: <date created on, in dd-mm-yyyy format>
+  Created: <date created on, in ISO 8601 (yyyy-mm-dd) format>
 * Post-History: <dates of postings to bitcoin mailing list>
 * Replaces: <BIP number>
 * Superseded-By: <BIP number>
@@ -125,7 +125,7 @@ While a BIP is in private discussions (usually during the initial Draft phase), 
 
 The Type header specifies the type of BIP: Standards Track, Informational, or Process.
 
-The Created header records the date that the BIP was assigned a number, while Post-History is used to record the dates of when new versions of the BIP are posted to bitcoin mailing lists. Both headers should be in dd-mmm-yyyy format, e.g. 14-Aug-2001.
+The Created header records the date that the BIP was assigned a number, while Post-History is used to record the dates of when new versions of the BIP are posted to bitcoin mailing lists. Both headers should be in yyyy-mm-dd format, e.g. 2001-08-14.
 
 BIPs may have a Requires header, indicating the BIP numbers that this BIP depends on.
 

--- a/bip-0010.mediawiki
+++ b/bip-0010.mediawiki
@@ -4,7 +4,7 @@
   Author: Alan Reiner
   Status: Draft
   Type: Informational
-  Created: 28-10-2011
+  Created: 2011-10-28
 </pre>
 
 A multi-signature transaction is one where a certain number of Bitcoins are "encumbered" with more than one recipient address.  The subsequent transaction that spends these coins will require each party involved (or some subset, depending on the script), to see the proposed transaction and sign it with their private key.  This necessarily requires collaboration between all parties -- to propose a distribution of encumbered funds, collect signatures from all necessary participants, and then broadcast the completed transaction.

--- a/bip-0011.mediawiki
+++ b/bip-0011.mediawiki
@@ -4,8 +4,8 @@
   Author: Gavin Andresen <gavinandresen@gmail.com>
   Status: Accepted
   Type: Standards Track
-  Created: 18-10-2011
-  Post-History: 02-10-2011
+  Created: 2011-10-18
+  Post-History: 2011-10-02
 </pre>
 
 ==Abstract==

--- a/bip-0012.mediawiki
+++ b/bip-0012.mediawiki
@@ -4,7 +4,7 @@
   Author: Gavin Andresen <gavinandresen@gmail.com>
   Status: Withdrawn
   Type: Standards Track
-  Created: 18-10-2011
+  Created: 2011-10-18
 </pre>
 
 ==Abstract==

--- a/bip-0013.mediawiki
+++ b/bip-0013.mediawiki
@@ -4,7 +4,7 @@
   Author: Gavin Andresen <gavinandresen@gmail.com>
   Status: Final
   Type: Standards Track
-  Created: 18-10-2011
+  Created: 2011-10-18
 </pre>
 
 ==Abstract==

--- a/bip-0014.mediawiki
+++ b/bip-0014.mediawiki
@@ -5,8 +5,8 @@
           Patrick Strateman <bitcoin-bips@covertinferno.org>
   Status: Accepted
   Type: Standards Track
-  Created: 10-11-2011
-  Post-History: 02-11-2011
+  Created: 2011-11-10
+  Post-History: 2011-11-02
 </pre>
 
 In this document, bitcoin will be used to refer to the protocol while Satoshi will refer to the current client in order to prevent confusion.

--- a/bip-0015.mediawiki
+++ b/bip-0015.mediawiki
@@ -4,7 +4,7 @@
   Author: Amir Taaki <genjix@riseup.net>
   Status: Deferred
   Type: Standards Track
-  Created: 10-12-2011
+  Created: 2011-12-10
 </pre>
 
 [[bip-0070.mediawiki|BIP 0070]] (payment protocol) may be seen as the alternative to Aliases.

--- a/bip-0016.mediawiki
+++ b/bip-0016.mediawiki
@@ -4,7 +4,7 @@
   Author: Gavin Andresen <gavinandresen@gmail.com>
   Status: Final
   Type: Standards Track
-  Created: 03-01-2012
+  Created: 2012-01-03
 </pre>
 
 ==Abstract==

--- a/bip-0017.mediawiki
+++ b/bip-0017.mediawiki
@@ -4,7 +4,7 @@
   Author: Luke Dashjr <luke+bip17@dashjr.org>
   Status: Draft
   Type: Withdrawn
-  Created: 18-01-2012
+  Created: 2012-01-18
 </pre>
 
 ==Abstract==

--- a/bip-0018.mediawiki
+++ b/bip-0018.mediawiki
@@ -4,7 +4,7 @@
   Author: Luke Dashjr <luke+bip17@dashjr.org>
   Status: Draft
   Type: Standards Track
-  Created: 27-01-2012
+  Created: 2012-01-27
 </pre>
 
 ==Abstract==

--- a/bip-0019.mediawiki
+++ b/bip-0019.mediawiki
@@ -4,7 +4,7 @@
   Author: Luke Dashjr <luke+bip17@dashjr.org>
   Status: Draft
   Type: Standards Track
-  Created: 30-01-2012
+  Created: 2012-01-30
 </pre>
 
 ==Abstract==

--- a/bip-0020.mediawiki
+++ b/bip-0020.mediawiki
@@ -4,7 +4,7 @@
   Author: Luke Dashjr <luke+bip@dashjr.org>
   Status: Replaced
   Type: Standards Track
-  Created: 10-01-2011
+  Created: 2011-01-10
 </pre>
 
 BIP 0020 is based off an earlier document by Nils Schneider. '''And has been replaced by BIP 0021'''

--- a/bip-0021.mediawiki
+++ b/bip-0021.mediawiki
@@ -5,7 +5,7 @@
           Matt Corallo <bip21@bluematt.me>
   Status: Accepted
   Type: Standards Track
-  Created: 29-01-2012
+  Created: 2012-01-29
 </pre>
 
 This BIP is a modification of an earlier [[bip-0020.mediawiki|BIP 0020]] by Luke Dashjr. BIP 0020 was based off an earlier document by Nils Schneider. The alternative payment amounts in BIP 0020 have been removed.

--- a/bip-0022.mediawiki
+++ b/bip-0022.mediawiki
@@ -4,7 +4,7 @@
   Author: Luke Dashjr <luke+bip22@dashjr.org>
   Status: Accepted
   Type: Standards Track
-  Created: 28-02-2012
+  Created: 2012-02-28
 </pre>
 
 ==Abstract==

--- a/bip-0023.mediawiki
+++ b/bip-0023.mediawiki
@@ -4,7 +4,7 @@
   Author: Luke Dashjr <luke+bip22@dashjr.org>
   Status: Accepted
   Type: Standards Track
-  Created: 28-02-2012
+  Created: 2012-02-28
 </pre>
 
 ==Abstract==

--- a/bip-0030.mediawiki
+++ b/bip-0030.mediawiki
@@ -4,7 +4,7 @@
   Author: Pieter Wuille <pieter.wuille@gmail.com>
   Status: Final
   Type: Standards Track
-  Created: 22-02-2012
+  Created: 2012-02-22
 </pre>
 
 ==Abstract==

--- a/bip-0031.mediawiki
+++ b/bip-0031.mediawiki
@@ -4,7 +4,7 @@
   Author: Mike Hearn <hearn@google.com>
   Status: Accepted
   Type: Standards Track
-  Created: 11-04-2012
+  Created: 2012-04-11
 </pre>
 
 ==Abstract==

--- a/bip-0032.mediawiki
+++ b/bip-0032.mediawiki
@@ -10,7 +10,7 @@ RECENT CHANGES:
   Author: Pieter Wuille
   Status: Accepted
   Type: Informational
-  Created: 11-02-2012
+  Created: 2012-02-11
 </pre>
 
 ==Abstract==

--- a/bip-0033.mediawiki
+++ b/bip-0033.mediawiki
@@ -4,7 +4,7 @@
   Author: Amir Taaki <genjix@riseup.net>
   Status: Draft
   Type: Standards Track
-  Created: 15-05-2012
+  Created: 2012-05-15
 </pre>
 
 == Abstract ==

--- a/bip-0036.mediawiki
+++ b/bip-0036.mediawiki
@@ -4,7 +4,7 @@
   Author: Stefan Thomas <justmoon@members.fsf.org>
   Status: Draft
   Type: Standards Track
-  Created: 03-08-2012
+  Created: 2012-08-03
 </pre>
 
 ==Abstract==

--- a/bip-0037.mediawiki
+++ b/bip-0037.mediawiki
@@ -4,7 +4,7 @@
   Author: Mike Hearn <hearn@google.com>, Matt Corallo <bip@bluematt.me>
   Status: Accepted
   Type: Standards Track
-  Created: 24-10-2012
+  Created: 2012-10-24
 </pre>
 
 ==Abstract==

--- a/bip-0038.mediawiki
+++ b/bip-0038.mediawiki
@@ -4,7 +4,7 @@
   Author: Mike Caldwell
   Status: Draft (Some confusion applies: The announcements for this never made it to the list, so it hasn't had public discussion)
   Type: Standards Track
-  Created: 20-11-2012
+  Created: 2012-11-20
 </pre>
 
 ==Abstract==

--- a/bip-0039.mediawiki
+++ b/bip-0039.mediawiki
@@ -8,7 +8,7 @@
            Sean Bowe <ewillbefull@gmail.com>
   Status:  Draft
   Type:    Standards Track
-  Created: 10-09-2013
+  Created: 2013-09-10
 </pre>
 
 ==Abstract==

--- a/bip-0042.mediawiki
+++ b/bip-0042.mediawiki
@@ -4,7 +4,7 @@
   Author: Pieter Wuille <pieter.wuille@gmail.com>
   Status: Draft
   Type: Standards Track
-  Created: 01-04-2014
+  Created: 2014-04-01
 </pre>
 
 ==Abstract==

--- a/bip-0050.mediawiki
+++ b/bip-0050.mediawiki
@@ -4,7 +4,7 @@
   Author: Gavin Andresen <gavinandresen@gmail.com>
   Status: Draft
   Type: Informational
-  Created: 20-03-2013
+  Created: 2013-03-20
 </pre>
 
 ==What went wrong==

--- a/bip-0060.mediawiki
+++ b/bip-0060.mediawiki
@@ -4,7 +4,7 @@
   Author: Amir Taaki <genjix@riseup.net>
   Status: Draft
   Type: Standards Track
-  Created: 16-06-2013
+  Created: 2013-06-16
 </pre>
 
 ==Abstract==

--- a/bip-0062.mediawiki
+++ b/bip-0062.mediawiki
@@ -4,7 +4,7 @@
   Author: Pieter Wuille <pieter.wuille@gmail.com>
   Status: Draft
   Type: Standards Track
-  Created: 12-03-2014
+  Created: 2014-03-12
 </pre>
 
 ==Abstract==

--- a/bip-0070.mediawiki
+++ b/bip-0070.mediawiki
@@ -4,7 +4,7 @@
   Author: Gavin Andresen <gavinandresen@gmail.com>
   Status: Draft
   Type: Standards Track
-  Created: 29-07-2013
+  Created: 2013-07-29
 </pre>
 
 ==Abstract==

--- a/bip-0071.mediawiki
+++ b/bip-0071.mediawiki
@@ -4,7 +4,7 @@
   Author: Gavin Andresen <gavinandresen@gmail.com>
   Status: Draft
   Type: Standards Track
-  Created: 29-07-2013
+  Created: 2013-07-29
 </pre>
 
 ==Abstract==

--- a/bip-0072.mediawiki
+++ b/bip-0072.mediawiki
@@ -4,7 +4,7 @@
   Author: Gavin Andresen <gavinandresen@gmail.com>
   Status: Draft
   Type: Standards Track
-  Created: 29-07-2013
+  Created: 2013-07-29
 </pre>
 
 ==Abstract==

--- a/bip-0073.mediawiki
+++ b/bip-0073.mediawiki
@@ -4,7 +4,7 @@
   Author: Stephen Pair <stephen@bitpay.com>
   Status: Draft
   Type: Standards Track
-  Created: 27-08-2013
+  Created: 2013-08-27
 </pre>
 
 ==Abstract==


### PR DESCRIPTION
This came up on the mailing list.

yyyy-mm-dd (ISO 8601) is the internationally accepted format for numeric
dates. This commit changes all BIPs to use that instead of dd-mm-yyyy.
It also updates BIP 0001 to prescribe the new format.
