### PR TITLE
BIP 44 - Added some alt coins to the registered coin types list

### DIFF
--- a/bip-0044.mediawiki
+++ b/bip-0044.mediawiki
@@ -144,6 +144,38 @@ All these constants are used as hardened derivation.
 |1
 |0x80000001
 |Bitcoin Testnet
+|-
+|2
+|0x80000002
+|Litecoin
+|-
+|3
+|0x80000003
+|Litecoin Testnet
+|-
+|4
+|0x80000004
+|Peercoin
+|-
+|5
+|0x80000005
+|Peercoin Testnet
+|-
+|6
+|0x80000006
+|Dogecoin
+|-
+|7
+|0x80000007
+|Dogecoin Testnet
+|-
+|8
+|0x80000008
+|Darkcoin
+|-
+|9
+|0x80000009
+|Darkcoin Testnet
 |}
 
 ==Examples==


### PR DESCRIPTION
Some coins added to the list: Litecoin, Peercoin, Dogecoin, Darkcoin.

@slush0, @prusnak did you had some other order in mind or working on?
