### PR TITLE
BIP-0001 Should be labeled as "Process" Type

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -16,7 +16,7 @@ Those proposing changes should consider that ultimately consent may rest with th
 | [[bip-0001.mediawiki|1]]
 | BIP Purpose and Guidelines
 | Amir Taaki
-| Standard
+| Process
 | Active
 |-
 | [[bip-0009.mediawiki|9]]

--- a/bip-0001.mediawiki
+++ b/bip-0001.mediawiki
@@ -2,7 +2,7 @@
   BIP: 1
   Title: BIP Purpose and Guidelines
   Status: Active
-  Type: Standards Track
+  Type: Process
   Created: 2011-08-19
 </pre>
 


### PR DESCRIPTION
Previously BIP-0001 listed in its header preamble that is was a "Standards Track"
type proposal. This conflicts with both its own definition of "Standards Track"
proposal as well as the type listed in PEP-0001 of which BIP-0001 is based on.

Defitions of each type of proposal:

A Standards Track BIP describes any change that affects most or all Bitcoin implementations.

An Informational BIP describes a Bitcoin design issue, or provides general guidelines or information to the Bitcoin community, but does not propose a new feature.

A Process BIP describes a process surrounding Bitcoin, or proposes a change to (or an event in) a process.
Specifically: "Any meta-BIP is also considered a Process BIP."

Based on these definitions BIP-0001 should have always been labeled as a "Process" BIP and this patch corrects this.