### PR TITLE
Reserve coin type 2 for Litecoin (implemented in Electrum-ltc)

### DIFF
--- a/bip-0044.mediawiki
+++ b/bip-0044.mediawiki
@@ -144,6 +144,10 @@ All these constants are used as hardened derivation.
 |1
 |0x80000001
 |Bitcoin Testnet
+|-
+|2
+|0x80000002
+|Litecoin
 |}
 
 ==Examples==


### PR DESCRIPTION
BIP44 has list of reserved coin types other than Bitcoin, please accept this simple pull request which make reservation for Litecoin.
