### PR TITLE
Superfluous Leading & Trailing Forwards Slashes

### DIFF
--- a/bip-0014.mediawiki
+++ b/bip-0014.mediawiki
@@ -54,12 +54,12 @@ Bitcoin user agents are a modified browser user agent with more structure to aid
 
 Basic format:
 
-  /Name:Version/Name:Version/.../
+  Name:Version/Name:Version/.../Name:Version
 
 Example:
 
-  /Satoshi:5.64/bitcoin-qt:0.4/
-  /Satoshi:5.12/Spesmilo:0.8/
+  Satoshi:5.64/bitcoin-qt:0.4
+  Satoshi:5.12/Spesmilo:0.8
 
 Here bitcoin-qt and Spesmilo may use protocol version 5.0, however the internal codebase they use are different versions of the same software. The version numbers are not defined to any strict format, although this guide recommends:
 


### PR DESCRIPTION
The user-agent string example begins and ends with delimiters (the forward slash or /) that have no use to humans or computers and therefore should be eliminated. Eliminating these superfluous delimiters will slightly decreased the data size transmitted to peers, stored when consuming API messages and make the UI look better.

So far, no one has been able to explain the benefit of the leading and trailing forwards slashes except that it is specified in this BIP.  Please see this pull request:  [https://github.com/bitcoin/bitcoin/pull/7640]