### PR TITLE
BIP151: Clarifications on sequence numbers.

### DIFF
--- a/bip-0151.mediawiki
+++ b/bip-0151.mediawiki
@@ -123,8 +123,6 @@ After a successful <code>encinit</code>/<code>encack</code> interaction from bot
 
 Encrypted messages do not have the 4byte network magic.
 
-The ciphertext payload length must be included in the AEAD MAC as AAD.
-
 The maximum message length needs to be chosen carefully. The 4 byte length field can lead to a required message buffer of 4 GiB.
 Processing the message before the authentication succeeds must not be done.
 

--- a/bip-0151.mediawiki
+++ b/bip-0151.mediawiki
@@ -123,12 +123,14 @@ After a successful <code>encinit</code>/<code>encack</code> interaction from bot
 
 Encrypted messages do not have the 4byte network magic.
 
+The ciphertext payload length must be included in the AEAD MAC as AAD.
+
 The maximum message length needs to be chosen carefully. The 4 byte length field can lead to a required message buffer of 4 GiB.
 Processing the message before the authentication succeeds must not be done.
 
 The 4byte sha256 checksum is no longer required because the AEAD.
 
-Both peers need to track the message number (int64) of sent messages to the remote peer for building a symmetric cipher IV. Padding might be required (96bit IVs).
+Both peers need to track the message sequence number (uint32) of sent messages to the remote peer for building a 64 bit symmetric cipher IV. Sequence numbers are allowed to overflow to zero after 4294967295 (2^32-1).
 
 The encrypted payload will result decrypted in one or many unencrypted messages:
 
@@ -156,7 +158,7 @@ The Re-Keying must be done after every 1GB of data sent or received (recommended
 
 === Risks ===
 
-The encryption does not include an identity authentication scheme. This BIP does not cover a proposal to avoid MITM attacks during the encryption initialization. 
+The encryption does not include an identity authentication scheme. This BIP does not cover a proposal to avoid MITM attacks during the encryption initialization.
 
 Identity authentication will be covered in another BIP and will presume communication encryption after this BIP.
 


### PR DESCRIPTION
~~This clarifies that the ciphertext payload length is meant to update the AEAD as AAD. OpenSSH does this, but in a naive way, [as seen here][1] (aadlen is 4 -- poly1305_auth is called on both size and payload).~~

~~Although the payload length _is_ AAD, OpenSSH violates [both][2] [RFCs][3] by not including the AAD length (or the ciphertext length) in the MAC before finalization. This change to the bip includes the size explicitly as AAD.~~

Update: Nevermind the above change. I confused myself by reading the openssh code too much (AAD not necessary due to bip151's encrypted size).

This change also explicitly mentions sequence numbers are meant to be uint32's which are allowed to overflow. This is in keeping with [openssh behavior][4]. I don't think having a 64bit sequence provides any benefit over a 32bit one for bip151's use case: we're guaranteed to have rekeyed by the time the seq number reaches uint32_max, so there's no danger in reusing a previous IV/sequence earlier.

Along with the sequence size, this PR shrinks IV size to 64 bits [a la openssh][5] (we weren't using all 96 bits even with 64bit sequences). This allows for a 64 bit chacha counter.

cc @jonasschnelli 

[1]: https://github.com/openssh/openssh-portable/blob/60c2c4ea5e1ad0ddfe8b2877b78ed5143be79c53/cipher-chachapoly.c#L93
[2]: https://tools.ietf.org/html/rfc7539#section-2.8.1
[3]: https://tools.ietf.org/html/draft-agl-tls-chacha20poly1305-03#section-5
[4]: https://github.com/openssh/openssh-portable/blob/286f5a77c3bfec1e8892ca268087ac885ac871bf/packet.c#L1315
[5]: https://github.com/openssh/openssh-portable/blob/master/chacha.c#L81