### PR TITLE
BIP0065: Provide warning about miner incentives for proof-of-sacrifice

### DIFF
--- a/bip-0065.mediawiki
+++ b/bip-0065.mediawiki
@@ -171,6 +171,14 @@ assuming miners behave optimally and rationally) but only at a time
 sufficiently far into the future that large miners profitably can't sell the
 sacrifices at a discount.
 
+Users should note that miners are incentivised to sit on these transactions
+until they can mine the sacrificed-fee as well, thus it may be unsafe to assume
+the transaction will be mined at any point prior to its lock-time. This can
+create a scenario where the sacrificer cannot prove the sacrifice-transaction
+was actually published prior to mining (implying the sacrificer was also the
+miner and didn't sacrifice anything), no different than if a traditional
+transaction fee was used instead.
+
 
 ===Replacing the nLockTime field entirely===
 


### PR DESCRIPTION
While I think this is an important use case, the current BIP doesn't reasonably support it. Unfortunately, I have to agree that addressing this use case may be more trouble than it's worth right now.