### PR TITLE
Correct description of which version bits are set

### DIFF
--- a/bip-0101.mediawiki
+++ b/bip-0101.mediawiki
@@ -44,7 +44,7 @@ Expressed in pseudo-code, using integer math, assuming that block_timestamp is a
 
 Deployment shall be controlled by hash-power supermajority vote (similar to the technique used in BIP34), but the earliest possible activation time is 2016-01-11 00:00:00 UTC.
 
-Activation is achieved when 750 of 1,000 consecutive blocks in the best chain have a version number with bits 1,2,3 and 14 set (0x20000007 in hex). The activation time will be the timestamp of the 750'th block plus a two week (1,209,600 second) grace period to give any remaining miners or services time to upgrade to support larger blocks. If a supermajority is achieved more than two weeks before 2016-01-11 00:00:00 UTC, the activation time will be 2016-01-11 00:00:00 UTC.
+Activation is achieved when 750 of 1,000 consecutive blocks in the best chain have a version number with the first, second, third, and thirtieth bits set (0x20000007 in hex). The activation time will be the timestamp of the 750'th block plus a two week (1,209,600 second) grace period to give any remaining miners or services time to upgrade to support larger blocks. If a supermajority is achieved more than two weeks before 2016-01-11 00:00:00 UTC, the activation time will be 2016-01-11 00:00:00 UTC.
 
 Block version numbers are used only for activation; once activation is achieved, the maximum block size shall be as described in the specification section, regardless of the version number of the block.
 


### PR DESCRIPTION
Bit thirty needs to be set to be compatible with Pieter's version proposal; I have no idea why I said 14.

And changed the description to "first, second... etc" to try to avoid "does numbering start with bit 0 or bit 1" confusion.
