### PR TITLE
bip-0044.mediawiki: fix typo

### DIFF
--- a/bip-0044.mediawiki
+++ b/bip-0044.mediawiki
@@ -147,7 +147,7 @@ All these constants are used as hardened derivation.
 |}
 
 This BIP is not a central directory for the registered coin types, please
-visit Satoshi Labs that maintains the full list:
+visit SatoshiLabs that maintains the full list:
 
 [[http://doc.satoshilabs.com/slips/slip-0044.html|SLIP-0044 : Registered coin types for BIP-0044]]
 


### PR DESCRIPTION
remove space which should not be there
