### PR TITLE
Add BIP0032 Go implementation.

### DIFF
--- a/bip-0032.mediawiki
+++ b/bip-0032.mediawiki
@@ -265,7 +265,9 @@ An Objective-C implementation is available at https://github.com/oleganza/CoreBi
 
 A Ruby implementation is available at https://github.com/wink/money-tree
 
-A Go implementation is available at https://github.com/WeMeetAgain/go-hdwallet
+Two Go implementations exist:
+
+hdkeychain (https://github.com/conformal/btcutil/tree/master/hdkeychain) provides an API for bitcoin hierarchical deterministic extended keys (BIP0032).  Go HD Wallet (https://github.com/WeMeetAgain/go-hdwallet).
 
 A JavaScript implementation is available at https://github.com/sarchar/brainwallet.github.com/tree/bip32
 


### PR DESCRIPTION
This pull request adds a new BIP0032 implementation written in Go ([hdkeychain](https://github.com/conformal/btcutil/tree/master/hdkeychain)).
