### PR TITLE
BIP-0069: [trivial] Move copyright section

### DIFF
--- a/bip-0069.mediawiki
+++ b/bip-0069.mediawiki
@@ -15,10 +15,6 @@ As a result, wallet clients often have a discernible blockchain fingerprint, and
 By contrast, a standard for non-deterministic sorting could be difficult to audit.
 This document proposes deterministic lexicographical sorting, using hashes of previous transactions and output indices to sort transaction inputs, as well as values and scriptPubKeys to sort transaction outputs.
 
-==Copyright==
-
-This BIP is in the public domain.
-
 ==Motivation==
 
 Currently, there is no clear standard for how wallet clients ought to order transaction inputs and outputs.
@@ -167,3 +163,7 @@ Outputs:
 
 Danno Ferrin &lt;danno@numisight.com&gt;, Sergio Demian Lerner &lt;sergiolerner@certimix.com&gt;, Justus Ranvier &lt;justus@openbitcoinprivacyproject.org&gt;, and Peter Todd &lt;pete@petertodd.org&gt; contributed to the design and motivations for this BIP.
 A similar proposal was submitted to the Bitcoin-dev mailing list independently by Rusty Russell &lt;rusty@rustcorp.com.au&gt;
+
+==Copyright==
+
+This BIP is in the public domain.


### PR DESCRIPTION
The section about the copyright should be either first or last.