### PR TITLE
Remove deployment section

### DIFF
--- a/bip-0141.mediawiki
+++ b/bip-0141.mediawiki
@@ -249,25 +249,7 @@ As a soft fork, older software will continue to operate without modification.  N
 
 == Deployment ==
 
-We reuse the double-threshold IsSuperMajority() switchover mechanism used in
-BIP65 with the same thresholds, but for nVersion = 5. The new rules are
-in effect for every block (at height H) with nVersion = 5 and at least
-750 out of 1000 blocks preceding it (with heights H-1000..H-1) also
-have nVersion >= 5. Furthermore, when 950 out of the 1000 blocks
-preceding a block do have nVersion >= 5, nVersion < 5 blocks become
-invalid, and all further blocks enforce the new rules.
-
-(It should be noted that BIP9 involves permanently setting a high-order bit to
-1 which results in nVersion >= all prior IsSuperMajority() soft-forks and thus
-no bits in nVersion are permanently lost.)
-
-=== SPV Clients ===
-
-While SPV clients are unable to fully validate blocks,
-they are able to validate block headers and, thus, can check block version and proof-of-work.
-SPV clients should reject nVersion < 5 blocks if 950 out of 1000 preceding blocks have
-nVersion >= 5 to prevent false confirmations from the remaining 5% of
-non-upgraded miners when the 95% threshold has been reached.
+This BIP is to be deployed by version-bits BIP9. Exact details TDB.
 
 == Credits ==
 


### PR DESCRIPTION
Now we know we will use BIP9 version bits, remove references to ISM() and leave TDB
as was done with BIP68,112 and 113.