### PR TITLE
Clarify BIP66 examples

### DIFF
--- a/bip-0066.mediawiki
+++ b/bip-0066.mediawiki
@@ -102,19 +102,19 @@ bool static IsValidSignatureEncoding(const std::vector<unsigned char> &sig) {
 
 Notation: P1 and P2 are valid, serialized, public keys. S1 and S2 are valid signatures using respective keys P1 and P2. S1' and S2' are non-DER but otherwise valid signatures using those same keys. F is any invalid but DER-compliant signature (including 0, the empty string). F' is any invalid and non-DER-compliant signature.
 
-# <code>S1' P1 CHECKSIG</code> fails (<b>changed</b>)
-# <code>S1' P1 CHECKSIG NOT</code> fails (unchanged)
-# <code>F P1 CHECKSIG</code> fails (unchanged)
-# <code>F P1 CHECKSIG NOT</code> can succeed (unchanged)
-# <code>F' P1 CHECKSIG</code> fails (unchanged)
-# <code>F' P1 CHECKSIG NOT</code> fails (<b>changed</b>)
+# <code>S1' P1 CHECKSIG</code> fails immediately (<b>changed</b> from returning true)
+# <code>S1' P1 CHECKSIG NOT</code> fails immediately (<b>changed</b> from returning false)
+# <code>F P1 CHECKSIG</code> returns false (unchanged)
+# <code>F P1 CHECKSIG NOT</code> returns true (unchanged)
+# <code>F' P1 CHECKSIG</code> fails immediately (<b>changed</b> from returning false)
+# <code>F' P1 CHECKSIG NOT</code> fails immediately (<b>changed</b> from returning true)
 
-# <code>0 S1' S2 2 P1 P2 2 CHECKMULTISIG</code> fails (<b>changed</b>)
-# <code>0 S1' S2 2 P1 P2 2 CHECKMULTISIG NOT</code> fails (unchanged)
-# <code>0 F S2' 2 P1 P2 2 CHECKMULTISIG</code> fails (unchanged)
-# <code>0 F S2' 2 P1 P2 2 CHECKMULTISIG NOT</code> fails (<b>changed</b>)
-# <code>0 S1' F 2 P1 P2 2 CHECKMULTISIG</code> fails (unchanged)
-# <code>0 S1' F 2 P1 P2 2 CHECKMULTISIG NOT</code> can succeed (unchanged)
+# <code>0 S1' S2 2 P1 P2 2 CHECKMULTISIG</code> fails immediately (<b>changed</b> from returning true)
+# <code>0 S1' S2 2 P1 P2 2 CHECKMULTISIG NOT</code> fails immediately (<b>changed</b> from returning false)
+# <code>0 F S2' 2 P1 P2 2 CHECKMULTISIG</code> fails immediately (<b>changed</b> from returning false)
+# <code>0 F S2' 2 P1 P2 2 CHECKMULTISIG NOT</code> fails immediately (<b>changed</b> from returning true)
+# <code>0 S1' F 2 P1 P2 2 CHECKMULTISIG</code> returns false (unchanged)
+# <code>0 S1' F 2 P1 P2 2 CHECKMULTISIG NOT</code> returns true (unchanged)
 
 Note that the examples above show that only additional failures are required by this change, as required for a soft forking change.
 


### PR DESCRIPTION
"returning false" and "fails" are different. In the former case, the script evaluation will continue and the overall result could be a true value.
