### PR TITLE
Corrections with the conditions for script failure

### DIFF
--- a/bip-0112.mediawiki
+++ b/bip-0112.mediawiki
@@ -22,10 +22,11 @@ being spent.
 CHECKSEQUENCEVERIFY redefines the existing NOP3 opcode.
 When executed, if any of the following conditions are true, the script interpreter will terminate with an error:
 
+* the stack is empty; or
 * the top item on the stack is less than 0; or
 * the top item on the stack has the disable flag (1 << 31) unset; and
 ** the transaction version is less than 2; or
-** the transaction input sequence number disable flag (1 << 31) is set; and
+** the transaction input sequence number disable flag (1 << 31) is set; or
 ** the relative lock-time type is not the same; or
 ** the top stack item is greater than the transaction sequence (when masked according to the BIP68);
 


### PR DESCRIPTION
Mainly for correcting the typo: and->or