### PR TITLE
Fix little typo in p2wpkh address creation

### DIFF
--- a/bip-0142.mediawiki
+++ b/bip-0142.mediawiki
@@ -134,7 +134,7 @@ When the same public key is encoded as P2WPKH, the scriptPubKey becomes:
   
     OP_0 <010966776006953D5567439E5E39F86A0D273BEE>
 
-Using 0x06 as witness version, followed 0x00 as witness version, and a 0x00 padding, the equivalent P2WPKH address is:
+Using 0x06 as address version, followed 0x00 as witness program version, and a 0x00 padding, the equivalent P2WPKH address is:
   
     p2xtZoXeX5X8BP8JfFhQK2nD3emtjch7UeFm
  


### PR DESCRIPTION
Was stumbling over this while reading the BIP.