### PR TITLE
Error in BIP0009 code example

### DIFF
--- a/bip-0009.mediawiki
+++ b/bip-0009.mediawiki
@@ -127,6 +127,7 @@ Note that a block's state never depends on its own nVersion; only on that of its
             if (count >= threshold) {
                 return LOCKED_IN;
             }
+            return STARTED;
 
 After a retarget period of LOCKED_IN, we automatically transition to ACTIVE.
 

--- a/bip-0009.mediawiki
+++ b/bip-0009.mediawiki
@@ -112,7 +112,7 @@ other one simultaneously transitions to STARTED, which would mean both would dem
 
 Note that a block's state never depends on its own nVersion; only on that of its ancestors.
 
-        case STARTED: {
+        case STARTED: 
             if (GetMedianTimePast(block.parent) >= timeout) {
                 return FAILED;
             }
@@ -127,7 +127,6 @@ Note that a block's state never depends on its own nVersion; only on that of its
             if (count >= threshold) {
                 return LOCKED_IN;
             }
-        }
 
 After a retarget period of LOCKED_IN, we automatically transition to ACTIVE.
 

--- a/bip-0009.mediawiki
+++ b/bip-0009.mediawiki
@@ -120,7 +120,7 @@ Note that a block's state never depends on its own nVersion; only on that of its
             walk = block;
             for (i = 0; i < 2016; i++) {
                 walk = walk.parent;
-                if (walk.nVersion & 0xE0000000 == 0x2000000 && (walk.nVersion >> bit) & 1 == 1) {
+                if (walk.nVersion & 0xE0000000 == 0x20000000 && (walk.nVersion >> bit) & 1 == 1) {
                     count++;
                 }
             }


### PR DESCRIPTION
A BIP in state STARTED that did not reach the threshold would disappear instead of stay in STARTED.

The hex error made me looking for a bug for almost an hour after copy pasting the hex values.