### PR TITLE
Promote Draft->Final BIPs: 50, 60, 64, 66, and 73

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -215,14 +215,14 @@ Those proposing changes should consider that ultimately consent may rest with th
 | March 2013 Chain Fork Post-Mortem
 | Gavin Andresen
 | Informational
-| Draft
+| Final
 <!-- 50 series reserved for a group of post-mortems -->
 |-
 | [[bip-0060.mediawiki|60]]
 | Fixed Length "version" Message (Relay-Transactions Field)
 | Amir Taaki
 | Standard
-| Draft
+| Final
 |-
 | [[bip-0061.mediawiki|61]]
 | "reject" P2P message
@@ -246,7 +246,7 @@ Those proposing changes should consider that ultimately consent may rest with th
 | getutxos message
 | Mike Hearn
 | Standard
-| Draft
+| Final
 |-
 | [[bip-0065.mediawiki|65]]
 | OP_CHECKLOCKTIMEVERIFY
@@ -258,7 +258,7 @@ Those proposing changes should consider that ultimately consent may rest with th
 | Strict DER signatures
 | Pieter Wuille
 | Standard
-| Draft
+| Final
 |-
 | [[bip-0067.mediawiki|67]]
 | Deterministic P2SH multi-signature addresses
@@ -300,7 +300,7 @@ Those proposing changes should consider that ultimately consent may rest with th
 | Use "Accept" header with Payment Request URLs
 | Stephen Pair
 | Standard
-| Draft
+| Final
 |-
 | [[bip-0074.mediawiki|74]]
 | Support zero value OP_RETURN in Payment Requests

--- a/bip-0050.mediawiki
+++ b/bip-0050.mediawiki
@@ -2,7 +2,7 @@
   BIP: 50
   Title: March 2013 Chain Fork Post-Mortem
   Author: Gavin Andresen <gavinandresen@gmail.com>
-  Status: Draft
+  Status: Final
   Type: Informational
   Created: 2013-03-20
 </pre>

--- a/bip-0060.mediawiki
+++ b/bip-0060.mediawiki
@@ -2,7 +2,7 @@
   BIP: 60
   Title: Fixed Length "version" Message (Relay-Transactions Field)
   Author: Amir Taaki <genjix@riseup.net>
-  Status: Draft
+  Status: Final
   Type: Standards Track
   Created: 2013-06-16
 </pre>

--- a/bip-0064.mediawiki
+++ b/bip-0064.mediawiki
@@ -2,7 +2,7 @@
   BIP: 64
   Title: getutxo message
   Author: Mike Hearn <hearn@vinumeris.com>
-  Status: Draft
+  Status: Final
   Type: Standards Track
   Created: 2014-06-10
 </pre>

--- a/bip-0073.mediawiki
+++ b/bip-0073.mediawiki
@@ -2,7 +2,7 @@
   BIP: 73
   Title: Use "Accept" header for response type negotiation with Payment Request URLs
   Author: Stephen Pair <stephen@bitpay.com>
-  Status: Draft
+  Status: Final
   Type: Standards Track
   Created: 2013-08-27
 </pre>


### PR DESCRIPTION
The following BIPs appear to meet the criteria for Final status, but have not been promoted to Accepted by their author yet, so need ACKs from the authors. Since at least @genjix is MIA, we probably also need to discuss how to handle such actions when BIP champions disappear - BIP 1 allows for me to assign an additional champion to take over, but I'm not sure anyone would necessarily *want* to do so in this case.

BIP 50: Proposed action items, including the hardfork, are completed. @gavinandresen

BIP 60: BIP 37 was apparently not clear on whether the new "relay transactions" flag was mandatory or optional. BIP 60 sought to explicitly make it mandatory. In parallel, Jeff Garzik interpreted BIP 37's field as mandatory in https://github.com/bitcoin/bitcoin/issues/2534 and Pieter Wuille implemented the changes required for that (and BIP 60) in https://github.com/bitcoin/bitcoin/pull/2763 . Numerous forks of Bitcoin Core since then have also picked up this change. @genjix

BIP 64: The getutxo message was implemented for use between (pre-contentious hardforks) Bitcoin XT and Lighthouse. Both of these are unmaintained now, but this does not seem relevant. @mikehearn

BIP 66: Softfork accepted by a supermajority of miners. @sipa

BIP 73: Implemented by at least Bitcoin Core and BitPay. @gasteve
