### PR TITLE
Fix Reference to Non-Existent BIPs

### DIFF
--- a/bip-0001.mediawiki
+++ b/bip-0001.mediawiki
@@ -152,7 +152,7 @@ For each new BIP that comes in an editor does the following:
 
 * Read the BIP to check if it is ready: sound and complete. The ideas must make technical sense, even if they don't seem likely to be accepted.
 * The title should accurately describe the content.
-* Edit the BIP for language (spelling, grammar, sentence structure, etc.), markup (for reST BIPs), code style.
+* Edit the BIP for language (spelling, grammar, sentence structure, etc.) and markup (for reST BIPs).
 
 If the BIP isn't ready, the editor will send it back to the author for revision, with specific instructions.
 

--- a/bip-0001.mediawiki
+++ b/bip-0001.mediawiki
@@ -152,7 +152,7 @@ For each new BIP that comes in an editor does the following:
 
 * Read the BIP to check if it is ready: sound and complete. The ideas must make technical sense, even if they don't seem likely to be accepted.
 * The title should accurately describe the content.
-* Edit the BIP for language (spelling, grammar, sentence structure, etc.), markup (for reST BIPs), code style (examples should match BIP 8 & 7).
+* Edit the BIP for language (spelling, grammar, sentence structure, etc.), markup (for reST BIPs), code style.
 
 If the BIP isn't ready, the editor will send it back to the author for revision, with specific instructions.
 


### PR DESCRIPTION
This document was derived from PEP-0001. This line makes reference to BIPs 8 and 7, which don't exist. These are leftover refrences to Python PEPs which establish guidelines for code styles.
