### PR TITLE
Update bip-0070.mediawiki, comment correction in signature field.

### DIFF
--- a/bip-0070.mediawiki
+++ b/bip-0070.mediawiki
@@ -126,7 +126,7 @@ A PaymentRequest is PaymentDetails optionally tied to a merchant's identity:
 |-
 | signature || digital signature over a hash of the protocol buffer serialized variation of the PaymentRequest message,
 with all serialized fields serialized in numerical order (all current protocol buffer implementations serialize
-fields in numerical order) and signed using the public key in pki_data. Optional fields that are not set
+fields in numerical order) and signed using the private key that corresponds to the public key in pki_data. Optional fields that are not set
 are not serialized (however, setting a field to its default value will cause it to be serialized and will affect
 the signature). Before serialization, the signature field must be set to an empty value so that the field is included in the signed PaymentRequest hash but contains no data.
 |}


### PR DESCRIPTION
Clarification regarding the signature field in payment details and which key should be used for signing.
