### PR TITLE
Reject URI Pollution

### DIFF
--- a/bip-0021.mediawiki
+++ b/bip-0021.mediawiki
@@ -86,7 +86,7 @@ Variables which are prefixed with a req- are considered required.  If a client d
 As this BIP is written, several clients already implement a bitcoin: URI scheme similar to this one, however usually without the additional "req-" prefix requirement.  Thus, it is recommended that additional variables prefixed with req- not be used in a mission-critical way until a grace period of 6 months from the finalization of this BIP has passed in order to allow client developers to release new versions, and users of old clients to upgrade.
 
 ==== Security ====
-Parameter pollution must be avoided. Reject URI's with multiple occurences of any parameter.                                                               
+Parameter pollution must be avoided. Reject URI's with multiple occurrences of any parameter, unless parameter name contains square brackets indicating repetition. (Ex: 'item[]')
 
 More details here: [https://www.owasp.org/index.php/Testing_for_HTTP_Parameter_pollution_(OWASP-DV-004)](https://www.owasp.org/index.php/Testing_for_HTTP_Parameter_pollution_(OWASP-DV-004))
 


### PR DESCRIPTION
Ensuring that parameter pollution is avoided in spec, to prevent
spoofing issues between systems passing along URIs.

RE: https://github.com/bitcoin/bitcoin/issues/4046
