### PR TITLE
Add reference implementation links

### DIFF
--- a/bip-0070.mediawiki
+++ b/bip-0070.mediawiki
@@ -297,6 +297,8 @@ Protocol Buffers : https://developers.google.com/protocol-buffers/
 Create Payment Request generator : https://bitcoincore.org/~gavin/createpaymentrequest.php
 Sources at : https://bitcoincore.org/~gavin/createpaymentrequest.php
 
+BitcoinJ : https://bitcoinj.github.io/payment-protocol#introduction
+
 ==See Also==
 
 Javascript Object Signing and Encryption working group :


### PR DESCRIPTION
This BIP is really hard to implement because of the lack of test vectors and lack of documented  implementations. This will save time for implementers.
