### PR TITLE
add link to btcsuite implementation of bip 0069

### DIFF
--- a/bip-0069.mediawiki
+++ b/bip-0069.mediawiki
@@ -162,6 +162,7 @@ Outputs:
 * [[https://github.com/bitcoinjs/bip69/blob/master/index.js|BitcoinJS]]
 * [[https://github.com/bitcoinjs/bip69/blob/master/test/fixtures.json|BitcoinJS Test Fixtures]]
 * [[https://www.npmjs.com/package/bip69|NodeJS]]
+* [[https://github.com/btcsuite/btcutil/blob/master/txsort/txsort.go|Btcsuite]]
 
 ==Acknowledgements==
 


### PR DESCRIPTION
Hi, adding a link to recently merged golang implementation of bip 0069.