### PR TITLE
BIP-47: correct base58check version byte

### DIFF
--- a/bip-0047.mediawiki
+++ b/bip-0047.mediawiki
@@ -1,5 +1,7 @@
 RECENT CHANGES:
 
+* (21 Sep 2015) Correct base58check version byte
+
 * (18 Sep 2015) Clarify decoding of notification transactions
 
 <pre>
@@ -72,7 +74,7 @@ A payment code contains the following elements:
 
 When a payment code is presented to the user, it SHOULD be presented encoded in Base58Check form.
 
-* The version byte is: 0x23 (produces a "P" as the first character of the serialized form)
+* The version byte is: 0x47 (produces a "P" as the first character of the serialized form)
 * The payload is the binary serialization of the payment code
 
 ===Protocol===


### PR DESCRIPTION
Previously specified version byte only produced the desired leading character if the check bytes were omitted

Thanks to TD from Samourai Wallet for pointing this out