### PR TITLE
BIP1: Formatfix for auxiliary files section and a small typofix

### DIFF
--- a/bip-0001.mediawiki
+++ b/bip-0001.mediawiki
@@ -85,9 +85,9 @@ Each BIP should have the following parts:
 
 ==BIP Formats and Templates==
 
-BIPs should be written in mediawiki or markdown format. Image files should be included in a subdirectory for that BIP.
+BIPs should be written in mediawiki or markdown format.
 
-==BIP Header Preamble==
+===BIP Header Preamble===
 
 Each BIP must begin with an RFC 822 style header preamble. The headers must appear in the following order. Headers marked with "*" are optional and are described below. All other headers are required.
 
@@ -129,9 +129,10 @@ The Created header records the date that the BIP was assigned a number, while Po
 BIPs may have a Requires header, indicating the BIP numbers that this BIP depends on.
 
 BIPs may also have a Superseded-By header indicating that a BIP has been rendered obsolete by a later document; the value is the number of the BIP that replaces the current document. The newer BIP must have a Replaces header containing the number of the BIP that it rendered obsolete.
-Auxiliary Files
 
-BIPs may include auxiliary files such as diagrams. Such files must be named BIP-XXXX-Y.ext, where "XXXX" is the BIP number, "Y" is a serial number (starting at 1), and "ext" is replaced by the actual file extension (e.g. "png").
+===Auxiliary Files===
+
+BIPs may include auxiliary files such as diagrams. Image files should be included in a subdirectory for that BIP. Auxiliary files must be named BIP-XXXX-Y.ext, where "XXXX" is the BIP number, "Y" is a serial number (starting at 1), and "ext" is replaced by the actual file extension (e.g. "png").
 
 ==Transferring BIP Ownership==
 

--- a/bip-0001.mediawiki
+++ b/bip-0001.mediawiki
@@ -175,6 +175,6 @@ This document was derived heavily from Python's PEP-0001. In many places text wa
 
 ==Changelog==
 
-10 Oct 2015 - Added clarifications about sumission process and BIP number assignment.
+10 Oct 2015 - Added clarifications about submission process and BIP number assignment.
 
 01 Jan 2016 - Clarified early stages of BIP idea championing, collecting community feedback, etc.


### PR DESCRIPTION
This pull request contains two trivial changes for BIP1:

* Formatfix the "auxiliary files" section, and also consolidating the sentence about images into the section about auxiliary files.

* Typofix "sumission" -> "submission" in the changelog section.

and two less-than-trivial changes:

* Make "BIP Header Preamble" a subsection of "BIP Formats and Templates".

* Make "auxiliary files" a subsection of "BIP Formats and Templates".