### PR TITLE
fix BIP141 nested P2SH scriptSig byte representation

### DIFF
--- a/bip-0141.mediawiki
+++ b/bip-0141.mediawiki
@@ -166,7 +166,7 @@ The following example is the same 1-of-2 multi-signature P2WSH witness program, 
 
     witness:      0 <signature1> <1 <pubkey1> <pubkey2> 2 CHECKMULTISIG>
     scriptSig:    <0 <32-byte-hash>>
-                  (0x0020{32-byte-hash})
+                  (0x220020{32-byte-hash})
     scriptPubKey: HASH160 <20-byte-hash> EQUAL
                   (0xA914{20-byte-hash}87)
 


### PR DESCRIPTION
The byte representation of "<0 <32-byte-hash>>" is "0x220020{32-byte-hash}"

What was listed here would be the byte representation of "0 <32-byte-hash>". The text explains that there is only one item in scriptSig, so I'm guessing the byte representation is wrong. Also the corrected byte representation would produce the same sig/pubkey described in P2WSH after following the bip16 rules.