### PR TITLE
Adding ruby implementation to Other implementation

### DIFF
--- a/bip-0039.mediawiki
+++ b/bip-0039.mediawiki
@@ -146,3 +146,6 @@ Haskell:
 JavaScript:
 * https://github.com/bitpay/bitcore-mnemonic
 * https://github.com/bitcoinjs/bip39 (used by [[https://github.com/blockchain/My-Wallet-V3/blob/v3.8.0/src/hd-wallet.js#L121-L146|blockchain.info]])
+
+Ruby:
+* https://github.com/sreekanthgs/bip_mnemonic


### PR DESCRIPTION
BipMnemonic is a ruby gem to generate BIP-39 compliant Mnemonic Words from specific entropy or random entropy of `n` bits and also to generate the BIP-32 seed from the BIP-39 Mnemonic.

It also lets you convert the Mnemonic back to the entropy.