### PR TITLE
Clarify BIP 112 language and fix typo

### DIFF
--- a/bip-0112.mediawiki
+++ b/bip-0112.mediawiki
@@ -27,13 +27,12 @@ When executed, if any of the following conditions are true, the script interpret
 * the top item on the stack has the disable flag (1 << 31) unset; and
 ** the transaction version is less than 2; or
 ** the transaction input sequence number disable flag (1 << 31) is set; or
-** the relative lock-time type is not the same; or
-** the top stack item is greater than the transaction sequence (when masked according to the BIP68);
+** the transaction input relative lock-time type (1 << 22) is not the same as the top stack item lock-time type (1 << 22); or
+** the transaction input sequence masked with 0x0000ffff is lower than the top stack item masked with 0x0000ffff;
 
 Otherwise, script execution will continue as if a NOP had been executed.
 
-BIP 68 prevents a non-final transaction from being selected for inclusion in a block until the corresponding input has reached the specified age, as measured in block-height or block-time. By comparing the argument to CHECKSEQUENCEVERIFY against the nSequence field, we indirectly verify a desired minimum age of the
-the output being spent; until that relative age has been reached any script execution pathway including the CHECKSEQUENCEVERIFY will fail to validate, causing the transaction not to be selected for inclusion in a block.
+BIP 68 prevents a transaction from being selected for inclusion in a block until all of its inputs have reached their specified age, as measured in block-height or block-time. By comparing the argument to CHECKSEQUENCEVERIFY against the nSequence field, we indirectly verify a desired minimum age of the output being spent; until that relative age has been reached any script execution pathway including the CHECKSEQUENCEVERIFY will fail to validate, causing the transaction not to be selected for inclusion in a block.
 
 
 ==Motivation==


### PR DESCRIPTION
Clarifies some language (eg replaces "the relative lock-time type is not the same" with "the transaction input relative lock-time type (1 << 22) is not the same as the top stack item lock-time type (1 << 22)") and fixes a typo "the the"
