### PR TITLE
fix secg.org secp256k1 docs link

### DIFF
--- a/bip-0032.mediawiki
+++ b/bip-0032.mediawiki
@@ -33,7 +33,7 @@ However, deterministic wallets typically consist of a single "chain" of keypairs
 
 ===Conventions===
 
-In the rest of this text we will assume the public key cryptography used in Bitcoin, namely elliptic curve cryptography using the field and curve parameters defined by secp256k1 (http://www.secg.org/index.php?action=secg,docs_secg). Variables below are either:
+In the rest of this text we will assume the public key cryptography used in Bitcoin, namely elliptic curve cryptography using the field and curve parameters defined by secp256k1 (http://www.secg.org/sec2-v2.pdf). Variables below are either:
 * Integers modulo the order of the curve (referred to as n).
 * Coordinates of points on the curve.
 * Byte sequences.


### PR DESCRIPTION
I think this is the right link to secp256k1 recommended parameters (page 9)
