### PR TITLE
BIP-0044 - add a compatible wallet

### DIFF
--- a/bip-0044.mediawiki
+++ b/bip-0044.mediawiki
@@ -265,6 +265,7 @@ is required. This can be done [[https://github.com/satoshilabs/docs/blob/master/
 * [[https://mytrezor.com|myTREZOR web wallet]] ([[https://github.com/trezor/webwallet|source]])
 * [[https://play.google.com/store/apps/details?id=com.bonsai.wallet32|Wallet32 @ Android]] ([[https://github.com/ksedgwic/Wallet32|source]])
 * [[https://play.google.com/store/apps/details?id=com.mycelium.wallet|Mycelium Bitcoin Wallet (Android)]] ([[https://github.com/mycelium-com/wallet|source]])
+* [[https://maza.club/encompass|Encompass]] ([[https://github.com/mazaclub/encompass|source]])
 
 ==Reference==
 


### PR DESCRIPTION
Add Encompass to the list of BIP-0044 compatible wallets.