### PR TITLE
BIP43: Block usage 0 because it's already used in BIP32.

### DIFF
--- a/bip-0043.mediawiki
+++ b/bip-0043.mediawiki
@@ -41,6 +41,9 @@ from overlapping BIP32 spaces.
 
 Example: Scheme described in BIP44 should use 44' (or 0x8000002C) as purpose.
 
+Note that m / 0' / * is already taken by BIP32 (default account), which
+preceded this BIP.
+
 Not all wallets may want to support the full range of features and possibilities
 described in these BIPs. Instead of choosing arbitrary subset of defined features
 and calling themselves BIPxx compatible, we suggest that software which needs


### PR DESCRIPTION
It would be unfortunate if BIP32 wallets would at one day overlap BIP43 wallets.
