### PR TITLE
BIP 108: Block size increase to 2MB + small steps (BIP 102 variant w/ small steps)

### DIFF
--- a/bip-0202.mediawiki
+++ b/bip-0202.mediawiki
@@ -1,0 +1,44 @@
+<pre>
+  BIP: 202
+  Title: Block size increase to 2MB + small steps
+  Author: Jeff Garzik <jgarzik@gmail.com>
+  Status: Draft
+  Type: Standards Track
+  Created: 2015-06-23
+</pre>
+
+==Abstract==
+
+Simple, one-time increase in total amount of transaction data permitted in a block from 1MB to 2MB, then small step increases.
+
+==Motivation==
+
+# Continue current economic policy.
+# Exercise hard fork network upgrade.
+
+==Specification==
+
+# MAX_BLOCK_SIZE increased to 2,000,000 bytes at trigger point.
+# Increase maximum block sigops by similar factor, preserving SIZE/50 formula.
+# Each 10-minute segment thereafter increases MAX_BLOCK_SIZE by 20 bytes.
+# Trigger:  (1) Block time 00:00:00 on flag day, AND (2) 75% of the last 1,000 blocks have signaled support.
+
+==Backward compatibility==
+
+Fully validating older clients are not compatible with this change.
+The first block exceeding 1,000,000 bytes will partition older clients
+off the new network.
+
+==Discussion==
+
+In the short term, an increase is needed to continue to current
+economic policies with regards to fees and block space, matching
+market expectations and preventing market disruption.
+
+In the long term, this limit should focus on reflecting the maximum
+network engineering limit.
+
+==Implementation==
+
+https://github.com/jgarzik/bitcoin/tree/2015_2mb_blocksize_step
+

--- a/drafts/draft-jg-small-bump-incr.mediawiki
+++ b/drafts/draft-jg-small-bump-incr.mediawiki
@@ -1,5 +1,5 @@
 <pre>
-  BIP: 202
+  BIP: draft-jg-small-bump-incr
   Title: Block size increase to 2MB + small steps
   Author: Jeff Garzik <jgarzik@gmail.com>
   Status: Draft
@@ -21,7 +21,7 @@ Simple, one-time increase in total amount of transaction data permitted in a blo
 # MAX_BLOCK_SIZE increased to 2,000,000 bytes at trigger point.
 # Increase maximum block sigops by similar factor, preserving SIZE/50 formula.
 # Each 10-minute segment thereafter increases MAX_BLOCK_SIZE by 20 bytes.
-# Trigger:  (1) Block time 00:00:00 on flag day, AND (2) 75% of the last 1,000 blocks have signaled support.
+# Trigger:  (1) Block time 00:00:00 on flag day, AND (2) 95% of the last 1,000 blocks have signaled support.
 
 ==Backward compatibility==
 


### PR DESCRIPTION
A request for BIP 102 was "a variant that does not require revisiting", so a small step was included per the current thinking on small-step small-shock.

*NOTE*: Creates new "drafts" directory to illustrate different proposal technique.