### PR TITLE
Fix BIP142: Example script needs PUSH length byte

### DIFF
--- a/bip-0142.mediawiki
+++ b/bip-0142.mediawiki
@@ -25,7 +25,6 @@ The first new Bitcoin address format defined is specific to pay-to-public-key-ha
 or:
   OP_0 <DUP HASH160 {20-byte-hash-value} EQUALVERIFY CHECKSIG>
 
-
 The new address is encoded exactly in the same way as the original pay-to-public-key-hash address:
   base58-encode: [1-byte version][20-byte-hash-value][4-byte checksum]
 

--- a/bip-0142.mediawiki
+++ b/bip-0142.mediawiki
@@ -19,8 +19,8 @@ To define standard payment addresses for native segwit transactions to promote e
 
 === P2PKH segwit address ===
 
-The first new Bitcoin address format defined is specific to pay-to-public-key-hash segwit transaction. The scriptPubKey is a single push of version-0 witness program in this form,
-  0x001976A914{20-byte-hash-value}88AC
+The first new Bitcoin address format defined is specific to pay-to-public-key-hash segwit transaction. The scriptPubKey consists of two PUSHDATA's: the version, and the serialized script.
+  0x00 0x1976A914{20-byte-hash-value}88AC
 
 or:
   OP_0 <DUP HASH160 {20-byte-hash-value} EQUALVERIFY CHECKSIG>
@@ -28,6 +28,7 @@ or:
 
 The new address is encoded exactly in the same way as the original pay-to-public-key-hash address:
   base58-encode: [1-byte version][20-byte-hash-value][4-byte checksum]
+
 Version byte is 0x19 for a main-network address, 0x41 for a testnet address. The following 20-byte is the public key hash. And the 4-byte checksum is the first four bytes of the double SHA256 hash of the version and public key hash.
 
 All addresses generated with this scheme will a constant length of 34 characters, with a "B" prefix for main-network and "T" prefix for testnet.
@@ -125,7 +126,7 @@ And the corresponding version 1 Bitcoin address is
 When the same script is encoded as a version 0 witness program, the scriptPubKey becomes: 
     OP_0 <0x76A914010966776006953D5567439E5E39F86A0D273BEE88AC>
 Using 0x19 as the address version, the equivalent witness program address is:
-    BGMZdnvTr2wXTjkSs5TmrCGRN33MWpzdoK
+    B4YZZ3nMBETWVF9ZSfotSwTxVnqhdkTi7r
 
 === General segwit address ===
 

--- a/bip-0142.mediawiki
+++ b/bip-0142.mediawiki
@@ -20,7 +20,12 @@ To define standard payment addresses for native segwit transactions to promote e
 === P2PKH segwit address ===
 
 The first new Bitcoin address format defined is specific to pay-to-public-key-hash segwit transaction. The scriptPubKey is a single push of version-0 witness program in this form,
-  <0x0076A914{20-byte-hash-value}88AC>
+  0x001976A914{20-byte-hash-value}88AC
+
+or:
+  OP_0 <DUP HASH160 {20-byte-hash-value} EQUALVERIFY CHECKSIG>
+
+
 The new address is encoded exactly in the same way as the original pay-to-public-key-hash address:
   base58-encode: [1-byte version][20-byte-hash-value][4-byte checksum]
 Version byte is 0x19 for a main-network address, 0x41 for a testnet address. The following 20-byte is the public key hash. And the 4-byte checksum is the first four bytes of the double SHA256 hash of the version and public key hash.
@@ -120,7 +125,7 @@ And the corresponding version 1 Bitcoin address is
 When the same script is encoded as a version 0 witness program, the scriptPubKey becomes: 
     OP_0 <0x76A914010966776006953D5567439E5E39F86A0D273BEE88AC>
 Using 0x19 as the address version, the equivalent witness program address is:
-    B4YZZ3nMBETWVF9ZSfotSwTxVnqhdkTi7r
+    BGMZdnvTr2wXTjkSs5TmrCGRN33MWpzdoK
 
 === General segwit address ===
 


### PR DESCRIPTION
Following the segwit BIP 141 #265, a version 0 program: OP_0 <a push of the script>

BIP142: #267 mentions the following script: 

      <0x0076A914{20-byte-hash-value}88AC>
which would be: OP_0 DUP HASH160 [hash] EQUALVERIFY CHECKSIG

Notice the witness program isn't _pushed_ like pay-to-script-hash. The push is missing the length marker, 0x19. I think it should be:

     OP_0 PUSHDATA|length [hash]
     script: OP_0 76a914010966776006953d5567439e5e39f86a0d273bee88ac
     scriptPubKey: 001976a914010966776006953d5567439e5e39f86a0d273bee88ac
     Address: BGMZdnvTr2wXTjkSs5TmrCGRN33MWpzdoK 