### PR TITLE
add copay link to bip44 compatible wallets list

### DIFF
--- a/bip-0044.mediawiki
+++ b/bip-0044.mediawiki
@@ -265,6 +265,7 @@ is required. This can be done [[https://github.com/satoshilabs/docs/blob/master/
 * [[https://mytrezor.com|myTREZOR web wallet]] ([[https://github.com/trezor/webwallet|source]])
 * [[https://play.google.com/store/apps/details?id=com.bonsai.wallet32|Wallet32 @ Android]] ([[https://github.com/ksedgwic/Wallet32|source]])
 * [[https://play.google.com/store/apps/details?id=com.mycelium.wallet|Mycelium Bitcoin Wallet (Android)]] ([[https://github.com/mycelium-com/wallet|source]])
+* [[https://copay.io/|Copay]] ([[https://github.com/bitpay/copay|source]])
 * [[https://maza.club/encompass|Encompass]] ([[https://github.com/mazaclub/encompass|source]])
 
 ==Reference==


### PR DESCRIPTION
I suggest that we add copay to thie list of compatible wallets for Bip44 as they use the Bip44 path for key derivation

![screenshot 2015-11-24 00 54 57](https://cloud.githubusercontent.com/assets/3032137/11362024/03c051e4-9246-11e5-9ffd-8be4a62cccf2.png)
