### PR TITLE
BIP 140: Normalized transaction ID

### DIFF
--- a/bip-00nn.mediawiki
+++ b/bip-00nn.mediawiki
@@ -8,15 +8,15 @@
 </pre>
 == Abstract ==
 
-This BIP describes the use of normalized transaction IDs (TXIDs) in order to eliminate transaction malleability, both in the third-party modification scenario as well as the participant modification scenario. The transaction ID is normalized by removing the signature scripts from transactions before computing its hash. The normalized transaction hashes are then used during the signature creation and signature verification of dependent transactions.
+This BIP describes the use of normalized transaction IDs (NTXIDs) in order to eliminate transaction malleability, both in the third-party modification scenario as well as the participant modification scenario. The transaction ID is normalized by removing the signature scripts from transactions before computing its hash. The normalized transaction hashes are then used during the signature creation and signature verification of dependent transactions.
 
 == Motivation ==
 
 Transaction malleability refers to the fact that transactions can be modified, either by one of the signers by re-signing the transaction or a third-party by modifying the signature representation. This is a problem since any modification to the serialized representation also changes the hash of the transaction, which is used by spending transaction to reference the funds that are being transferred. If a transaction is modified and later confirmed by ending up in the blockchain all transactions that depended on the original transaction are no longer valid, and thus orphaned.
 
