### PR TITLE
Organize bips by status

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -6,289 +6,258 @@ Having a BIP here does not make it a formally accepted standard until its status
 
 Those proposing changes should consider that ultimately consent may rest with the consensus of the Bitcoin users (see also: [https://en.bitcoin.it/wiki/Economic_majority economic majority]).
 
-{| class="wikitable sortable" style="width: auto; text-align: center; font-size: smaller; table-layout: fixed;"
+== Final/Accepted/Active ==
+
+{|
 !Number
 !Title
 !Owner
 !Type
 !Status
-|- style="background-color: #cfffcf"
-| [[bip-0001.mediawiki|1]]
-| BIP Purpose and Guidelines
-| Amir Taaki
-| Standard
-| Active
 |-
-| [[bip-0010.mediawiki|10]]
-| Multi-Sig Transaction Distribution
-| Alan Reiner
-| Informational
-| Withdrawn
-|- style="background-color: #cfffcf"
-| [[bip-0011.mediawiki|11]]
-| M-of-N Standard Transactions
-| Gavin Andresen
-| Standard
-| Accepted
-|- style="background-color: #ffcfcf"
-| [[bip-0012.mediawiki|12]]
-| OP_EVAL
-| Gavin Andresen
-| Standard
-| Withdrawn
-|- style="background-color: #cfffcf"
-| [[bip-0013.mediawiki|13]]
-| Address Format for pay-to-script-hash
-| Gavin Andresen
-| Standard
-| Final
-|- style="background-color: #cfffcf"
-| [[bip-0014.mediawiki|14]]
-| Protocol Version and User Agent
-| Amir Taaki, Patrick Strateman
-| Standard
-| Accepted
-|- style="background-color: #ffcfcf"
-| [[bip-0015.mediawiki|15]]
-| Aliases
-| Amir Taaki
-| Standard
-| Deferred
-|- style="background-color: #cfffcf"
-| [[bip-0016.mediawiki|16]]
-| Pay To Script Hash
-| Gavin Andresen
-| Standard
-| Final
-|- style="background-color: #ffcfcf"
-| [[bip-0017.mediawiki|17]]
-| OP_CHECKHASHVERIFY (CHV)
-| Luke Dashjr
-| Withdrawn
-| Draft
+|[[bip-0001.mediawiki|1]]
+|BIP Purpose and Guidelines
+|Amir Taaki
+|Standard
+|Active
 |-
-| [[bip-0018.mediawiki|18]]
-| hashScriptCheck
-| Luke Dashjr
-| Standard
-| Draft
+|[[bip-0011.mediawiki|11]]
+|M-of-N Standard Transactions
+|Gavin Andresen
+|Standard
+|Accepted
 |-
-| [[bip-0019.mediawiki|19]]
-| M-of-N Standard Transactions (Low SigOp)
-| Luke Dashjr
-| Standard
-| Draft
-|- style="background-color: #ffcfcf"
-| [[bip-0020.mediawiki|20]]
-| URI Scheme
-| Luke Dashjr
-| Standard
-| Replaced
-|- style="background-color: #cfffcf"
-| [[bip-0021.mediawiki|21]]
-| URI Scheme
-| Nils Schneider, Matt Corallo
-| Standard
-| Accepted
-|- style="background-color: #cfffcf"
-| [[bip-0022.mediawiki|22]]
-| getblocktemplate - Fundamentals
-| Luke Dashjr
-| Standard
-| Accepted
-|- style="background-color: #cfffcf"
-| [[bip-0023.mediawiki|23]]
-| getblocktemplate - Pooled Mining
-| Luke Dashjr
-| Standard
-| Accepted
-|- style="background-color: #cfffcf"
-| [[bip-0030.mediawiki|30]]
-| Duplicate transactions
-| Pieter Wuille
-| Standard
-| Final
-|- style="background-color: #cfffcf"
-| [[bip-0031.mediawiki|31]]
-| Pong message
-| Mike Hearn
-| Standard
-| Accepted
-|- style="background-color: #cfffcf"
-| [[bip-0032.mediawiki|32]]
-| Hierarchical Deterministic Wallets
-| Pieter Wuille
-| Informational
-| Accepted
+|[[bip-0013.mediawiki|13]]
+|Address Format for pay-to-script-hash
+|Gavin Andresen
+|Standard
+|Final
 |-
-| [[bip-0033.mediawiki|33]]
-| Stratized Nodes
-| Amir Taaki
-| Standard
-| Draft
-|- style="background-color: #cfffcf"
-| [[bip-0034.mediawiki|34]]
-| Block v2, Height in coinbase
-| Gavin Andresen
-| Standard
-| Accepted
-|- style="background-color: #cfffcf"
-| [[bip-0035.mediawiki|35]]
-| mempool message
-| Jeff Garzik
-| Standard
-| Accepted
+|[[bip-0014.mediawiki|14]]
+|Protocol Version and User Agent
+|Amir Taaki, Patrick Strateman
+|Standard
+|Accepted
 |-
-| [[bip-0036.mediawiki|36]]
-| Custom Services
-| Stefan Thomas
-| Standard
-| Draft
-|- style="background-color: #cfffcf"
-| [[bip-0037.mediawiki|37]]
-| Bloom filtering
-| Mike Hearn and Matt Corallo
-| Standard
-| Accepted
+|[[bip-0016.mediawiki|16]]
+|Pay To Script Hash
+|Gavin Andresen
+|Standard
+|Final
 |-
-| [[bip-0038.mediawiki|38]]
-| Passphrase-protected private key
-| Mike Caldwell
-| Standard
-| Draft
+|[[bip-0021.mediawiki|21]]
+|URI Scheme
+|Nils Schneider, Matt Corallo
+|Standard
+|Accepted
 |-
-| [[bip-0039.mediawiki|39]]
-| Mnemonic code for generating deterministic keys
-| Slush
-| Standard
-| Draft
+|[[bip-0022.mediawiki|22]]
+|getblocktemplate - Fundamentals
+|Luke Dashjr
+|Standard
+|Accepted
 |-
-| 40
-| Stratum wire protocol
-| Slush
-| Standard
-| BIP number allocated
+|[[bip-0023.mediawiki|23]]
+|getblocktemplate - Pooled Mining
+|Luke Dashjr
+|Standard
+|Accepted
 |-
-| 41
-| Stratum mining protocol
-| Slush
-| Standard
-| BIP number allocated
+|[[bip-0030.mediawiki|30]]
+|Duplicate transactions
+|Pieter Wuille
+|Standard
+|Final
 |-
-| [[bip-0042.mediawiki|42]]
-| A finite monetary supply for Bitcoin
-| Pieter Wuille
-| Standard
-| Draft
+|[[bip-0031.mediawiki|31]]
+|Pong message
+|Mike Hearn
+|Standard
+|Accepted
 |-
-| [[bip-0043.mediawiki|43]]
-| Purpose Field for Deterministic Wallets
-| Slush
-| Standard
-| Draft
+|[[bip-0032.mediawiki|32]]
+|Hierarchical Deterministic Wallets
+|Pieter Wuille
+|Informational
+|Accepted
 |-
-| [[bip-0044.mediawiki|44]]
-| Multi-Account Hierarchy for Deterministic Wallets
-| Slush
-| Standard
-| Draft
+|[[bip-0034.mediawiki|34]]
+|Block v2, Height in coinbase
+|Gavin Andresen
+|Standard
+|Accepted
 |-
-| [[bip-0045.mediawiki|45]]
-| Structure for Deterministic P2SH Multisignature Wallets
-| Manuel Araoz
-| Standard
-| Draft
+|[[bip-0035.mediawiki|35]]
+|mempool message
+|Jeff Garzik
+|Standard
+|Accepted
 |-
-| [[bip-0050.mediawiki|50]]
-| March 2013 Chain Fork Post-Mortem
-| Gavin Andresen
-| Informational
-| Draft
-<!-- 50 series reserved for a group of post-mortems -->
+|[[bip-0037.mediawiki|37]]
+|Bloom filtering
+|Mike Hearn and Matt Corallo
+|Standard
+|Accepted
 |-
-| [[bip-0060.mediawiki|60]]
-| Fixed Length "version" Message (Relay-Transactions Field)
-| Amir Taaki
-| Standard
-| Draft
+|[[bip-0061.mediawiki|61]]
+|&quot;reject&quot; P2P message
+|Gavin Andresen
+|Standard
+|Final
 |-
-| [[bip-0061.mediawiki|61]]
-| "reject" P2P message
-| Gavin Andresen
-| Standard
-| Final
+|[[bip-0070.mediawiki|70]]
+|Payment protocol
+|Gavin Andresen
+|Standard
+|Final
 |-
-| [[bip-0062.mediawiki|62]]
-| Dealing with malleability
-| Pieter Wuille
-| Standard
-| Draft
+|[[bip-0071.mediawiki|71]]
+|Payment protocol MIME types
+|Gavin Andresen
+|Standard
+|Final
 |-
-| 63
-| Stealth Addresses
-| Peter Todd
-| Standard
-| BIP number allocated
+|[[bip-0072.mediawiki|72]]
+|Payment protocol URIs
+|Gavin Andresen
+|Standard
+|Final
+|}
+
+== Draft ==
+
+{|
+!Number
+!Title
+!Owner
+!Type
+!Status
 |-
-| [[bip-0064.mediawiki|64]]
-| getutxos message
-| Mike Hearn
-| Standard
-| Draft
+|[[bip-0017.mediawiki|17]]
+|OP_CHECKHASHVERIFY (CHV)
+|Luke Dashjr
+|Withdrawn
+|Draft
 |-
-| [[bip-0065.mediawiki|65]]
-| OP_CHECKLOCKTIMEVERIFY
-| Peter Todd
-| Standard
-| Draft
+|[[bip-0018.mediawiki|18]]
+|hashScriptCheck
+|Luke Dashjr
+|Standard
+|Draft
 |-
-| [[bip-0066.mediawiki|66]]
-| Strict DER signatures
-| Pieter Wuille
-| Standard
-| Draft
+|[[bip-0019.mediawiki|19]]
+|M-of-N Standard Transactions (Low SigOp)
+|Luke Dashjr
+|Standard
+|Draft
 |-
-| [[bip-0067.mediawiki|67]]
-| Deterministic P2SH multi-signature addresses
-| Thomas Kerin
-| Standard
-| Draft
+|[[bip-0033.mediawiki|33]]
+|Stratized Nodes
+|Amir Taaki
+|Standard
+|Draft
 |-
-| [[bip-0068.mediawiki|68]]
-| Consensus-enforced transaction replacement signalled via sequence numbers
-| Mark Friedenbach
-| Standard
-| Draft
+|[[bip-0036.mediawiki|36]]
+|Custom Services
+|Stefan Thomas
+|Standard
+|Draft
 |-
-| [[bip-0070.mediawiki|70]]
-| Payment protocol
-| Gavin Andresen
-| Standard
-| Final
+|[[bip-0038.mediawiki|38]]
+|Passphrase-protected private key
+|Mike Caldwell
+|Standard
+|Draft
 |-
-| [[bip-0071.mediawiki|71]]
-| Payment protocol MIME types
-| Gavin Andresen
-| Standard
-| Final
+|[[bip-0039.mediawiki|39]]
+|Mnemonic code for generating deterministic keys
+|Slush
+|Standard
+|Draft
 |-
-| [[bip-0072.mediawiki|72]]
-| Payment protocol URIs
-| Gavin Andresen
-| Standard
-| Final
+|[[bip-0042.mediawiki|42]]
+|A finite monetary supply for Bitcoin
+|Pieter Wuille
+|Standard
+|Draft
 |-
-| [[bip-0073.mediawiki|73]]
-| Use "Accept" header with Payment Request URLs
-| Stephen Pair
-| Standard
-| Draft
+|[[bip-0043.mediawiki|43]]
+|Purpose Field for Deterministic Wallets
+|Slush
+|Standard
+|Draft
 |-
-| [[bip-0101.mediawiki|101]]
-| Increase maximum block size
-| Gavin Andresen
-| Standard
-| Draft
+|[[bip-0044.mediawiki|44]]
+|Multi-Account Hierarchy for Deterministic Wallets
+|Slush
+|Standard
+|Draft
+|-
+|[[bip-0045.mediawiki|45]]
+|Structure for Deterministic P2SH Multisignature Wallets
+|Manuel Araoz
+|Standard
+|Draft
+|-
+|[[bip-0050.mediawiki|50]]
+|March 2013 Chain Fork Post-Mortem
+|Gavin Andresen
+|Informational
+|Draft
+|-
+|[[bip-0060.mediawiki|60]]
+|Fixed Length &quot;version&quot; Message (Relay-Transactions Field)
+|Amir Taaki
+|Standard
+|Draft
+|-
+|[[bip-0062.mediawiki|62]]
+|Dealing with malleability
+|Pieter Wuille
+|Standard
+|Draft
+|-
+|[[bip-0064.mediawiki|64]]
+|getutxos message
+|Mike Hearn
+|Standard
+|Draft
+|-
+|[[bip-0065.mediawiki|65]]
+|OP_CHECKLOCKTIMEVERIFY
+|Peter Todd
+|Standard
+|Draft
+|-
+|[[bip-0066.mediawiki|66]]
+|Strict DER signatures
+|Pieter Wuille
+|Standard
+|Draft
+|-
+|[[bip-0067.mediawiki|67]]
+|Deterministic P2SH multi-signature addresses
+|Thomas Kerin
+|Standard
+|Draft
+|-
+|[[bip-0068.mediawiki|68]]
+|Consensus-enforced transaction replacement signalled via sequence numbers
+|Mark Friedenbach
+|Standard
+|Draft
+|-
+|[[bip-0073.mediawiki|73]]
+|Use &quot;Accept&quot; header with Payment Request URLs
+|Stephen Pair
+|Standard
+|Draft
+|-
+|[[bip-0101.mediawiki|101]]
+|Increase maximum block size
+|Gavin Andresen
+|Standard
+|Draft
 |-
 | [[bip-0111.mediawiki|111]]
 | NODE_BLOOM service bit
@@ -297,4 +266,55 @@ Those proposing changes should consider that ultimately consent may rest with th
 | Draft
 |}
 
-<!-- IMPORTANT!  See the instructions at the top of this page, do NOT JUST add BIPs here! -->
+== Withdrawn/Deferred/Replaced ==
+
+{|
+!Number
+!Title
+!Owner
+!Type
+!Status
+|-
+|[[bip-0010.mediawiki|10]]
+|Multi-Sig Transaction Distribution
+|Alan Reiner
+|Informational
+|Withdrawn
+|-
+|[[bip-0012.mediawiki|12]]
+|OP_EVAL
+|Gavin Andresen
+|Standard
+|Withdrawn
+|-
+|[[bip-0015.mediawiki|15]]
+|Aliases
+|Amir Taaki
+|Standard
+|Deferred
+|-
+|[[bip-0020.mediawiki|20]]
+|URI Scheme
+|Luke Dashjr
+|Standard
+|Replaced
+|-
+|40
+|Stratum wire protocol
+|Slush
+|Standard
+|BIP number allocated
+|-
+|41
+|Stratum mining protocol
+|Slush
+|Standard
+|BIP number allocated
+|-
+|63
+|Stealth Addresses
+|Peter Todd
+|Standard
+|BIP number allocated
+|}
+


### PR DESCRIPTION
Separate BIPS into sections: [Accepted ones, Draft ones, Rejects]. BIPs are sorted into sections and then by number. This makes it still very easy to find BIPs by number but it makes it crystal clear what their status is.

The idea here is to further guide readers towards the concept that a BIP can be a draft or rejected.

![screen shot 2015-08-27 at 7 44 30 pm](https://cloud.githubusercontent.com/assets/2470152/9537975/4d92cf32-4cf4-11e5-923b-20d038bb7e0c.png)
