### PR TITLE
BIP143: fix typo ("including")

### DIFF
--- a/bip-0143.mediawiki
+++ b/bip-0143.mediawiki
@@ -191,7 +191,7 @@ This proposal is deployed with Segregated Witness softfork (BIP 141)
 
 == Backward compatibility ==
 
-As a soft fork, older software will continue to operate without modification. Non-upgraded nodes, however, will not see nor validate the witness data and will consider all witness programs, inculding the redefined sigops, as anyone-can-spend scripts.
+As a soft fork, older software will continue to operate without modification. Non-upgraded nodes, however, will not see nor validate the witness data and will consider all witness programs, including the redefined sigops, as anyone-can-spend scripts.
 
 == Reference Implementation ==
 


### PR DESCRIPTION
Minor typo fix for BIP143, "inculding" -> "including".