### PR TITLE
BIP0062: Add a warning about its undeployable status

### DIFF
--- a/bip-0062.mediawiki
+++ b/bip-0062.mediawiki
@@ -1,3 +1,5 @@
+'''NOTICE: This document is a work in progress and is not complete, implemented, or otherwise suitable for deployment.'''
+
 <pre>
   BIP: 62
   Title: Dealing with malleability


### PR DESCRIPTION
[Some folks are asking miners to deploy BIP 62](http://blog.coinkite.com/post/130318407326/ongoing-bitcoin-malleability-attack-low-s-high), but it isn't in a deployable state right now...