### PR TITLE
Amend BIP72 by an "h" parameter, which contains a hash of the…

### DIFF
--- a/bip-0072.mediawiki
+++ b/bip-0072.mediawiki
@@ -26,15 +26,27 @@ message should be fetched (characters not allowed within the scope
 of a query parameter must be percent-encoded as described in RFC 3986
 and bip-0021).
 
+If the "r" parameter is provided, then an additional "h" parameter
+may be provided. If provided, it must contain an unpadded
+Base64Url-encoded SHA256 hash of the PaymentRequest message bytes
+referred to by the "r" parameter.
+
 If the "r" parameter is provided and backwards compatibility
 is not required, then the bitcoin address portion of the URI may be
 omitted (the URI will be of the form: bitcoin:?r=... ).
 
-When Bitcoin wallet software that supports this BIP receives a
-bitcoin: URI with a request parameter, it should ignore the bitcoin
-address/amount/label/message in the URI and instead fetch a
-PaymentRequest message and then follow the payment protocol, as
-described in BIP 70.
+When Bitcoin wallet software receives a bitcoin: URI with a "r" and "h"
+parameters and the hash in the "h" parameter matches the hash of the
+PaymentRequest message fetched via the "r" parameter, it must ignore
+the BIP 21 parameters (address, amount, label and message) in the URI
+and instead follow the payment protocol as described in BIP 70. The
+software may use any present BIP 21 parameter as a fallback if fetching
+the PaymentRequest fails, the "h" parameter is missing or the hash
+doesn't match.
+
+A non-matching hash must be handled identically to a missing "h"
+parameter, in order to be able to match to different objects in
+future versions of this spec.
 
 Bitcoin wallets must support fetching PaymentRequests via http and
 https protocols; they may support other protocols. Wallets must
@@ -52,7 +64,7 @@ redirect) should be handled as outlined in RFC 2616.
 ==Compatibility==
 
 Wallet software that does not support this BIP will simply ignore the
-r parameter and will initiate a payment to bitcoin address.
+r and h parameters and will initiate a payment to bitcoin address.
 
 ==Examples==
 A backwards-compatible request:


### PR DESCRIPTION
…PaymentRequest message that is fetched via the "r" parameter.

The hash is meant to link the trust anchor (e.g. the QR code) to the payment request message in a secure way. This will solve the problem several apps are comparing address+amount fields as a workaround instead, preventing some advanced BIP70 usecases. When these apps read a matching hash, they need not compare any of the other fields.

Thanks to Julian Haight for helping with the standard.
