### PR TITLE
[WIP] clarify BIP152 sendcmpct message exchange

### DIFF
--- a/bip-0152.mediawiki
+++ b/bip-0152.mediawiki
@@ -105,12 +105,12 @@ A new inv type (MSG_CMPCT_BLOCK == 4) and several new protocol messages are adde
 ====sendcmpct====
 # The sendcmpct message is defined as a message containing a 1-byte integer followed by a 8-byte integer where pchCommand == "sendcmpct".
 # The first integer SHALL be interpreted as a boolean (and MUST have a value of either 1 or 0)
-# The second integer SHALL be interpreted as a little-endian version number. Nodes sending a sendcmpct message MUST currently set this value to 1.
-# Upon receipt of a "sendcmpct" message with the first and second integers set to 1, the node SHOULD announce new blocks by sending a cmpctblock message.
-# Upon receipt of a "sendcmpct" message with the first integer set to 0, the node SHOULD NOT announce new blocks by sending a cmpctblock message, but SHOULD announce new blocks by sending invs or headers, as defined by BIP130.
-# Upon receipt of a "sendcmpct" message with the second integer set to something other than 1, nodes MUST treat the peer as if they had not received the message (as it indicates the peer will provide an unexpected encoding in cmpctblock, and/or other, messages). This allows future versions to send duplicate sendcmpct messages with different versions as a part of a version handshake for future versions.
+# The second integer SHALL be interpreted as a little-endian version number. Nodes sending a sendcmpct message MUST currently set this value to 1. Upon receipt of a "sendcmpct" message with the second integer set to something other than 1, nodes MUST treat the peer as if they had not received the message (as it indicates the peer will provide an unexpected encoding in cmpctblock, and/or other, messages). This allows future versions to send duplicate sendcmpct messages with different versions as a part of a version handshake for future versions.
+# Upon receipt of a "sendcmpct" message with the first integer set to 1, if the node wishes to use high-bandwidth compact block mode, it MUST respond with a "sendcmpct" message with the first integer set to 1. Upon receipt of a "sendcmpct" message with the first integer set to 0, if the node wishes to use low-bandwidth compact block mode, it MUST respond with a "sendcmpct" message with the first integer set to 0.
+# If the node has sent *and* received "sendcmpct" with the first integer set to 1, the node SHOULD announce new blocks by sending a cmpctblock message.
+# If the node has sent *and* received "sendcmpct" with the first integer set to 0, the node SHOULD NOT announce new blocks by sending a cmpctblock message, but SHOULD announce new blocks by sending invs or headers, as defined by BIP130.
 # Nodes SHOULD check for a protocol version of >= 70014 before sending sendcmpct messages.
-# Nodes MUST NOT send a request for a MSG_CMPCT_BLOCK object to a peer before having received a sendcmpct message from that peer.
+# Nodes MUST NOT send a request for a MSG_CMPCT_BLOCK object to a peer before having sent and received a "sendcmpct" message with that peer.
 
 ====MSG_CMPCT_BLOCK====
 # getdata messages may now contain requests for MSG_CMPCT_BLOCK objects.


### PR DESCRIPTION
@TheBlueMatt - as discussed, this PR slightly clarifies the BIP 152 text:
- version must always be set to 1 (whether mode is set to 0 or 1)
- sendcmpct is reciprocal
