### PR TITLE
Clarify what remains "to be decided"

### DIFF
--- a/bip-0141.mediawiki
+++ b/bip-0141.mediawiki
@@ -249,7 +249,11 @@ As a soft fork, older software will continue to operate without modification.  N
 
 == Deployment ==
 
-This BIP is to be deployed by version-bits BIP9. Exact details TDB.
+This BIP will be deployed by "version bits" BIP9 using bit TBD.
+
+For Bitcoin mainnet, the BIP9 starttime will be midnight TBD UTC (Epoch timestamp TBD) and BIP9 timeout will be midnight TBD UTC (Epoch timestamp TBD).
+
+For Bitcoin testnet, the BIP9 starttime will be midnight TBD UTC (Epoch timestamp TBD) and BIP9 timeout will be midnight TBD UTC (Epoch timestamp TBD).
 
 == Credits ==
 


### PR DESCRIPTION
This is the result of feedback from the general public.

Basically we know we're using BIP9 deployment, but we haven't decided on the deployment variables `starttime`, `timeout`, and `bit`. I'm providing a template here so we can file them out once known.