### PR TITLE
BIP49 - fix wrong cointype for test vectors - use m/49'/1'/0' for testnet

### DIFF
--- a/bip-0049.mediawiki
+++ b/bip-0049.mediawiki
@@ -73,21 +73,21 @@ This BIP is not backwards compatible by design as described under [#consideratio
   masterseedWords = abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about
   masterseed = tprv8ZgxMBicQKsPe5YMU9gHen4Ez3ApihUfykaqUorj9t6FDqy3nP6eoXiAo2ssvpAjoLroQxHqr3R5nE3a5dU3DHTjTgJDd7zrbniJr6nrCzd (testnet)
 
-  // Account 0, root = m/49'/0'/0'
-  account0Xpriv = tprv8fnNnm525ViePCEx7Z9cZb6QNUtsUc8XKaePnZtPnKZWHw1rnAC9r6MdMdsmrkGW7Vy3eVtwtRqrfkxfWjnitBTNEZjTb6pbui7BUmnBBd3 (testnet)
+  // Account 0, root = m/49'/1'/0'
+  account0Xpriv = tprv8gRrNu65W2Msef2BdBSUgFdRTGzC8EwVXnV7UGS3faeXtuMVtGfEdidVeGbThs4ELEoayCAzZQ4uUji9DUiAs7erdVskqju7hrBcDvDsdbY (testnet)
 
-  // Account 0, first receiving private key = m/49'/0'/0'/0/0
-  account0recvPrivateKey = cQHH4LLDxjDqTM2rRpEi29f9a3EAQ8A7yWxiNdR8nC8WrkKU7Dms
-  account0recvPrivateKeyHex = 0x508c73a06f6b6c817238ba61be232f5080ea4616c54f94771156934666d38ee3
-  account0recvPublickKeyHex = 0x039b3b694b8fc5b5e07fb069c783cac754f5d38c3e08bed1960e31fdb1dda35c24
+  // Account 0, first receiving private key = m/49'/1'/0'/0/0
+  account0recvPrivateKey = cULrpoZGXiuC19Uhvykx7NugygA3k86b3hmdCeyvHYQZSxojGyXJ
+  account0recvPrivateKeyHex = 0xc9bdb49cfbaedca21c4b1f3a7803c34636b1d7dc55a717132443fc3f4c5867e8
+  account0recvPublickKeyHex = 0x03a1af804ac108a8a51782198c2d034b28bf90c8803f5a53f76276fa69a4eae77f
 
   // Address derivation
-  keyhash = HASH160(account0recvPublickKeyHex) = 0xf990679acafe25c27615373b40bf22446d24ff44
-  scriptSig = <0 <keyhash>> = 0x0014f990679acafe25c27615373b40bf22446d24ff44
-  addressBytes = HASH160(scriptSig) = 0x3fb6e95812e57bb4691f9a4a628862a61a4f769b
+  keyhash = HASH160(account0recvPublickKeyHex) = 0x38971f73930f6c141d977ac4fd4a727c854935b3
+  scriptSig = <0 <keyhash>> = 0x001438971f73930f6c141d977ac4fd4a727c854935b3
+  addressBytes = HASH160(scriptSig) = 0x336caa13e08b96080a32b5d818d59b4ab3b36742
 
   // addressBytes base58check encoded for testnet
-  address = base58check(prefix | addressBytes) = 2My47gHNc8nhX5kBWqXHU4f8uuQvQKEgwMd (testnet)
+  address = base58check(prefix | addressBytes) = 2Mww8dCYPUpKHofjgcXcBCEGmniw9CoaiD2 (testnet)
 </pre>
 
 


### PR DESCRIPTION
Just noticed that I used the wrong coin-type for the derivation path (0' for prodnet instead of 1' testnet).

Fixed it and recalculated the test vectors.