### PR TITLE
BIP 0039 - Add passphrase info to Test Vectors section

### DIFF
--- a/bip-0039.mediawiki
+++ b/bip-0039.mediawiki
@@ -16,17 +16,17 @@
 This BIP describes the implementation of a mnemonic code or mnemonic sentence --
 a group of easy to remember words -- for the generation of deterministic wallets.
 
-It consists of two parts: generating the mnemonic, and converting it into a
+It consists of two parts: generating the mnenomic, and converting it into a
 binary seed. This seed can be later used to generate deterministic wallets using
 BIP-0032 or similar methods.
 
 ==Motivation==
 
-A mnemonic code or sentence is superior for human interaction compared to the
-handling of raw binary or hexadecimal representations of a wallet seed. The
+A mnenomic code or sentence is superior for human interaction compared to the
+handling of raw binary or hexidecimal representations of a wallet seed. The
 sentence could be written on paper or spoken over the telephone.
 
-This guide meant to be as a way to transport computer-generated randomness over
+This guide meant to be as a way to transport computer-generated randomnes over
 human readable transcription. It's not a way how to process user-created
 sentences (also known as brainwallet) to wallet seed.
 


### PR DESCRIPTION
In the Test Vectors section it doesn't say anywhere which passphrase is used when generating the test vectors, leading to some frustration when trying and failing to match them. I added the passphrase in the section.

Also ran spell check:
mnenomic -> mnemonic
hexidecimal -> hexadecimal
randomnes -> randomness
