### PR TITLE
Fix URL to source of PHP payment request generator

### DIFF
--- a/bip-0070.mediawiki
+++ b/bip-0070.mediawiki
@@ -298,8 +298,7 @@ Protocol Buffers : https://developers.google.com/protocol-buffers/
 
 ==Reference implementation==
 
-Create Payment Request generator : https://bitcoincore.org/~gavin/createpaymentrequest.php
-Sources at : https://bitcoincore.org/~gavin/createpaymentrequest.php
+Create Payment Request generator : https://bitcoincore.org/~gavin/createpaymentrequest.php ([[https://github.com/gavinandresen/paymentrequest|source]])
 
 BitcoinJ : https://bitcoinj.github.io/payment-protocol#introduction
 


### PR DESCRIPTION
The link to the source code of Gavin's PHP implementation was for the demo web page instead of the GitHub repository.
