### PR TITLE
Validate a payment request is still valid prior to payment

### DIFF
--- a/bip-0070.mediawiki
+++ b/bip-0070.mediawiki
@@ -153,6 +153,7 @@ after the time of the payment request. After that time has expired, parties must
 If the customer authorizes payment, then the Bitcoin client:
 
 # Creates and signs one or more transactions that satisfy (pay in full) PaymentDetails.outputs
+# Validate that customer's system unix time (UTC) is still before PaymentDetails.expires. If it is not, the payment should be cancelled.
 # Broadcast the transactions on the Bitcoin p2p network.
 # If PaymentDetails.payment_url is specified, POST a Payment message to that URL. The Payment message is serialized and sent as the body of the POST request.
 


### PR DESCRIPTION
Currently there exists the potential for a user to load a payment request into
their wallet which is valid at that time but its expiration lapses prior to
the user authorizing the payment. This could lead to an unnecessary customer
service interaction.
