### PR TITLE
Move Test 3 to the correct location.

### DIFF
--- a/bip-0038.mediawiki
+++ b/bip-0038.mediawiki
@@ -226,6 +226,13 @@ Test 2:
 *Unencrypted (WIF): 5HtasZ6ofTHP6HCwTqTkLDuLQisYPah7aUnSKfC7h4hMUVw2gi5
 *Unencrypted (hex): 09C2686880095B1A4C249EE3AC4EEA8A014F11E6F986D0B5025AC1F39AFBD9AE
 
+Test 3:
+*Passphrase ϓ␀𐐀💩 (<tt>\u03D2\u0301\u0000\U00010400\U0001F4A9</tt>; [http://codepoints.net/U+03D2 GREEK UPSILON WITH HOOK], [http://codepoints.net/U+0301 COMBINING ACUTE ACCENT], [http://codepoints.net/U+0000 NULL], [http://codepoints.net/U+10400 DESERET CAPITAL LETTER LONG I], [http://codepoints.net/U+1F4A9 PILE OF POO])
+*Encrypted key: 6PRW5o9FLp4gJDDVqJQKJFTpMvdsSGJxMYHtHaQBF3ooa8mwD69bapcDQn
+*Bitcoin Address: 16ktGzmfrurhbhi6JGqsMWf7TyqK9HNAeF
+*Unencrypted private key (WIF): 5Jajm8eQ22H3pGWLEVCXyvND8dQZhiQhoLJNKjYXk9roUFTMSZ4
+* ''Note:'' The non-standard UTF-8 characters in this passphrase should be NFC normalized to result in a passphrase of <tt>0xcf9300f0909080f09f92a9</tt> before further processing
+
 ===Compression, no EC multiply===
 
 Test 1:
@@ -257,13 +264,6 @@ Test 2:
 *Bitcoin address: 1CqzrtZC6mXSAhoxtFwVjz8LtwLJjDYU3V
 *Unencrypted private key (WIF): 5KJ51SgxWaAYR13zd9ReMhJpwrcX47xTJh2D3fGPG9CM8vkv5sH
 *Unencrypted private key (hex): C2C8036DF268F498099350718C4A3EF3984D2BE84618C2650F5171DCC5EB660A
-
-Test 3:
-*Passphrase ϓ␀𐐀💩 (<tt>\u03D2\u0301\u0000\U00010400\U0001F4A9</tt>; [http://codepoints.net/U+03D2 GREEK UPSILON WITH HOOK], [http://codepoints.net/U+0301 COMBINING ACUTE ACCENT], [http://codepoints.net/U+0000 NULL], [http://codepoints.net/U+10400 DESERET CAPITAL LETTER LONG I], [http://codepoints.net/U+1F4A9 PILE OF POO])
-*Encrypted key: 6PRW5o9FLp4gJDDVqJQKJFTpMvdsSGJxMYHtHaQBF3ooa8mwD69bapcDQn
-*Bitcoin Address: 16ktGzmfrurhbhi6JGqsMWf7TyqK9HNAeF
-*Unencrypted private key (WIF): 5Jajm8eQ22H3pGWLEVCXyvND8dQZhiQhoLJNKjYXk9roUFTMSZ4
-* ''Note:'' The non-standard UTF-8 characters in this passphrase should be NFC normalized to result in a passphrase of <tt>0xcf9300f0909080f09f92a9</tt> before further processing
 
 ===EC multiply, no compression, lot/sequence numbers===
 


### PR DESCRIPTION
The encrypted key for unicode test should be in the section for No compression, no EC multiply.
