### PR TITLE
BIP2: Remove Superseded from choices for Status

### DIFF
--- a/bip-0002.mediawiki
+++ b/bip-0002.mediawiki
@@ -126,7 +126,7 @@ Each BIP must begin with an RFC 822 style header preamble. The headers must appe
 * Comments-Summary: <summary tone>
   Comments-URI: <links to wiki page for comments>
   Status: <Draft | Active | Proposed | Deferred | Rejected |
-           Withdrawn | Final | Superseded>
+           Withdrawn | Final | Replaced>
   Type: <Standards Track | Informational | Process>
   Created: <date created on, in ISO 8601 (yyyy-mm-dd) format>
   License: <abbreviation for approved license(s)>


### PR DESCRIPTION
The section about the BIP status field only defines
"Replaced or Obsolete (which is equivalent to Replaced)",
so remove "Superseded" for clarity.