-BIPs 62<ref>[[https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki|BIP 62 - Dealing with malleability]]</ref> and 66<ref>[[https://github.com/bitcoin/bips/blob/master/bip-0066.mediawiki|BIP 66 - Strict DER signatures]]</ref> alleviate the problem of third-party modification by defining a canonical representation of the signatures. However, the checking the canonical representation is complex and may not eliminate all sources of third-party malleability. Furthermore, these BIPs do not address modifications by one of the signers, i.e., re-signing the transaction, because signers can produce any number of signatures due to the random parameter in ECDSA.
+BIPs 62<ref>[[https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki|BIP 62 - Dealing with malleability]]</ref> and 66<ref>[[https://github.com/bitcoin/bips/blob/master/bip-0066.mediawiki|BIP 66 - Strict DER signatures]]</ref> alleviate the problem of third-party modification by defining a canonical representation of the signatures. However, checking the canonical representation is complex and may not eliminate all sources of third-party malleability. Furthermore, these BIPs do not address modifications by one of the signers, i.e., re-signing the transaction, because signers can produce any number of signatures due to the random parameter in ECDSA.
 
-This proposal eliminates malleability altogether by removing the malleable signatures from the hash used to reference the outputs spent by a transaction. The new hash used to reference an output is called the ''normalized transaction ID''. The integrity of all data that is used to reference the output is guaranteed by the signature itself, and any modification that would change the normalized transaction ID would also invalidate the signature itself.
+This proposal eliminates malleability by removing the malleable signatures from the hash used to reference the outputs spent by a transaction. The new hash used to reference an output is called the ''normalized transaction ID''. The integrity of all data that is used to reference the output is guaranteed by the signature itself, and any modification that would change the normalized transaction ID would also invalidate the signature itself.
 
 Besides eliminating transaction malleability as a source of problems it also allows the use of transaction templates. Transaction templates simplify higher level protocols and allows new uses. They allow an unsigned template transaction to be used as a basis for a sequence of transaction and only once the sequence matches the signers' expectations they provide the necessary signatures for the template to become valid, thus opting in to the sequence.
 
@@ -24,55 +24,40 @@ Besides eliminating transaction malleability as a source of problems it also all
 
 The use of normalized transaction IDs is introduced as a softfork. The specification is divided into three parts:
 
- - Computation of the normalized transaction ID
- - Introduction of a new extensible signature verification opcode to enable softfork deployment
- - Changes to the UTXO tracking to enable normalized transaction ID lookup
+* Computation of the normalized transaction ID
+* Introduction of a new extensible signature verification opcode to enable softfork deployment
+* Changes to the UTXO tracking to enable normalized transaction ID lookup
 
 === Normalized Transaction ID computation ===
 
-In order to calculate the normalized transaction ID, the signature script is stripped from each input of the transaction of non-coinbase transactions. Stripping the signature script is achieved by setting the script's length to 0 and removing the <code>uchar[]</code> array from the <code>TxIn</code>.<ref>[[https://en.bitcoin.it/wiki/Protocol_Specification#tx|Protocol Specification: TX]]</ref>
-The normalized transaction ID is then computed as the <code>SHA 256</code> hash of the stripped transaction matching the existing transaction ID computation. The normalized transaction ID remains unchanged even if the signatures of the transaction are replaced/malleated and describe a class of semantically identical transactions. In the following we use ''transaction instance ID'' to refer to the transaction ID computed on the transaction including signatures. Normalized transaction IDs for coinbase transactions are computed with the signature script in the coinbase input, in order to avoid hash collisions.
+In order to calculate the normalized transaction ID, the signature script is stripped from each input of the transaction of non-coinbase transactions and each input is normalized. Stripping the signature script is achieved by setting the script's length to 0 and removing the <code>uchar[]</code> array from the <code>TxIn</code>.<ref>[[https://en.bitcoin.it/wiki/Protocol_Specification#tx|Protocol Specification: TX]]</ref>
+Inputs are then normalized by replacing the hash of each previous transaction with its normalized version if available, i.e., the normalized hash of the previous transaction that created the output being spent in the current transaction. Version 1 transactions do not have a normalized transaction ID hence the non-normalized transaction ID is used for input normalization.
+
+The normalized transaction ID is then computed as the double <code>SHA 256</code> hash of the normalized transaction matching the existing transaction ID computation. The normalized transaction ID remains unchanged even if the signatures of the transaction are replaced/malleated and describe a class of semantically identical transactions. In the following we use ''transaction instance ID'' to refer to the transaction ID computed on the transaction including signatures. Normalized transaction IDs for coinbase transactions are computed with the signature script in the coinbase input, in order to avoid hash collisions.
 
 === OP_CHECKSIGEX ===
-This BIP introduces a new opcode <code>OP_CHECKSIGEX</code> which replaces <code>OP_NOP4</code>. <code>OP_CHECKSIGEX</code> subsumes <code>OP_CHECKSIG(VERIFY)</code> and <code>OP_CHECKMULTISIG(VERIFY)</code> and extends their semantics by allowing additional parameters.
+This BIP introduces a new opcode <code>OP_CHECKSIGEX</code> which replaces <code>OP_NOP4</code>. <code>OP_CHECKSIGEX</code> subsumes <code>OP_CHECKSIGVERIFY</code> and <code>OP_CHECKMULTISIGVERIFY</code>, and extends them by accepting a new <code>VERSION</code> parameter. The version parameter is a single integer pushed onto the stack before invoking <code>OP_CHECKSIGEX</code> and is used to group and evolve future versions of signature checking opcodes.
 
-When executed <code>OP_CHECKSIGEX</code> pops an integer from the top of the stack. This integer encodes the binary options which determine how <code>OP_CHECKSIGEX</code> verifies signatures. The following table shows the possible flags at the time of writing:
+When executed <code>OP_CHECKSIGEX</code> pops the version from the stack and then performs the signature check according to the specified version. If the verifying client does not support the specified version, i.e., the version was defined after the release of the client, the client must treat the <code>OP_CHECKSIGEX</code> as an <code>OP_NOP</code>.
 
-{| class="wikitable"
-!colspan="6"|OP_CHECKSIGEX flags
-|-
-! Name
-! Value
-! Description
-|-
-| <code>SCRIPT_CHECKSIGEX_VERIFY</code>
-| 2^0
-| Verify after checking validity and fail script if verification failed
-|-
-| <code>SCRIPT_CHECKSIGEX_MULTI</code>
-| 2^1
-| Mimic <code>OP_CHECKMULTISIG</code> if set otherwise mimic <code>OP_CHECKSIG</code>
-|-
-| <code>SCRIPT_CHECKSIGEX_NORMALIZE</code>
-| 2^2
-| Normalize input hashes before checking signature
-|}
+==== Version 1 ====
 
-A combination of <code>SCRIPT_CHECKSIGEX_VERIFY</code> and </code>SCRIPT_CHECKSIGEX_MULTI</code> recreates the semantics of <code>OP_CHECKSIG</code>, <code>OP_CHECKSIGVERIFY</code>, <code>OP_CHECKMULTISIG</code> and <code>OP_CHECKMULTISIGVERIFY</code>. Refer to the developer documentation<ref>[[https://bitcoin.org/en/developer-guide#p2pkh-script-validation|Developer Documentation - P2PKH Script Validation]]</ref> for their semantics.
+The first version of <code>OP_CHECKSIGEX</code> (<code>VERSION=1</code>) implements normalized transaction IDs and uses Schnorr signatures instead of the current ECDSA signatures.
+
+Version 1 introduces the following new standard script format:
+
+    m {pubkey}...{pubkey} n v OP_CHECKSIGEX
+
+with matching scriptSig format:
+
+    {signature}...{signature}
+
+This is the standard ''m-of-n'' script defined in [https://github.com/bitcoin/bips/blob/master/bip-0011.mediawiki BIP 11] with an additional version parameter <code>v</code> and the new opcode. Singlesig transactions are encoded as ''1-of-1'' transactions.
 
 The existing <code>OP_CHECKMULTISIG</code> and <code>OP_CHECKMULTISIGVERIFY</code> have a bug<ref>[[https://bitcoin.org/en/developer-guide#multisig|Developer Documentation - Multisig]]</ref> that pops one argument too many from the stack. This bug is not reproduced in the implementation of OP_CHECKSIGEX, so the canonical solution of pushing a dummy value onto the stack is not necessary.
 
-<code>SCRIPT_CHECKSIGEX_NORMALIZE</code> indicates that before computing the signaturehash, i.e., the hash that is signed, the transaction should be normalized by replacing all transaction IDs in the inputs by their normalized variants. The normalized transction IDs are computed as described in the next section. This normalization step is performed both when creating the signatures as well as when checking the signatures.
-
-In order to make use of the normalization feature, this BIP introduces two new standard transaction types
-
-    OP_DUP OP_HASH160 <pubkey hash> OP_EQUALVERIFY OP_4 OP_CHECKSIGEX
-
-and 
-
-    <num sigs> <pubkeys> <numpubkeys> OP_6 OP_CHECKSIGEX
-
-The first is the equivalent of the pay-to-pubkeyhash script with normalization (<code>OP_4 = SCRIPT_CHECKSIGEX_NORMALIZE</code>), while the second is the equivalent of the pay-to-multisig also with normalization (<code>OP_6 = SCRIPT_CHECKSIGEX_NORMALIZE | SCRIPT_CHECKSIGEX_MULTI</code>). The format of the <code>scriptSig</code> corresponds to the original version, with exception of omitting the dummy <code>OP_0</code> in the multisig case.
+The normalization is achieved by normalizing the transaction before computing the signaturehash, i.e., the hash that is signed.
+The transaction must be normalized by replacing all transaction IDs in the inputs by their normalized variants and stripping the signature scripts. The normalized transction IDs are computed as described in the previous section. This normalization step is performed both when creating the signatures as well as when checking the signatures.
 
 === Tracking Normalized Transaction IDs ===
 
@@ -82,12 +67,13 @@ Outputs created by version 1 transactions are not annotated with the normalized 
 
 == Rationale ==
 
+=== Normalization ===
 Normalized transaction IDs are provably non-malleable since no data is included in the signaturehash whose integrity is not also proven in the signature, thus any modification causing the hash to change will also invalidate the signature.
 Normalized transactions are secure as they still use cryptographic hashes over all the semantic information of the transaction, i.e., the inputs, outputs and metadata, thus it is still computationally infeasible to cause a hash collision between transactions.
 
 There are a number of advantages to using normalized transaction IDs:
 
-* Like BIP 62 and BIP 66 it solves the problem of third-parties picking transactions out of the network, modifying them and reinjecting them, as was allegedly done to defraud MtGox<ref>[[http://www.tik.ee.ethz.ch/file/7e4a7f3f2991784786037285f4876f5c/malleability.pdf|Bitcoin Transaction Malleability and MtGox]]</ref>.
+* Like BIP 62 and BIP 66 it solves the problem of third-parties picking transactions out of the network, modifying them and reinjecting them.
 * ''m-of-n'' multisig outputs are often used in higher level protocols<ref>[[http://www.tik.ee.ethz.ch/file/716b955c130e6c703fac336ea17b1670/duplex-micropayment-channels.pdf|A Fast and Scalable Payment Network with Bitcoin Duplex Micropayment Channels ]]</ref><ref>[[http://lightning.network/lightning-network-paper.pdf|The Bitcoin Lightning Network:
 Scalable Off-Chain Instant Payments]]</ref> in which several parties sign a transaction. Without normalized transaction IDs it is trivial for one party to re-sign a transaction, hence changing the transaction hash and invalidating any transaction built on top of its outputs. Normalized transaction IDs force the ID not to change, even if a party replaces its signature.
 * Many higher level protocols build structures of transactions on top of multisig outputs that are not completely signed. This is currently not possible without one party holding a fully signed transaction and then calculating the ID. It is desirable to be able to build successive transactions without one party collecting all signatures, and thus possibly lock in funds unilaterally. Normalized transaction IDs allow the use of transaction templates, i.e., completely unsigned transactions upon which further transactions can be built, and only once every party is assured the structure matches its expectations it signs the template, thus validating the template.
@@ -96,13 +82,20 @@ The only occurence in which transactions can still be modified unilaterally is i
 
 In case of a transaction becoming invalid due to one of the inputs being malleated it is necessary to modify the spending transaction to reference the modified transaction ID. However, the signatures, which only use the normalized IDs, remain valid as long as the semantics of the funding transaction remain unchanged. An observer in the network may fix the transaction and reinject a corrected version.
 
-Using version 2 for transactions is an explicit optin to the normalized ID tracking and a simple upgrade for existing clients. It avoids having to reprocess the entire blockchain and computing the normalized transaction IDs for existing outputs in the UTXO. This would be further complicated by having to recursively compute normalized transaction IDs down to the coinbase transactions which created the coins.
-
-The new opcode <code>OP_CHECKSIGEX</code> was introduced in order to allow the use of normalized transaction IDs as a softfork and in order to keep the number of <code>OP_NOP</code>s needed to a bare minimum. The additional argument containing the flags can be pushed on the stack using a single byte as long as only the least significant 4 bits are set (<code>OP_1</code> - <code>OP_16</code>), resulting in one byte overhead for this script type. Furthermore it removes the bug requiring a dummy push in the multisig scenario, resulting in the same size in this scenario.
+Using version 2 for transactions is an explicit opt-in to the normalized ID tracking and a simple upgrade for existing clients. It avoids having to reprocess the entire blockchain and computing the normalized transaction IDs for existing outputs in the UTXO. This would be further complicated by having to recursively compute normalized transaction IDs down to the coinbase transactions which created the coins.
 
 Tracking the normalized transaction IDs in the UTXO requires the storage of an additional hash per transaction whose outputs are not completely spent, which at 7,000,000 transactions with unspent outputs amounts to 224MB additional storage on disk.
 
 The coinbase transactions have been checked for hash-collisions and no collisions were found except for the coinbase transactions in blocks at heights 91842 and 91880, which are known to be identical<ref>[[https://github.com/bitcoin/bips/blob/master/bip-0030.mediawiki|BIP 30 - Duplicate transactions]]</ref>, and motivated the introduction of BIP 34.<ref>[[https://github.com/bitcoin/bips/blob/master/bip-0034.mediawiki|Block v2, Height in Coinbase]]</ref> Since coinbase transactions are invalid if transmitted outside of a block it is not possible to modify them on the fly and since they only mature after being included for a long time in the blockchain they are considered safe.
+
+=== OP_CHECKSIGEX ===
+
+The new opcode <code>OP_CHECKSIGEX</code> was introduced in order to allow the use of normalized transaction IDs as a softfork and in order to keep the number of <code>OP_NOP</code>s needed to a bare minimum, while enabling future soft-fork updates to the signing algorithms.
+
+The additional argument containing the version can be pushed on the stack using a single byte up to version 16 (<code>OP_1</code> - <code>OP_16</code>), resulting in one byte overhead for this script type. Using the standard multisig format also for 1-of-1 transactions add an additional 2 bytes, however it also removes the bug requiring a dummy push, resulting in a single byte overhead.
+Furthermore, using Schnorr signatures instead of ECDSA brings a number of improvements that reduce the size of transactions (''m-of-m'' is the same size as ''1-of-1'') and increase verification speed (batch signature validation by summing up keys and signatures). The code is already in bitcoin/secp256k1 and can be merged in. We limited the description of this BIP to re-using BIP 11 style ''m-of-n'' scripts to keep it short, however Schnorr also allows a number of more complex applications which we defer to future BIPs.
+
+Version 0 was intentionally skipped in order to guarantee that the top-most element before <code>OP_CHECKSIGEX</code> is non-zero. This is necessary to guarantee that non-upgraded clients, which interpret <code>OP_CHECKSIGEX</code> as <code>OP_NOP4</code>, do not end up with a zero value on top of the stack after execution, which would be interpreted as script failure.
 
 === Impact ===
 

--- a/bip-00nn.mediawiki
+++ b/bip-00nn.mediawiki
@@ -1,0 +1,120 @@
+<pre>
+  BIP: NN
+  Title: Normalized TXID
+  Author: Christian Decker <decker.christian@gmail.com>
+  Status: Draft
+  Type: Standards Track
+  Created: 2015-10-14
+</pre>
+== Abstract ==
+
+This BIP describes the use of normalized transaction IDs (TXIDs) in order to eliminate transaction malleability, both in the third-party modification scenario as well as the participant modification scenario. The transaction ID is normalized by removing the signature scripts from transactions before computing its hash. The normalized transaction hashes are then used during the signature creation and signature verification of dependent transactions.
+
+== Motivation ==
+
+Transaction malleability refers to the fact that transactions can be modified, either by one of the signers by re-signing the transaction or a third-party by modifying the signature representation. This is a problem since any modification to the serialized representation also changes the hash of the transaction, which is used by spending transaction to reference the funds that are being transferred. If a transaction is modified and later confirmed by ending up in the blockchain all transactions that depended on the original transaction are no longer valid, and thus orphaned.
+
+BIPs 62<ref>[[https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki|BIP 62 - Dealing with malleability]]</ref> and 66<ref>[[https://github.com/bitcoin/bips/blob/master/bip-0066.mediawiki|BIP 66 - Strict DER signatures]]</ref> alleviate the problem of third-party modification by defining a canonical representation of the signatures. However, the checking the canonical representation is complex and may not eliminate all sources of third-party malleability. Furthermore, these BIPs do not address modifications by one of the signers, i.e., re-signing the transaction, because signers can produce any number of signatures due to the random parameter in ECDSA.
+
+This proposal eliminates malleability altogether by removing the malleable signatures from the hash used to reference the outputs spent by a transaction. The new hash used to reference an output is called the ''normalized transaction ID''. The integrity of all data that is used to reference the output is guaranteed by the signature itself, and any modification that would change the normalized transaction ID would also invalidate the signature itself.
+
+Besides eliminating transaction malleability as a source of problems it also allows the use of transaction templates. Transaction templates simplify higher level protocols and allows new uses. They allow an unsigned template transaction to be used as a basis for a sequence of transaction and only once the sequence matches the signers' expectations they provide the necessary signatures for the template to become valid, thus opting in to the sequence.
+
+== Specification ==
+
+The use of normalized transaction IDs is introduced as a softfork. The specification is divided into three parts:
+
+ - Computation of the normalized transaction ID
+ - Introduction of a new extensible signature verification opcode to enable softfork deployment
+ - Changes to the UTXO tracking to enable normalized transaction ID lookup
+
+=== Normalized Transaction ID computation ===
+
+In order to calculate the normalized transaction ID, the signature script is stripped from each input of the transaction of non-coinbase transactions. Stripping the signature script is achieved by setting the script's length to 0 and removing the <code>uchar[]</code> array from the <code>TxIn</code>.<ref>[[https://en.bitcoin.it/wiki/Protocol_Specification#tx|Protocol Specification: TX]]</ref>
+The normalized transaction ID is then computed as the <code>SHA 256</code> hash of the stripped transaction matching the existing transaction ID computation. The normalized transaction ID remains unchanged even if the signatures of the transaction are replaced/malleated and describe a class of semantically identical transactions. In the following we use ''transaction instance ID'' to refer to the transaction ID computed on the transaction including signatures. Normalized transaction IDs for coinbase transactions are computed with the signature script in the coinbase input, in order to avoid hash collisions.
+
+=== OP_CHECKSIGEX ===
+This BIP introduces a new opcode <code>OP_CHECKSIGEX</code> which replaces <code>OP_NOP4</code>. <code>OP_CHECKSIGEX</code> subsumes <code>OP_CHECKSIG(VERIFY)</code> and <code>OP_CHECKMULTISIG(VERIFY)</code> and extends their semantics by allowing additional parameters.
+
+When executed <code>OP_CHECKSIGEX</code> pops an integer from the top of the stack. This integer encodes the binary options which determine how <code>OP_CHECKSIGEX</code> verifies signatures. The following table shows the possible flags at the time of writing:
+
+{| class="wikitable"
+!colspan="6"|OP_CHECKSIGEX flags
+|-
+! Name
+! Value
+! Description
+|-
+| <code>SCRIPT_CHECKSIGEX_VERIFY</code>
+| 2^0
+| Verify after checking validity and fail script if verification failed
+|-
+| <code>SCRIPT_CHECKSIGEX_MULTI</code>
+| 2^1
+| Mimic <code>OP_CHECKMULTISIG</code> if set otherwise mimic <code>OP_CHECKSIG</code>
+|-
+| <code>SCRIPT_CHECKSIGEX_NORMALIZE</code>
+| 2^2
+| Normalize input hashes before checking signature
+|}
+
+A combination of <code>SCRIPT_CHECKSIGEX_VERIFY</code> and </code>SCRIPT_CHECKSIGEX_MULTI</code> recreates the semantics of <code>OP_CHECKSIG</code>, <code>OP_CHECKSIGVERIFY</code>, <code>OP_CHECKMULTISIG</code> and <code>OP_CHECKMULTISIGVERIFY</code>. Refer to the developer documentation<ref>[[https://bitcoin.org/en/developer-guide#p2pkh-script-validation|Developer Documentation - P2PKH Script Validation]]</ref> for their semantics.
+
+The existing <code>OP_CHECKMULTISIG</code> and <code>OP_CHECKMULTISIGVERIFY</code> have a bug<ref>[[https://bitcoin.org/en/developer-guide#multisig|Developer Documentation - Multisig]]</ref> that pops one argument too many from the stack. This bug is not reproduced in the implementation of OP_CHECKSIGEX, so the canonical solution of pushing a dummy value onto the stack is not necessary.
+
+<code>SCRIPT_CHECKSIGEX_NORMALIZE</code> indicates that before computing the signaturehash, i.e., the hash that is signed, the transaction should be normalized by replacing all transaction IDs in the inputs by their normalized variants. The normalized transction IDs are computed as described in the next section. This normalization step is performed both when creating the signatures as well as when checking the signatures.
+
+In order to make use of the normalization feature, this BIP introduces two new standard transaction types
+
+    OP_DUP OP_HASH160 <pubkey hash> OP_EQUALVERIFY OP_4 OP_CHECKSIGEX
+
+and 
+
+    <num sigs> <pubkeys> <numpubkeys> OP_6 OP_CHECKSIGEX
+
+The first is the equivalent of the pay-to-pubkeyhash script with normalization (<code>OP_4 = SCRIPT_CHECKSIGEX_NORMALIZE</code>), while the second is the equivalent of the pay-to-multisig also with normalization (<code>OP_6 = SCRIPT_CHECKSIGEX_NORMALIZE | SCRIPT_CHECKSIGEX_MULTI</code>). The format of the <code>scriptSig</code> corresponds to the original version, with exception of omitting the dummy <code>OP_0</code> in the multisig case.
+
+=== Tracking Normalized Transaction IDs ===
+
+The transaction version is bumped to 2. The new version signals to clients receiving the transaction that they should track the normalized transaction ID along with the transaction instance ID in the unspent transaction output (UTXO) set. Upon receiving a version 2 transaction the client computes the normalized transaction ID, annotates the outputs with it, and adds them into the UTXO set indexed by the transaction instance ID as before. Transactions continue using the transaction instance ID to reference the outputs, but while checking the signature they may get normalized. All network messages continue to use the transaction instance ID to reference the transaction, specifically <code>inv</code>, <code>getdata</code>, <code>tx</code> and <code>block</code> messages still use transaction instance IDs, not the normalized transaction IDs.
+
+Outputs created by version 1 transactions are not annotated with the normalized transaction ID, and when normalizing the hashes in transaction inputs referencing version 1 outputs are not modified.
+
+== Rationale ==
+
+Normalized transaction IDs are provably non-malleable since no data is included in the signaturehash whose integrity is not also proven in the signature, thus any modification causing the hash to change will also invalidate the signature.
+Normalized transactions are secure as they still use cryptographic hashes over all the semantic information of the transaction, i.e., the inputs, outputs and metadata, thus it is still computationally infeasible to cause a hash collision between transactions.
+
+There are a number of advantages to using normalized transaction IDs:
+
+* Like BIP 62 and BIP 66 it solves the problem of third-parties picking transactions out of the network, modifying them and reinjecting them, as was allegedly done to defraud MtGox<ref>[[http://www.tik.ee.ethz.ch/file/7e4a7f3f2991784786037285f4876f5c/malleability.pdf|Bitcoin Transaction Malleability and MtGox]]</ref>.
+* ''m-of-n'' multisig outputs are often used in higher level protocols<ref>[[http://www.tik.ee.ethz.ch/file/716b955c130e6c703fac336ea17b1670/duplex-micropayment-channels.pdf|A Fast and Scalable Payment Network with Bitcoin Duplex Micropayment Channels ]]</ref><ref>[[http://lightning.network/lightning-network-paper.pdf|The Bitcoin Lightning Network:
+Scalable Off-Chain Instant Payments]]</ref> in which several parties sign a transaction. Without normalized transaction IDs it is trivial for one party to re-sign a transaction, hence changing the transaction hash and invalidating any transaction built on top of its outputs. Normalized transaction IDs force the ID not to change, even if a party replaces its signature.
+* Many higher level protocols build structures of transactions on top of multisig outputs that are not completely signed. This is currently not possible without one party holding a fully signed transaction and then calculating the ID. It is desirable to be able to build successive transactions without one party collecting all signatures, and thus possibly lock in funds unilaterally. Normalized transaction IDs allow the use of transaction templates, i.e., completely unsigned transactions upon which further transactions can be built, and only once every party is assured the structure matches its expectations it signs the template, thus validating the template.
+
+The only occurence in which transactions can still be modified unilaterally is in the case <code>SIGHASH_NONE</code>, <code>SIGHASH_SINGLE</code> or <code>SIGHASH_ANYONECANPAY</code> is used. This however is not problematic since in these cases the creator of the transaction explicitly allows modification.
+
+In case of a transaction becoming invalid due to one of the inputs being malleated it is necessary to modify the spending transaction to reference the modified transaction ID. However, the signatures, which only use the normalized IDs, remain valid as long as the semantics of the funding transaction remain unchanged. An observer in the network may fix the transaction and reinject a corrected version.
+
+Using version 2 for transactions is an explicit optin to the normalized ID tracking and a simple upgrade for existing clients. It avoids having to reprocess the entire blockchain and computing the normalized transaction IDs for existing outputs in the UTXO. This would be further complicated by having to recursively compute normalized transaction IDs down to the coinbase transactions which created the coins.
+
+The new opcode <code>OP_CHECKSIGEX</code> was introduced in order to allow the use of normalized transaction IDs as a softfork and in order to keep the number of <code>OP_NOP</code>s needed to a bare minimum. The additional argument containing the flags can be pushed on the stack using a single byte as long as only the least significant 4 bits are set (<code>OP_1</code> - <code>OP_16</code>), resulting in one byte overhead for this script type. Furthermore it removes the bug requiring a dummy push in the multisig scenario, resulting in the same size in this scenario.
+
+Tracking the normalized transaction IDs in the UTXO requires the storage of an additional hash per transaction whose outputs are not completely spent, which at 7,000,000 transactions with unspent outputs amounts to 224MB additional storage on disk.
+
+The coinbase transactions have been checked for hash-collisions and no collisions were found except for the coinbase transactions in blocks at heights 91842 and 91880, which are known to be identical<ref>[[https://github.com/bitcoin/bips/blob/master/bip-0030.mediawiki|BIP 30 - Duplicate transactions]]</ref>, and motivated the introduction of BIP 34.<ref>[[https://github.com/bitcoin/bips/blob/master/bip-0034.mediawiki|Block v2, Height in Coinbase]]</ref> Since coinbase transactions are invalid if transmitted outside of a block it is not possible to modify them on the fly and since they only mature after being included for a long time in the blockchain they are considered safe.
+
+=== Impact ===
+
+This is a softfork which replaces <code>OP_NOP4</code> with the new implementation of <code>OP_CHECKSIGEX</code>, as such the impact on the network is minimal. Wallets that do not implement this opcode will not be able to verify the validity of the scripts, however if transactions using <code>OP_CHECKSIGEX</code> are included in blocks they will accept them and track the inputs correctly. This is guaranteed since the transaction inputs still use the non-normalized transaction ID to reference the outputs to be claimed, hence non-upgraded wallets can still lookup the outputs and mark them as spent. Furthermore, clients that do not implement this BIP are unable to identify outputs using this script as their own, however upgrading and rescanning the blockchain will make them available.
+
+== See also ==
+
+* [[bip-0062.mediawiki|BIP 62: Dealing with malleability]]
+* [[bip-0066.mediawiki|BIP 66: Strict DER Signatures]]
+
+== References ==
+<references>
+
+==Copyright==
+This document is placed in the public domain.


### PR DESCRIPTION
This is the amended Normalized Transaction ID BIP previously discussed
on the mailing list. Since the discussion on the mailing list there
have been some major changes, for one the BIP changed from requiring a
hard-fork to a much easier soft-fork (thanks sipa for helping me
figure out how).

The normalized transaction IDs are computed on a stripped version of
the transaction, in which all the malleable parts, i.e., the
signatures, where removed. This solves malleability in a simple and
clean way.

Unlike the original proposal, this version does not use the normalized
transaction IDs on a network level, instead they are used solely when
signing and checking signatures. Normalized transactions are swapped
in on-demand when using a new opcode OP_CHECKSIGEX and are tracked in
the UTXO, no longer requiring lookups by normalized transaction ID.

In order to give clear semantics when to track the normalized
transaction IDs and anchoring them without recursively computing the
IDs of previous transactions down to the coinbases, the version is
bumped to 2. Version 2 outputs may be referenced using the normalized
transaction IDs, while nothing changes for version 1 transactions.

There is a working implementation of this BIP in my [normtx
branch](https://github.com/cdecker/bitcoin/tree/normtx).