### PR TITLE
Remove OPL licensing option.

### DIFF
--- a/bip-0001.mediawiki
+++ b/bip-0001.mediawiki
@@ -67,7 +67,7 @@ Each BIP should have the following parts:
 
 * Abstract -- a short (~200 word) description of the technical issue being addressed.
 
-* Copyright/public domain -- Each BIP must either be explicitly labelled as placed in the public domain (see this BIP as an example) or licensed under the Open Publication License.
+* Copyright/public domain -- Each BIP must either be explicitly labelled as placed in the public domain (see this BIP as an example).
 
 * Specification -- The technical specification should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current Bitcoin platforms (Satoshi, BitcoinJ, bitcoin-js, libbitcoin).
 


### PR DESCRIPTION
The OPL enables the author to both prohibit modifications
 without their explicit approval, as well as enabling them
 to prohibit distribution in print form.

This is antithetical to the goals of having transparent,
 public, collaborative, community standards for interoperability
 and I don't believe it was anyone's intention here.
