### PR TITLE
BIP1: Update copyright requirements

### DIFF
--- a/bip-0001.mediawiki
+++ b/bip-0001.mediawiki
@@ -67,8 +67,10 @@ Each BIP should have the following parts:
 
 * Abstract -- a short (~200 word) description of the technical issue being addressed.
 
-* Copyright/public domain -- Each BIP must either be explicitly labelled as placed in the public domain (see this BIP as an example).
-
+* Copyright -- Each BIP must be explicitly labeled as placed in the public domain or licensed under at least one of the following licenses:
+** BSD-2-Clause: [https://opensource.org/licenses/BSD-2-Clause OSI-approved BSD 2-clause license]
+** CC0-1.0: [https://creativecommons.org/publicdomain/zero/1.0/ Creative Commons CC0 1.0 Universal]
+** CC-BY-SA-4.0: [https://creativecommons.org/licenses/by-sa/4.0/ Creative Commons Attribution-ShareAlike 4.0 International]
 * Specification -- The technical specification should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current Bitcoin platforms (Satoshi, BitcoinJ, bitcoin-js, libbitcoin).
 
 * Motivation -- The motivation is critical for BIPs that want to change the Bitcoin protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the BIP solves. BIP submissions without sufficient motivation may be rejected outright.

--- a/bip-0001.mediawiki
+++ b/bip-0001.mediawiki
@@ -67,7 +67,7 @@ Each BIP should have the following parts:
 
 * Abstract -- a short (~200 word) description of the technical issue being addressed.
 
-* Copyright/public domain -- Each BIP must either be explicitly labelled as placed in the public domain (see this BIP as an example) or licensed under the Open Publication License.
+* Copyright/public domain -- Each BIP must either be explicitly labelled as placed in the public domain (see this BIP as an example).
 
 * Specification -- The technical specification should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current Bitcoin platforms (Satoshi, BitcoinJ, bitcoin-js, libbitcoin).
 


### PR DESCRIPTION
Please see discussion in https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2016-September/013164.html and #446:

Neither PD, nor OPL are acceptable open source "licenses". This pull changes BIP1 such that CC0 can be chosen as a legally valid alternative to PD and CC-BY-SA-4.0 as an alternative to OPL. Additionally, the BSD 2-clause license is added to the list of acceptable licenses, such that BIPs which are currently dual-licensed under OPL and BSD 2-clause can stay in the repo.
