### PR TITLE
Update bip-0112.mediawiki

### DIFF
--- a/bip-0112.mediawiki
+++ b/bip-0112.mediawiki
@@ -185,7 +185,7 @@ Alice might look like the following in Alice's commitment transaction:
     ELSE
         <Commit-Revocation-Hash> EQUAL
         NOTIF
-            "24h" CHECKLOCKTIMEVERIFY DROP
+            "2015/10/20 10:33" CHECKLOCKTIMEVERIFY DROP
         ENDIF
         <Bob key hash>
     ENDIF


### PR DESCRIPTION
CHECKLOCKTIMEVERIFY is absolute (not relative) isn't it?