### PR TITLE
Additional chains

### DIFF
--- a/bip-0044.mediawiki
+++ b/bip-0044.mediawiki
@@ -92,7 +92,7 @@ constant 0x7FFFFFFF. These chains are considered as external. They can be used t
 share their xpub with a third party that provides multiple payments 
 where address of each payment is calculated from that xpub. Coins sent to the 
 additional chains are still part of account so their outputs can be combined with 
-outputs from other chains for single payment.
+outputs from other chains into a single payment.
 
 Public derivation is used at this level.
 
@@ -122,9 +122,9 @@ Please note that the algorithm works with the transaction history, not account
 balances, so you can have an account with 0 total coins and the algorithm will
 still continue with discovery.
 
-Additional external chains (chains 2,3,...) can be scanned after account is 
+Additional external chains (chains 2,3,...) can be scanned after the account is 
 discovered. The user should avoid creation of additional external chains when
-there is on transaction on the account. Every additional chain should have at
+there is no transaction on the account. Every additional chain should have at
 least one transaction or an output to perform scanning for next additional chain.
 
 ===Address gap limit===

--- a/bip-0044.mediawiki
+++ b/bip-0044.mediawiki
@@ -87,6 +87,13 @@ to be visible outside of the wallet (e.g. for receiving payments). Internal
 chain is used for addresses which are not meant to be visible outside of the
 wallet and is used for return transaction change.
 
+The wallet can provide additional chains starting by constant 2 to maximum possible 
+constant 0x7FFFFFFF. These chains are considered as external. They can be used to 
+share their xpub with a third party that provides multiple payments 
+where address of each payment is calculated from that xpub. Coins sent to the 
+additional chains are still part of account so their outputs can be combined with 
+outputs from other chains for single payment.
+
 Public derivation is used at this level.
 
 ===Index===
@@ -114,6 +121,11 @@ accounts if previous one has no transaction history, as described in chapter
 Please note that the algorithm works with the transaction history, not account
 balances, so you can have an account with 0 total coins and the algorithm will
 still continue with discovery.
+
+Additional external chains (chains 2,3,...) can be scanned after account is 
+discovered. The user should avoid creation of additional external chains when
+there is on transaction on the account. Every additional chain should have at
+least one transaction or an output to perform scanning for next additional chain.
 
 ===Address gap limit===
 


### PR DESCRIPTION
Additional chains are chains that can be exported as xpub and shared with a third party. Currently, user have to use new account, and coins sent there must be transferred to the main account which brings additional fees and consumes user 's expensive time.