### PR TITLE
BIP65: Change to accepted status

### DIFF
--- a/bip-0065.mediawiki
+++ b/bip-0065.mediawiki
@@ -2,7 +2,7 @@
   BIP: 65
   Title: OP_CHECKLOCKTIMEVERIFY
   Author: Peter Todd <pete@petertodd.org>
-  Status: Draft
+  Status: Accepted
   Type: Standards Track
   Created: 2014-10-01
 </pre>


### PR DESCRIPTION
With https://github.com/bitcoin/bitcoin/pull/6351 merged (and subsequent backport's), it would seem this status is fitting?