### PR TITLE
BIP 102: Increase block size limit to 2MB

### DIFF
--- a/bip-0102.mediawiki
+++ b/bip-0102.mediawiki
@@ -1,5 +1,5 @@
 <pre>
-  BIP: XX
+  BIP: 102
   Title: Block size increase to 2MB
   Author: Jeff Garzik <jgarzik@gmail.com>
   Status: Draft

--- a/bip-XX-2mb.mediawiki
+++ b/bip-XX-2mb.mediawiki
@@ -1,0 +1,41 @@
+<pre>
+  BIP: XX
+  Title: Block size increase to 2MB
+  Author: Jeff Garzik <jgarzik@gmail.com>
+  Status: Draft
+  Type: Standards Track
+  Created: 2015-06-23
+</pre>
+
+==Abstract==
+
+Increase total amount of transaction data permitted in a block from 1MB to 2MB on November 11, 2015.
+
+==Motivation==
+
+# Exercise network upgrade procedure.
+# Continue current economic policy of low fee pressure on average.
+
+==Specification==
+
+# Maximum block size permitted to be valid is 1MB.
+# Increase this maximum to 2MB on November 11, 2015 at 00:00:00 UTC.
+# Increase maximum block sigops by similar factor, preserving SIZE/50 formula.
+
+==Backward compatibility==
+
+Older clients are not compatible with this change.  The first block exceeding 1,000,000 bytes will partition older clients off the new network.
+
+==Discussion==
+
+In the short term, an increase is needed to continue to facilitate
+network growth, and buy time for more comprehensive solutions to be
+developed.  This continues the current economic policies with regards to
+fees, matching market expectations and preventing market disruption.
+
+In the long term, continued direct management of this limit is a moral hazard that clouds free market input and prevents a healthy fee market from developing.  This area of code should be transitioned away from direct management.
+
+==Implementation==
+
+https://github.com/jgarzik/bitcoin/tree/2015_2mb_blocksize
+

--- a/bip-XX-2mb.mediawiki
+++ b/bip-XX-2mb.mediawiki
@@ -13,8 +13,9 @@ Increase total amount of transaction data permitted in a block from 1MB to 2MB o
 
 ==Motivation==
 
-# Exercise network upgrade procedure.
+# Enable network growth.
 # Continue current economic policy of low fee pressure on average.
+# Exercise network upgrade procedure.
 
 ==Specification==
 


### PR DESCRIPTION
A minimum-increase BIP alternative.