### PR TITLE
Update README statuses to match individual BIPs

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -53,13 +53,13 @@ Those proposing changes should consider that ultimately consent may rest with th
 | Aliases
 | Amir Taaki
 | Standard
-| Withdrawn
+| Deferred
 |- style="background-color: #cfffcf"
 | [[bip-0016.mediawiki|16]]
 | Pay To Script Hash
 | Gavin Andresen
 | Standard
-| Accepted
+| Final
 |- style="background-color: #ffcfcf"
 | [[bip-0017.mediawiki|17]]
 | OP_CHECKHASHVERIFY (CHV)
@@ -107,7 +107,7 @@ Those proposing changes should consider that ultimately consent may rest with th
 | Duplicate transactions
 | Pieter Wuille
 | Standard
-| Accepted
+| Final
 |- style="background-color: #cfffcf"
 | [[bip-0031.mediawiki|31]]
 | Pong message
@@ -210,7 +210,7 @@ Those proposing changes should consider that ultimately consent may rest with th
 | "reject" P2P message
 | Gavin Andresen
 | Standard
-| Draft
+| Final
 |-
 | [[bip-0062.mediawiki|62]]
 | Dealing with malleability
@@ -234,19 +234,19 @@ Those proposing changes should consider that ultimately consent may rest with th
 | Payment protocol
 | Gavin Andresen
 | Standard
-| Draft
+| Final
 |-
 | [[bip-0071.mediawiki|71]]
 | Payment protocol MIME types
 | Gavin Andresen
 | Standard
-| Draft
+| Final
 |-
 | [[bip-0072.mediawiki|72]]
 | Payment protocol URIs
 | Gavin Andresen
 | Standard
-| Draft
+| Final
 |-
 | [[bip-0073.mediawiki|73]]
 | Use "Accept" header with Payment Request URLs

--- a/bip-0001.mediawiki
+++ b/bip-0001.mediawiki
@@ -1,7 +1,7 @@
 <pre>
   BIP: 1
   Title: BIP Purpose and Guidelines
-  Status: Accepted
+  Status: Active
   Type: Standards Track
   Created: 2011-08-19
 </pre>


### PR DESCRIPTION
This is intended to be a simple copy edit fix: there are a number of BIPs whose status has been updated in the individual BIP, but whose status has not been updated in the README file.

Although most of the changes are straightforward, the exact status of BIP15 is a little unclear and may require a bit of additional scrutiny...
