### PR TITLE
BIP0070 limits and error handling

### DIFF
--- a/bip-0070.mediawiki
+++ b/bip-0070.mediawiki
@@ -99,8 +99,8 @@ about the merchant and a digital signature.
 | merchant_data || Arbitrary data that may be used by the merchant to identify the PaymentRequest. May be omitted if the merchant does not need to associate Payments with PaymentRequest or if they associate each PaymentRequest with a separate payment address.
 |}
 
-The payment_url specified in the PaymentDetails must remain valid at least until the PaymentDetails
-expires (or indefinitely if the PaymentDetails does not expire). Note that this is irrespective of
+The payment_url specified in the PaymentDetails should remain valid at least until the PaymentDetails
+expires (or as long as possible if the PaymentDetails does not expire). Note that this is irrespective of
 any state change in the underlying payment request; for example cancellation of an order should not
 invalidate the payment_url, as it is important that the merchant's server can record mis-payments
 in order to refund the payment.


### PR DESCRIPTION
Changed example URL to be standard example domain.
Added file size limits for PaymentRequest and PaymentACK.
Added requirement to handle repeated sending of Payment message (i.e. to handle network failure).
