### PR TITLE
BIP65 spv clients

### DIFF
--- a/bip-0065.mediawiki
+++ b/bip-0065.mediawiki
@@ -277,8 +277,8 @@ We reuse the double-threshold switchover mechanism from BIPs 34 and
 66, with the same thresholds, but for nVersion = 4. The new rules are
 in effect for every block (at height H) with nVersion = 4 and at least
 750 out of 1000 blocks preceding it (with heights H-1000..H-1) also
-have nVersion = 4. Furthermore, when 950 out of the 1000 blocks
-preceding a block do have nVersion = 4, nVersion = 3 blocks become
+have nVersion >= 4. Furthermore, when 950 out of the 1000 blocks
+preceding a block do have nVersion >= 4, nVersion < 4 blocks become
 invalid, and all further blocks enforce the new rules.
 
 

--- a/bip-0065.mediawiki
+++ b/bip-0065.mediawiki
@@ -282,6 +282,16 @@ preceding a block do have nVersion >= 4, nVersion < 4 blocks become
 invalid, and all further blocks enforce the new rules.
 
 
+===SPV Clients===
+
+While SPV clients are (currently) unable to validate blocks in general,
+trusting miners to do validation for them, they are able to validate block
+headers and thus can validate a subset of the deployment rules. SPV clients
+should reject nVersion < 4 blocks if 950 out of 1000 preceding blocks have
+nVersion >= 4 to prevent false confirmations from the remaining 5% of
+non-upgraded miners when the 95% threshold has been reached.
+
+
 ==Credits==
 
 Thanks goes to Gregory Maxwell for suggesting that the argument be compared


### PR DESCRIPTION
Add recommendation that SPV clients validate nVersion deployment rules to prevent the acceptance of invalid blocks after the 95% threshold has been reached.