### PR TITLE
BIP 39: remove "public beta" from blockchain.info link

### DIFF
--- a/bip-0039.mediawiki
+++ b/bip-0039.mediawiki
@@ -145,4 +145,4 @@ Haskell:
 
 JavaScript:
 * https://github.com/bitpay/bitcore-mnemonic
-* https://github.com/bitcoinjs/bip39 (used by [[https://github.com/blockchain/My-Wallet-V3/blob/v3.8.0/src/hd-wallet.js#L121-L146|blockchain.info public beta]])
+* https://github.com/bitcoinjs/bip39 (used by [[https://github.com/blockchain/My-Wallet-V3/blob/v3.8.0/src/hd-wallet.js#L121-L146|blockchain.info]])


### PR DESCRIPTION
This is now in the default wallet.