### PR TITLE
BIP112/114 example fix

### DIFF
--- a/bip-0112.mediawiki
+++ b/bip-0112.mediawiki
@@ -138,10 +138,10 @@ A simple output, paying to Alice might then look like:
 
     HASH160 <revokehash> EQUAL
     IF
-        <Bob key hash>
+        <Bob's pubkey>
     ELSE
         "24h" CHECKSEQUENCEVERIFY DROP
-        <Alice key hash>
+        <Alice's pubkey>
     ENDIF
     CHECKSIG
 
@@ -153,10 +153,10 @@ With CHECKLOCKTIMEVERIFY, this would look like:
 
     HASH160 <revokehash> EQUAL
     IF
-        <Bob key hash>
+        <Bob's pubkey>
     ELSE
         "2015/12/15" CHECKLOCKTIMEVERIFY DROP
-        <Alice key hash>
+        <Alice's pubkey>
     ENDIF
     CHECKSIG
 
@@ -181,13 +181,13 @@ Alice might look like the following in Alice's commitment transaction:
     IF
         "24h" CHECKSEQUENCEVERIFY
         2DROP
-        <Alice key hash>
+        <Alice's pubkey>
     ELSE
         <Commit-Revocation-Hash> EQUAL
         NOTIF
             "2015/10/20 10:33" CHECKLOCKTIMEVERIFY DROP
         ENDIF
-        <Bob key hash>
+        <Bob's pubkey>
     ENDIF
     CHECKSIG
 
@@ -196,12 +196,12 @@ and correspondingly in Bob's commitment transaction:
    HASH160 DUP <R-HASH> EQUAL
    SWAP <Commit-Revocation-Hash> EQUAL ADD
    IF
-       <Alice key hash>
+       <Alice's pubkey>
    ELSE
        "2015/10/20 10:33" CHECKLOCKTIMEVERIFY
        "24h" CHECKSEQUENCEVERIFY
        2DROP
-       <Bob key hash>
+       <Bob's pubkey>
    ENDIF
    CHECKSIG
 

--- a/bip-0114.mediawiki
+++ b/bip-0114.mediawiki
@@ -96,20 +96,20 @@ The following is the "Hashed TIme-Lock Contract" example in [[bip-0112.mediawiki
     IF
         "24h" CHECKSEQUENCEVERIFY
         2DROP
-        <Alice key hash>
+        <Alice's pubkey>
     ELSE
         <Commit-Revocation-Hash> EQUAL
         NOTIF
             "Timestamp" CHECKLOCKTIMEVERIFY DROP
         ENDIF
-        <Bob key hash>
+        <Bob's pubkey>
     ENDIF
     CHECKSIG
 
 To create a MAST Root, it is flattened to 3 mutually exclusive branches:
-    HASH160 <R-HASH> EQUALVERIFY "24h" CHECKSEQUENCEVERIFY DROP <Alice key hash> CHECKSIG
-    HASH160 <Commit-Revocation-Hash> EQUALVERIFY <Bob key hash> CHECKSIG
-    "Timestamp" CHECKLOCKTIMEVERIFY DROP <Bob key hash> CHECKSIG
+    HASH160 <R-HASH> EQUALVERIFY "24h" CHECKSEQUENCEVERIFY DROP <Alice's pubkey> CHECKSIG
+    HASH160 <Commit-Revocation-Hash> EQUALVERIFY <Bob's pubkey> CHECKSIG
+    "Timestamp" CHECKLOCKTIMEVERIFY DROP <Bob's pubkey> CHECKSIG
 
 which significantly improves readability and reduces the witness size when it is redeemed.
 


### PR DESCRIPTION
The "key hash" in these examples are followed by a CHECKSIG, so that should be "pubkey", not "key hash"