### PR TITLE
BIP70: Fix broken extensions registry link in code comment.

### DIFF
--- a/bip-0070/paymentrequest.proto
+++ b/bip-0070/paymentrequest.proto
@@ -3,7 +3,7 @@
 //
 // Use fields 1000+ for extensions;
 // to avoid conflicts, register extensions via pull-req at
-// https://github.com/bitcoin/bips/bip-0070/extensions.mediawiki
+// https://github.com/bitcoin/bips/blob/master/bip-0070/extensions.mediawiki
 //
 
 package payments;


### PR DESCRIPTION
This resolves an incorrect link to `extensions.mediawiki` in the code comments of `paymentrequest.proto`.