### PR TITLE
Reject code DUPLICATE also used for rejecting tx

### DIFF
--- a/bip-0061.mediawiki
+++ b/bip-0061.mediawiki
@@ -107,6 +107,8 @@ The following codes are used:
 |-
 | 0x10 || Transaction is invalid for some reason (invalid signature, output value greater than input, etc.)
 |-
+| 0x12 || An input is already spent
+|-
 | 0x40 || Not mined/relayed because it is "non-standard" (type or version unknown by the server)
 |-
 | 0x41 || One or more output amounts are below the 'dust' threshold


### PR DESCRIPTION
The reject code 0x12 is used for Version duplicate, but also when an input is already spent (bad-txns-inputs-spent)