### PR TITLE
Update BIP9 assignments list

### DIFF
--- a/bip-0009/assignments.mediawiki
+++ b/bip-0009/assignments.mediawiki
@@ -19,7 +19,7 @@ State can be defined, active, failed. Dates are in UTC.
 | 0
 | 2016-05-01 00:00:00
 | 2017-05-01 00:00:00
-| defined
+| active since #419328
 | 2016-03-01 00:00:00
 | 2017-05-01 00:00:00
 | active since #770112

--- a/bip-0009/assignments.mediawiki
+++ b/bip-0009/assignments.mediawiki
@@ -18,11 +18,11 @@ State can be defined, active, failed. Dates are in UTC.
 | csv
 | 0
 | 2016-05-01 00:00:00
-| 2017-05-01 00:00:00 
+| 2017-05-01 00:00:00
 | defined
 | 2016-03-01 00:00:00
 | 2017-05-01 00:00:00
-| active since #770111
+| active since #770112
 | [[/bip-0068.mediawiki|68]], [[/bip-0112.mediawiki|112]], [[/bip-0113.mediawiki|113]]
 |-
 | segwit

--- a/bip-0009/assignments.mediawiki
+++ b/bip-0009/assignments.mediawiki
@@ -32,6 +32,6 @@ State can be defined, active, failed. Dates are in UTC.
 | -
 | 2016-05-01 00:00:00
 | 2017-05-01 00:00:00
-| defined
+| active since #834624
 | [[/bip-0141.mediawiki|141]], [[/bip-0143.mediawiki|143]]
 |}


### PR DESCRIPTION
This PR updates the BIP9 bit assignments list since the `segwit` deployment is now active on testnet. It also changes the `csv` testnet activation height from "770111" to "770112" since that is the first block where the deployment is active.