### PR TITLE
bip141: clarify that marker is 1 byte

### DIFF
--- a/bip-0141.mediawiki
+++ b/bip-0141.mediawiki
@@ -48,7 +48,7 @@ A new <code>wtxid</code> is defined: the double SHA256 of the new serialization 
   
 Format of <code>nVersion</code>, <code>txins</code>, <code>txouts</code>, and <code>nLockTime</code> are same as traditional serialization.
 
-The <code>marker</code> MUST be <code>0x00</code>.
+The <code>marker</code> MUST be a 1-byte zero value: <code>0x00</code>.
 
 The <code>flag</code> MUST be a 1-byte non-zero value. Currently, <code>0x01</code> MUST be used.
 


### PR DESCRIPTION
Might seem superfluous,  but I would find the clarification meaningful,  even if the given literal is inherently 1 byte.