### PR TITLE
Remove filterclear

### DIFF
--- a/bip-0111.mediawiki
+++ b/bip-0111.mediawiki
@@ -48,11 +48,11 @@ NODE_BLOOM is distinct from NODE_NETWORK, and it is legal to advertise
 NODE_BLOOM but not NODE_NETWORK (though there is little reason to do
 so now, some proposals may make this more useful in the future)
 
-If a node does not support bloom filters but receives a "filterload",
-"filteradd", or "filterclear" message from a peer the node should
-disconnect that peer immediately. For backwards compatibility, in
-initial implementations, nodes may choose to only disconnect nodes which
-have the new protocol version set and attempt to send a filter command.
+If a node does not support bloom filters but receives a "filterload" or
+"filteradd" message from a peer the node should disconnect that peer
+immediately. For backwards compatibility, in initial implementations,
+nodes may choose to only disconnect nodes which have the new protocol
+version set and attempt to send a filter command.
 
 While outside the scope of this BIP it is suggested that DNS seeds and
 other peer discovery mechanisms support the ability to specify the


### PR DESCRIPTION
This message (filterclear) isn't included in the reasons for moving bloom services into a opt-out service.

Also, filterclear is a useful way for nodes to start with TX relay off and to request TX relay later. (e.g. during IBD).

Discussed in https://github.com/bitcoin/bitcoin/pull/8709
