### PR TITLE
BIP32: Disambiguate Which Key Is Compromised When Ext. PubKey + PrivKey Are Leaked

### DIFF
--- a/bip-0032.mediawiki
+++ b/bip-0032.mediawiki
@@ -201,7 +201,7 @@ Private and public keys must be kept safe as usual. Leaking a private key means 
 
 Somewhat more care must be taken regarding extended keys, as these correspond to an entire (sub)tree of keys.
 
-One weakness that may not be immediately obvious, is that knowledge of the extended public key + any non-hardened private key descending from it is equivalent to knowing the extended private key (and thus every private and public key descending from it). This means that extended public keys must be treated more carefully than regular public keys.
+One weakness that may not be immediately obvious, is that knowledge of a parent extended public key plus any non-hardened private key descending from it is equivalent to knowing the parent extended private key (and thus every private and public key descending from it). This means that extended public keys must be treated more carefully than regular public keys.
 It is also the reason for the existence of hardened keys, and why they are used for the account level in the tree. This way, a leak of account-specific (or below) private key never risks compromising the master or other accounts.
 
 


### PR DESCRIPTION
I mistakenly inferred from the following clause that a parent extended public key plus a child private key would be equivalent to knowing the extended _child_ private key---meaning that the _parent_ private key was still secure:

> knowledge of the extended public key + any non-hardened private key descending from it is equivalent to knowing the extended private key

This patch's addition of the word "parent" (twice) removes the ambiguity and may help other readers draw the correct inference that the parent private key is no longer secure in this case.

I also changed "+" to "plus" to avoid confusion with the actual mathematical operations used in this BIP.
