### PR TITLE
Remove support for SHA-1 from BIP0070

### DIFF
--- a/bip-0070.mediawiki
+++ b/bip-0070.mediawiki
@@ -118,7 +118,7 @@ A PaymentRequest is PaymentDetails optionally tied to a merchant's identity:
 {|
 | payment_details_version || See below for a discussion of versioning/upgrading.
 |-
-| pki_type  || public-key infrastructure (PKI) system being used to identify the merchant. All implementation should support "none", "x509+sha256" and "x509+sha1".
+| pki_type  || public-key infrastructure (PKI) system being used to identify the merchant. All implementation should support "none" and "x509+sha256".
 |-
 | pki_data || PKI-system data that identifies the merchant and can be used to create a digital signature. In the case of X.509 certificates, pki_data contains one or more X.509 certificates (see Certificates section below).
 |-
@@ -234,8 +234,7 @@ merchant's website responds with PaymentACK.message "σας ευχαριστού
 
 The default PKI system is X.509 certificates (the same system used to
 authenticate web servers). The format of pki_data when pki_type is
-"x509+sha256" or "x509+sha1" is a protocol-buffer-encoded certificate
-chain:
+"x509+sha256" is a protocol-buffer-encoded certificate chain:
 <pre>
     message X509Certificates {
         repeated bytes certificate = 1;
@@ -243,8 +242,7 @@ chain:
 </pre>
 If pki_type is "x509+sha256", then the PaymentRequest message is hashed using
 the SHA256 algorithm to produce the message digest that is
-signed. If pki_type is "x509+sha1", then the SHA1 algorithm is
-used.
+signed.
 
 Each certificate is a DER [ITU.X690.1994] PKIX certificate value. The
 certificate containing the public key of the entity that digitally


### PR DESCRIPTION
SHA-1 has long been considered an insecure hashing algorithm. While
there have not been any collisions found yet, there are indications that
actual collisions are imminent.

Since 2011, we have known about the hash collision attack by Marc
Stevens [0] which brings down the complexity to approximately 2^65.

However, the recent attack by Stevens, Karpman, Peyrin on October 8th,
2015 which allowed them to construct and publish a freestart collision
attack on SHA-1's compression function (termed the "SHAppening") with
only 2^57 evaluations [1] is even more worrysome.

Under these circumstances, PKI CAs are already discussing the sunsetting
of SHA1 as a hash function, as it is considered cryptographically
insecure. These discussions have led to decisions to stop using SHA-1 in
PKI certificates. Specifically [2]

1. SHA-1 certificates will no longer be issued after the end of 2015.
2. SHA-1 certificates issued earlier will no longer be accepted after
the end of 2016.

As the CA discussions indicate, it is not sufficient to pull SHA-1
support from CAs. As MD5 has shown, hash functions will have to be
pulled from applications (such as the browser or BIP0070 for bitcoin)
for the hashes to be discontinued. Therefore, it is not enough for us to
rely on CAs following the deadlines.

As BIP0070 concerns the security of payments, we should discontinue the
acceptance or recommendation of SHA-1 as a hash method for our protocol
sooner than later.

This patch removes SHA-1 support for X.509 certificates from BIP0070.

[0]
https://marc-stevens.nl/research/papers/PhD%20Thesis%20Marc%20Stevens%20-%20Attacks%20on%20Hash%20Functions%20and%20Applications.pdf
[1] https://sites.google.com/site/itstheshappening/
[2] https://cabforum.org/pipermail/public/2015-November/006280.html