### PR TITLE
Update BIP 144 'havewitness' to service bit

### DIFF
--- a/bip-0144.mediawiki
+++ b/bip-0144.mediawiki
@@ -86,9 +86,10 @@ Currently, the only witness objects type supported are script witnesses which co
 * '''Rationale for the 0x01 flag byte in between''': this will allow us to easily add more extra non-committed data to transactions (like txouts being spent, ...). It can be interpreted as a bitvector.
 
 === Handshake ===
-A new message 'havewitness' is sent after receiving 'verack' to
-indicate that a node can provide witness if requested (similar to
-'sendheaders') (Note: it might be better to signal this with a services bit in the version message)
+A node will signal that it can provide witnesses using the following service bit
+
+    NODE_WITNESS = (1 << 3)
+	
 
 === Hashes ===
 Transaction hashes used in the transaction merkle tree and txin outpoints are always computed using the old non-witness


### PR DESCRIPTION
As per the meeting: http://www.erisian.com.au/meetbot/bitcoin-core-dev/2016/bitcoin-core-dev.2016-04-28-19.00.html

Updates BIP 144 to specify the use of the NODE_WTINESS service bit instead of a havewitness message.