### PR TITLE
Define the values for witness inv types

### DIFF
--- a/bip-0144.mediawiki
+++ b/bip-0144.mediawiki
@@ -113,6 +113,13 @@ MSG_WITNESS_TX getdata requests should use the non-witness serialized hash. The 
 
 MSG_WITNESS_BLOCK requests will return a block message with transactions that have a witness using witness serialization.
 
+The values for these inv types are defined as follows:
+
+    const uint32_t MSG_WITNESS_FLAG = 1 << 30;
+    MSG_WITNESS_BLOCK = MSG_BLOCK | MSG_WITNESS_FLAG
+    MSG_WITNESS_TX = MSG_TX | MSG_WITNESS_FLAG
+
+
 == Credits ==
 Special thanks to Gregory Maxwell for originating many of the ideas in this BIP and Luke-Jr for figuring out how to deploy this as a soft fork.
 


### PR DESCRIPTION
Actually give the values for the witness inv types so people don't have to dig them out of protocol.h.