### PR TITLE
Crypzo has changed name to CoinVault

### DIFF
--- a/bip-0044.mediawiki
+++ b/bip-0044.mediawiki
@@ -267,7 +267,7 @@ is required and a pull request to the above file should be created.
 * [[https://play.google.com/store/apps/details?id=com.mycelium.wallet|Mycelium Bitcoin Wallet (Android)]] ([[https://github.com/mycelium-com/wallet|source]])
 * [[https://copay.io/|Copay]] ([[https://github.com/bitpay/copay|source]])
 * [[https://maza.club/encompass|Encompass]] ([[https://github.com/mazaclub/encompass|source]])
-* [[https://www.crypzo.com/|Crypzo]] 
+* [[https://www.coinvault.io/|CoinVault]] 
 ==Reference==
 
 * [[bip-0032.mediawiki|BIP32 - Hierarchical Deterministic Wallets]]


### PR DESCRIPTION
The original link was broken use http://www.crypzo.com to get the redirect