### PR TITLE
Adding crypzo to BIP44 supported wallets

### DIFF
--- a/bip-0044.mediawiki
+++ b/bip-0044.mediawiki
@@ -267,7 +267,7 @@ is required and a pull request to the above file should be created.
 * [[https://play.google.com/store/apps/details?id=com.mycelium.wallet|Mycelium Bitcoin Wallet (Android)]] ([[https://github.com/mycelium-com/wallet|source]])
 * [[https://copay.io/|Copay]] ([[https://github.com/bitpay/copay|source]])
 * [[https://maza.club/encompass|Encompass]] ([[https://github.com/mazaclub/encompass|source]])
-
+* [[https://www.crypzo.com/|Crypzo]] 
 ==Reference==
 
 * [[bip-0032.mediawiki|BIP32 - Hierarchical Deterministic Wallets]]


### PR DESCRIPTION
Some of the source will be released soon.