### PR TITLE
Fix ambiguous reference to seed value in BIP32 test vectors

### DIFF
--- a/bip-0032.mediawiki
+++ b/bip-0032.mediawiki
@@ -209,7 +209,7 @@ It is also the reason for the existence of hardened keys, and why they are used 
 
 ===Test vector 1===
 
-Master (hex): 000102030405060708090a0b0c0d0e0f
+Seed (hex): 000102030405060708090a0b0c0d0e0f
 * Chain m
 ** ext pub: xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8
 ** ext prv: xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi
@@ -231,7 +231,7 @@ Master (hex): 000102030405060708090a0b0c0d0e0f
 
 ===Test vector 2===
 
-Master (hex): fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542
+Seed (hex): fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542
 * Chain m
 ** ext pub: xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB
 ** ext prv: xprv9s21ZrQH143K31xYSDQpPDxsXRTUcvj2iNHm5NUtrGiGG5e2DtALGdso3pGz6ssrdK4PFmM8NSpSBHNqPqm55Qn3LqFtT2emdEXVYsCzC2U


### PR DESCRIPTION
The test vectors currently reference a "master", an ambiguous term with no single meaning in the BIP32 spec. The test vectors should instead reference the seed.