### PR TITLE
Change BIP1 to status Active

### DIFF
--- a/bip-0001.mediawiki
+++ b/bip-0001.mediawiki
@@ -1,7 +1,7 @@
 <pre>
   BIP: 1
   Title: BIP Purpose and Guidelines
-  Status: Accepted
+  Status: Active
   Type: Standards Track
   Created: 2011-08-19
 </pre>


### PR DESCRIPTION
Make it consistent. From the text: "Some Informational and Process BIPs may also have a status of "Active" if they are never meant to be completed. E.g. BIP 1 (this BIP)."
