### PR TITLE
BIP-0014: MAX_SUBVERSION_LENGTH

### DIFF
--- a/bip-0014.mediawiki
+++ b/bip-0014.mediawiki
@@ -84,6 +84,8 @@ They should not be misused beyond what is specified in this section.
 * : specifies the implementation version of the particular stack
 * ( and ) delimits a comment which optionally separates data using ;
 
+The total length of the user agent string after appending the optional comments must not exceed 256 bytes.
+
 == Timeline ==
 
 When this document was published, the bitcoin protocol and Satoshi client versions were currently at 0.5 and undergoing changes. In order to minimise disruption and allow the undergoing changes to be completed, the next protocol version at 0.6 became peeled from the client version (also at 0.6). As of that time (January 2012), protocol and implementation version numbers are distinct from each other.


### PR DESCRIPTION
I don't know if this should be mentioned in the bip because it may change at some point in the future... Yet, changing it may cause a fork of the network (extremely unlikely but possible).