### PR TITLE
Clarify identifier serialization

### DIFF
--- a/bip-0032.mediawiki
+++ b/bip-0032.mediawiki
@@ -113,7 +113,7 @@ Each leaf node in the tree corresponds to an actual key, while the internal node
 
 ===Key identifiers===
 
-Extended keys can be identified by the Hash160 (RIPEMD160 after SHA256) of the serialized public key, ignoring the chain code. This corresponds exactly to the data used in traditional Bitcoin addresses. It is not advised to represent this data in base58 format though, as it may be interpreted as an address that way (and wallet software is not required to accept payment to the chain key itself).
+Extended keys can be identified by the Hash160 (RIPEMD160 after SHA256) of the serialized ECSDA public key K, ignoring the chain code. This corresponds exactly to the data used in traditional Bitcoin addresses. It is not advised to represent this data in base58 format though, as it may be interpreted as an address that way (and wallet software is not required to accept payment to the chain key itself).
 
 The first 32 bits of the identifier are called the key fingerprint.
 


### PR DESCRIPTION
I had a tough time interpreting "serialization of the public key", which is hashed to get the extended key identifier. Since the very next section is "Serialization format [for extended keys]" I thought that I was supposed to use the serialization of the /extended/ public key. Then I noticed "ignoring the chain code", so I tried skipping that part of the extended key serialization. Then I realized that what was meant was "the `K` half of `(K, c)`".
