### PR TITLE
Added clarifications to BIP0009.

### DIFF
--- a/bip-0009.mediawiki
+++ b/bip-0009.mediawiki
@@ -23,7 +23,6 @@ Each soft fork deployment is specified by the following parameters (further elab
 
 # The '''bit''' determines which bit in the nVersion field of the block is to be used to signal the soft fork lock-in and activation.
 # The '''threshold''' specifies how many blocks within a single retarget period (2016 blocks) must have the bit set before we lock in the deployment.
-# The '''deploytime''' specifies a time at which the bit starts counting towards lock-in.
 # The '''timeout''' specifies a time at which the deployment is considered failed. If the median time of a block >= timeout and the soft fork has not yet locked in (including this block's bit state), the deployment is considered failed on all descendants of the block.
 
 ===Mechanism===

--- a/bip-0009.mediawiki
+++ b/bip-0009.mediawiki
@@ -19,6 +19,13 @@ In addition, BIP 34 made the integer comparison (nVersion >= 2) a consensus rule
 
 ==Specification==
 
+Each soft fork deployment is specified by the following parameters (further elaborated below):
+
+# The '''bit''' determines which bit in the nVersion field of the block is to be used to signal the soft fork lock-in and activation.
+# The '''threshold''' specifies how many blocks within a single retarget period (2016 blocks) must have the bit set before we lock in the deployment.
+# The '''deploytime''' specifies a time at which the bit starts counting towards lock-in.
+# The '''timeout''' specifies a time at which the deployment is considered failed. If the median time of a block >= timeout and the soft fork has not yet locked in (including this block's bit state), the deployment is considered failed on all descendants of the block.
+
 ===Mechanism===
 
 '''Bit flags'''


### PR DESCRIPTION
I added explicit parameters for deployment at the beginning of the specification. I think this greatly clarifies the spec for someone approaching it for the first time.

We've decided for now not to consensus-enforce the bit states, making the RFC language that had been previously proposed a bit superfluous. The only thing that remains consensus-enforced is the moment of activation which should be clear from context.