### PR TITLE
Update BIP39 Add reference to a .NET implementation

### DIFF
--- a/bip-0039.mediawiki
+++ b/bip-0039.mediawiki
@@ -135,3 +135,5 @@ Objective-C - https://github.com/nybex/NYMnemonic
 
 Haskell - https://github.com/haskoin/haskoin
 
+.NET C# (PCL) - https://github.com/Thashiznets/BIP39.NET
+


### PR DESCRIPTION
Hello, I have added a reference to my .NET implementation of BIP39 into the specification documentation.

I am writing "modules" in .NET that can be maintained independently without having to do full blown upgrades etc. when one spec changes or whatever. So I have my BitcoinUtilities module which provides the BouncyCastle crypto stuff and then any other shared functionality between modules and I will be writing modules for BIPS as I have done for BIP39. I have wrote a module (KeyCore) which does the legacy style private keys where each key is formed from a crypto random 32 byte seed, Then can determine the WIF/WIF Compressed and the two addresses from the seed, however I realise everyone is heading to HD wallets and I plan to write a BIP32 module as well.

This BIP39 module is correct for all the English test vectors, has unit tests to test as much and I have thoroughly documented my code. Also providing a demo GUI to demonstrate usage.

This is a PCL so it will work on all modern platforms, Windows Phone, Windows RT, Windows Desktop etc. (Demo GUI is Windows Desktop for maximum compatibility as people may not have Windows Phone SDK etc).
