### PR TITLE
BIP-0070 extension: instantconfirmation

### DIFF
--- a/bip-0070/extensions.mediawiki
+++ b/bip-0070/extensions.mediawiki
@@ -3,7 +3,30 @@
 Add your extension below using tags starting at 1000 and submit a pull-req.
 
 {|
-| Field Number || Extension Name || Field Name || Description
+| Field Number || Extension Name || Field Names || Description
+
 |-
-| 1000 || [[https://example.com|(unassigned)]] || (unassigned) || (unassigned)
+| 1000-1001 || instantconfirmation || In PaymentDetails:
+* requires_instant,
+* trusted_instant_providers,
+In Payment:
+* instant_signature,
+* instant_provider || Instant confirmation verified against double spends by a third party: [[instantconfirmation.proto|instantconfirmation.proto]]
+|-
+
+| 1002 || [[https://example.com|(unassigned)]] || (unassigned) || (unassigned)
 |}
+
+=== instantconfirmation ===
+This extension adds 4 fields for requesting and providing an instant confirmation that the transaction was verified against double spends by a third party. This verification can be implemented for instance (as [[https://greenaddress.it|GreenAddress]] does) by requiring 2of2 client+server signature on some funds, where the server is a trusted entity that provides the instant verification.
+
+===== ECSDA signing key derivation =====
+The signature for instantconfirmation is done using a key derived from extended [[https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki|BIP32]] key stored by the merchant in a "domainname -> (key, chaincode)" mapping. Every merchant is responsible for deciding which set of third parties for instant confirmations they want to trust.
+
+The key derivation is done as follows:
+* The hash of first transaction from the Payment message is calculated and stored as `txhash`.
+* `txhash` is splitted into 32 8-bit unsigned integers i0, i1, i2, ..., i31.
+* Public-derived subkey i0/i1/i2/.../i31 is used for signing the Payment message.
+
+===== instant_signature =====
+instant_signature should be calculated from SHA256 hash of the serialized Transactions message (defined in [[instantconfirmation.proto|instantconfirmation.proto]]), with transactions field copied over from the Payment message.

--- a/bip-0070/instantconfirmation.proto
+++ b/bip-0070/instantconfirmation.proto
@@ -1,0 +1,17 @@
+import "paymentrequest.proto";
+
+package instantconfirmation;
+option java_package = "org.bitcoin.protocols.payments";
+option java_outer_classname = "InstantConfirmationProtos";
+
+extend payments.PaymentDetails {
+        optional bool requires_instant = 1000;             // If the Payment message should include instant confirmation
+        repeated string trusted_instant_providers = 1001;  // List of trusted instant confirmation provider DNS names
+}
+extend payments.Payment {
+        optional bytes instant_signature = 1000;  // DER-encoded signature for instant confirmation
+        optional string instant_provider = 1001;  // DNS name of trusted instant confirmation provider
+}
+message Transactions {
+        repeated bytes transactions = 1;  // Transactions copied over from the Payment message for signing
+}

--- a/bip-0070/paymentrequest.proto
+++ b/bip-0070/paymentrequest.proto
@@ -23,6 +23,7 @@ message PaymentDetails {
         optional string memo = 5;           // Human-readable description of request for the customer
         optional string payment_url = 6;    // URL to send Payment and get PaymentACK
         optional bytes merchant_data = 7;   // Arbitrary data to include in the Payment message
+        extensions 1000 to max;
 }
 message PaymentRequest {
         optional uint32 payment_details_version = 1 [default = 1];
@@ -39,8 +40,10 @@ message Payment {
         repeated bytes transactions = 2;   // Signed transactions that satisfy PaymentDetails.outputs
         repeated Output refund_to = 3;     // Where to send refunds, if a refund is necessary
         optional string memo = 4;          // Human-readable message for the merchant
+        extensions 1000 to max;
 }
 message PaymentACK {
         required Payment payment = 1;      // Payment message that triggered this ACK
         optional string memo = 2;          // human-readable message for customer
+        extensions 1000 to max;
 }


### PR DESCRIPTION
As per discussion in bitcoin-dev IRC, this adds a protocol extention that can be reused by both various merchant and end users as well as various providers of instant confirmation. Feedback and comments very welcome.
