### PR TITLE
Update BIP 141 to include definition of Virtual transaction size and Transaction weight

### DIFF
--- a/bip-0141.mediawiki
+++ b/bip-0141.mediawiki
@@ -125,6 +125,20 @@ The sigop limit is likewise quadrupled to ≤ 80,000.
 
 Each P2WPKH input is counted as 1 sigop. In addition, opcodes within a P2WSH <code>witnessScript</code> are counted identically as previously within the P2SH <code>redeemScript</code>. That is, CHECKSIG is counted as only 1 sigop, and CHECKMULTISIG is counted as 1 to 20 sigops according to the arguments. This rule applies to both native witness program and P2SH witness program.
 
+=== Additional definitions ===
+
+The following definitions are not used for consensus limits, but are suggested to provide language consistent with the terminology introduced above.
+
+==== Transaction size calculations ====
+
+''Transaction weight'' is defined as ''Base transaction size'' * 3 + ''Total transaction size'' (ie. the same method as calculating ''Block weight'' from ''Base size'' and ''Total size'').
+
+''Virtual transaction size'' is defined as ''Transaction weight'' / 4 (rounded up to nearest integer).
+
+''Base transaction size'' is the transaction size in bytes with the original transaction serialization without any witness-related data.
+
+''Total transaction size'' is the transaction size in bytes serialized as described in [[bip-0144.mediawiki|BIP144]], including base data and witness data.
+
 == Examples ==
 
 === P2WPKH ===


### PR DESCRIPTION
Virtual transaction size and Transaction weight are not consensus-critical, but are used in bitcoin-core IsStandard() policy, and v0.13.0+, RPCs calls return virtual transaction size instead of serialized transaction size. Although non-normative, BIP 141 should include definitions for these concepts.

https://github.com/bitcoin/bitcoin/pull/8747 is a PR to fix the RPC help text to refer to virtual transaction size instead of transaction size.