### PR TITLE
Minor: Fix BIP65 status in README

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -252,7 +252,7 @@ Those proposing changes should consider that ultimately consent may rest with th
 | OP_CHECKLOCKTIMEVERIFY
 | Peter Todd
 | Standard
-| Draft
+| Accepted
 |-
 | [[bip-0066.mediawiki|66]]
 | Strict DER signatures


### PR DESCRIPTION
We changed it in the BIP doc itself, but not the index.