### PR TITLE
BIP 80 & 81: Hierarchies for Voting Pool Deterministic Multisig Wallets

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -302,6 +302,18 @@ Those proposing changes should consider that ultimately consent may rest with th
 | Standard
 | Draft
 |-
+| [[bip-0080.mediawiki|80]]
+| Hierarchy for Non-Colored Voting Pool Deterministic Multisig Wallets
+| Monetas
+| Informational
+| Draft
+|-
+| [[bip-0081.mediawiki|81]]
+| Hierarchy for Colored Voting Pool Deterministic Multisig Wallets
+| Monetas
+| Informational
+| Draft
+|-
 | [[bip-0083.mediawiki|83]]
 | Dynamic Hierarchical Deterministic Key Trees
 | Eric Lombrozo

--- a/bip-0080.mediawiki
+++ b/bip-0080.mediawiki
@@ -64,6 +64,10 @@ Public derivation is used at this level.
 
 * [[https://github.com/btcsuite/btcwallet|btcwallet]] is the reference Bitcoin wallet for voting pools.
 
+==Copyright==
+
+This document is placed in the public domain.
+
 ==Reference==
 
 * [[bip-0032.mediawiki|BIP32 - Hierarchical Deterministic Wallets]]

--- a/bip-0080.mediawiki
+++ b/bip-0080.mediawiki
@@ -62,7 +62,7 @@ Public derivation is used at this level.
 
 ==Compatible wallets==
 
-* [[https://github.com/conformal/btcd|btcd]] is the reference Bitcoin wallet for voting pools.
+* [[https://github.com/btcsuite/btcwallet|btcwallet]] is the reference Bitcoin wallet for voting pools.
 
 ==Reference==
 

--- a/bip-0080.mediawiki
+++ b/bip-0080.mediawiki
@@ -1,0 +1,71 @@
+<pre>
+  BIP:     80
+  Title:   Hierarchy for Non-Colored Voting Pool Deterministic Multisig Wallets
+  Authors: Justus Ranvier <justus@monetas.net>
+           Jimmy Song <jimmy@monetas.net>
+  Status:  Draft
+  Type:    Informational
+  Created: 2014-08-11
+</pre>
+
+==Abstract==
+
+This BIP defines a logical hierarchy for non-colored voting pool deterministic multisig wallets based on an algorithm described in BIP-0032 (BIP32 from now on) and purpose scheme described in BIP-0043 (BIP43 from now on).
+
+This BIP is a particular application of BIP43 and is based on BIP44.
+
+==Motivation==
+
+The hierarchy proposed in this paper allows the handling of multiple coins and multiple series from a single seed.
+
+==Path levels==
+
+We define the following 4 levels in BIP32 path:
+
+<pre>
+m / purpose' / coin_type' / series' / address_index
+</pre>
+
+Apostrophe in the path indicates that BIP32 hardened derivation is used.
+
+Each level has a special meaning, described in the chapters below.
+
+===Purpose===
+
+Purpose is a constant set following the BIP43 recommendation to: the ASCII value of "80" with the most signifigant bit set to indicate hardened derivation (0x80000050). It indicates that the subtree of this node is used according to this specification.
+
+Hardened derivation is used at this level.
+
+===Coin type===
+
+One master node (seed) can be used for unlimited number of independent cryptocoins such as Bitcoin, Litecoin or Namecoin. However, sharing the same space for various cryptocoins has some disadvantages.
+
+This level creates a separate subtree for every cryptocoin, avoiding reusing addresses across cryptocoins and improving privacy issues.
+
+Coin type is a constant, set for each cryptocoin. The list of registered coin type constants should be obtained from BIP44.
+
+Hardened derivation is used at this level.
+
+===Series===
+
+Series are used by voting pools in order to implement FIFO cold storage. By directing deposits into multiple series, the private keys for most of the deposits can be kept offline, and a limited portion can be brought online to process withdrawals.
+
+Hardened derivation is used at this level.
+
+===Index===
+
+Public/private keypairs are numbered from index 0 in sequentially increasing manner. This number is used as child index in BIP32 derivation.
+
+Public keys obtained at this level of the heirarchy are used to construct multisig deposit scripts, using a schema that is shared between the members as an out-of-band contract.
+
+Public derivation is used at this level.
+
+==Compatible wallets==
+
+* [[https://github.com/conformal/btcd|btcd]] is the reference Bitcoin wallet for voting pools.
+
+==Reference==
+
+* [[bip-0032.mediawiki|BIP32 - Hierarchical Deterministic Wallets]]
+* [[bip-0043.mediawiki|BIP43 - Purpose Field for Deterministic Wallets]]
+* [[bip-0044.mediawiki|BIP44 - Multi-Account Hierarchy for Deterministic Wallets]]

--- a/bip-0081.mediawiki
+++ b/bip-0081.mediawiki
@@ -58,7 +58,7 @@ Public derivation is used at this level.
 
 ==Compatible wallets==
 
-* [[https://github.com/conformal/btcd|btcd]] is the reference Bitcoin wallet for voting pools.
+* [[https://github.com/btcsuite/btcwallet|btcwallet]] is the reference Bitcoin wallet for voting pools.
 
 ==Reference==
 

--- a/bip-0081.mediawiki
+++ b/bip-0081.mediawiki
@@ -60,6 +60,10 @@ Public derivation is used at this level.
 
 * [[https://github.com/btcsuite/btcwallet|btcwallet]] is the reference Bitcoin wallet for voting pools.
 
+==Copyright==
+
+This document is placed in the public domain.
+
 ==Reference==
 
 * [[bip-0032.mediawiki|BIP32 - Hierarchical Deterministic Wallets]]

--- a/bip-0081.mediawiki
+++ b/bip-0081.mediawiki
@@ -1,0 +1,68 @@
+<pre>
+  BIP:     81
+  Title:   Hierarchy for Colored Voting Pool Deterministic Multisig Wallets
+  Authors: Justus Ranvier <justus@monetas.net>
+           Jimmy Song <jimmy@monetas.net>
+  Status:  Draft
+  Type:    Informational
+  Created: 2014-08-11
+</pre>
+
+==Abstract==
+
+This BIP defines a logical hierarchy for colored coin voting pool deterministic multisig wallets based on an algorithm described in BIP-0032 (BIP32 from now on) and purpose scheme described in BIP-0043 (BIP43 from now on).
+
+This BIP is a particular application of BIP43 and is based on BIP44.
+
+==Motivation==
+
+The hierarchy proposed in this paper allows the handling of multiple color definitions from a single seed.
+
+==Path levels==
+
+We define the following 8 levels in BIP32 path:
+
+<pre>
+m / purpose' / series' / (5 color definition levels) / address_index
+</pre>
+
+Apostrophe in the path indicates that BIP32 hardened derivation is used.
+
+Each level has a special meaning, described in the chapters below.
+
+===Purpose===
+
+Purpose is a constant set following the BIP43 recommendation to: the ASCII value of "81" with the most signifigant bit set to indicate hardened derivation (0x80000051). It indicates that the subtree of this node is used according to this specification.
+
+Hardened derivation is used at this level.
+
+===Color Definition===
+
+Index values which can be applied to a BIP32 node are limited to 4 bytes (32 bits).
+
+Since this is not sufficient to identify color definitions without a risk of collision, multiple levels are used.
+
+Color definitions are first shortened to 20 bytes using the Bitcoin hash160 function.
+
+The resulting 20 bytes are split into five groups in little endian format, and where each group is used as the seed for the five levels of color definition levels
+
+Public derivation is used at these levels, even when the index exceeds 2^31.
+
+===Index===
+
+Public/private keypairs are numbered from index 0 in sequentially increasing manner. This number is used as child index in BIP32 derivation.
+
+Public keys obtained at this level of the heirarchy are used to construct multisig deposit scripts, using a schema that is shared between the members as an out-of-band contract.
+
+Public derivation is used at this level.
+
+==Compatible wallets==
+
+* [[https://github.com/conformal/btcd|btcd]] is the reference Bitcoin wallet for voting pools.
+
+==Reference==
+
+* [[bip-0032.mediawiki|BIP32 - Hierarchical Deterministic Wallets]]
+* [[bip-0043.mediawiki|BIP43 - Purpose Field for Deterministic Wallets]]
+* [[bip-0044.mediawiki|BIP44 - Multi-Account Hierarchy for Deterministic Wallets]]
+* [[bip-0080.mediawiki|BIP44 - Hierarchy for Non-Colored Voting Pool Deterministic Multisig Wallets]]

--- a/bip-0081.mediawiki
+++ b/bip-0081.mediawiki
@@ -65,4 +65,4 @@ Public derivation is used at this level.
 * [[bip-0032.mediawiki|BIP32 - Hierarchical Deterministic Wallets]]
 * [[bip-0043.mediawiki|BIP43 - Purpose Field for Deterministic Wallets]]
 * [[bip-0044.mediawiki|BIP44 - Multi-Account Hierarchy for Deterministic Wallets]]
-* [[bip-0080.mediawiki|BIP44 - Hierarchy for Non-Colored Voting Pool Deterministic Multisig Wallets]]
+* [[bip-0080.mediawiki|BIP80 - Hierarchy for Non-Colored Voting Pool Deterministic Multisig Wallets]]


### PR DESCRIPTION
Two informational BIPs are submitted for voting pool HD wallets.

This wallet format follows the BIP43 recommendation to use reserved BIP numbers to avoid namespace collisions.

The purpose of the wallet formats is to efficiently implement multisig, FIFO cold storage for bulk bitcoins and for colored bitcoins.