### PR TITLE
BIP 123: Clarify how used with non-Standards BIPs, and update list

### DIFF
--- a/bip-0123.mediawiki
+++ b/bip-0123.mediawiki
@@ -1,6 +1,5 @@
 <pre>
   BIP: 123
-  Layer: Process
   Title: BIP Classification
   Author: Eric Lombrozo <elombrozo@gmail.com>
   Status: Draft
@@ -30,6 +29,8 @@ Standards BIPs are placed in one of four layers:
 # Peer Services
 # API/RPC
 # Applications
+
+Non-standards BIPs may be placed in these layers, or none at all.
 
 ===1. Consensus Layer===
 
@@ -76,19 +77,26 @@ The applications layer specifies high level structures, abstractions, and conven
 !Status
 |- style="background-color: #cfffcf"
 | [[bip-0001.mediawiki|1]]
-| Process
+|
 | BIP Purpose and Guidelines
 | Amir Taaki
-| Standard
+| Process
 | Active
 |-
+| [[bip-0002.mediawiki|2]]
+|
+| BIP process, revised
+| Luke Dashjr
+| Process
+| Draft
+|- style="background-color: #cfffcf"
 | [[bip-0009.mediawiki|9]]
-| Consensus (soft fork)
+|
 | Version bits with timeout and delay
 | Pieter Wuille, Peter Todd, Greg Maxwell, Rusty Russell
 | Informational
-| Draft
-|- 
+| Final
+|- style="background-color: #ffcfcf"
 | [[bip-0010.mediawiki|10]]
 | Applications
 | Multi-Sig Transaction Distribution
@@ -97,11 +105,11 @@ The applications layer specifies high level structures, abstractions, and conven
 | Withdrawn
 |- style="background-color: #cfffcf"
 | [[bip-0011.mediawiki|11]]
-| Peer Services
+| Applications
 | M-of-N Standard Transactions
 | Gavin Andresen
 | Standard
-| Accepted
+| Final
 |- style="background-color: #ffcfcf"
 | [[bip-0012.mediawiki|12]]
 | Consensus (soft fork)
@@ -122,8 +130,8 @@ The applications layer specifies high level structures, abstractions, and conven
 | Protocol Version and User Agent
 | Amir Taaki, Patrick Strateman
 | Standard
-| Accepted
-|- style="background-color: #ffcfcf"
+| Final
+|-
 | [[bip-0015.mediawiki|15]]
 | Applications
 | Aliases
@@ -133,7 +141,7 @@ The applications layer specifies high level structures, abstractions, and conven
 |- style="background-color: #cfffcf"
 | [[bip-0016.mediawiki|16]]
 | Consensus (soft fork)
-| Pay To Script Hash
+| Pay to Script Hash
 | Gavin Andresen
 | Standard
 | Final
@@ -142,18 +150,18 @@ The applications layer specifies high level structures, abstractions, and conven
 | Consensus (soft fork)
 | OP_CHECKHASHVERIFY (CHV)
 | Luke Dashjr
+| Standard
 | Withdrawn
-| Draft
-|-
+|- style="background-color: #ffffcf"
 | [[bip-0018.mediawiki|18]]
 | Consensus (soft fork)
 | hashScriptCheck
 | Luke Dashjr
 | Standard
-| Draft
+| Accepted
 |-
 | [[bip-0019.mediawiki|19]]
-| Peer Services
+| Applications
 | M-of-N Standard Transactions (Low SigOp)
 | Luke Dashjr
 | Standard
@@ -171,21 +179,21 @@ The applications layer specifies high level structures, abstractions, and conven
 | URI Scheme
 | Nils Schneider, Matt Corallo
 | Standard
-| Accepted
+| Final
 |- style="background-color: #cfffcf"
 | [[bip-0022.mediawiki|22]]
 | API/RPC
 | getblocktemplate - Fundamentals
 | Luke Dashjr
 | Standard
-| Accepted
+| Final
 |- style="background-color: #cfffcf"
 | [[bip-0023.mediawiki|23]]
 | API/RPC
 | getblocktemplate - Pooled Mining
 | Luke Dashjr
 | Standard
-| Accepted
+| Final
 |- style="background-color: #cfffcf"
 | [[bip-0030.mediawiki|30]]
 | Consensus (soft fork)
@@ -199,17 +207,17 @@ The applications layer specifies high level structures, abstractions, and conven
 | Pong message
 | Mike Hearn
 | Standard
-| Accepted
+| Final
 |- style="background-color: #cfffcf"
 | [[bip-0032.mediawiki|32]]
 | Applications
 | Hierarchical Deterministic Wallets
 | Pieter Wuille
 | Informational
-| Accepted
+| Final
 |-
 | [[bip-0033.mediawiki|33]]
-| API/RPC
+| Peer Services
 | Stratized Nodes
 | Amir Taaki
 | Standard
@@ -217,17 +225,17 @@ The applications layer specifies high level structures, abstractions, and conven
 |- style="background-color: #cfffcf"
 | [[bip-0034.mediawiki|34]]
 | Consensus (soft fork)
-| Block v2, Height in coinbase
+| Block v2, Height in Coinbase
 | Gavin Andresen
 | Standard
-| Accepted
+| Final
 |- style="background-color: #cfffcf"
 | [[bip-0035.mediawiki|35]]
 | Peer Services
 | mempool message
 | Jeff Garzik
 | Standard
-| Accepted
+| Final
 |-
 | [[bip-0036.mediawiki|36]]
 | Peer Services
@@ -238,38 +246,24 @@ The applications layer specifies high level structures, abstractions, and conven
 |- style="background-color: #cfffcf"
 | [[bip-0037.mediawiki|37]]
 | Peer Services
-| Bloom filtering
-| Mike Hearn and Matt Corallo
+| Connection Bloom filtering
+| Mike Hearn, Matt Corallo
 | Standard
-| Accepted
+| Final
 |-
 | [[bip-0038.mediawiki|38]]
 | Applications
 | Passphrase-protected private key
-| Mike Caldwell
+| Mike Caldwell, Aaron Voisine
 | Standard
 | Draft
-|-
+|- style="background-color: #ffffcf"
 | [[bip-0039.mediawiki|39]]
 | Applications
 | Mnemonic code for generating deterministic keys
-| Slush
+| Marek Palatinus, Pavol Rusnak, Aaron Voisine, Sean Bowe
 | Standard
-| Draft
-|-
-| 40
-| Applications
-| Stratum wire protocol
-| Slush
-| Standard
-| BIP number allocated
-|-
-| 41
-| Applications
-| Stratum mining protocol
-| Slush
-| Standard
-| BIP number allocated
+| Accepted
 |-
 | [[bip-0042.mediawiki|42]]
 | Consensus (soft fork)
@@ -281,31 +275,44 @@ The applications layer specifies high level structures, abstractions, and conven
 | [[bip-0043.mediawiki|43]]
 | Applications
 | Purpose Field for Deterministic Wallets
-| Slush
-| Standard
+| Marek Palatinus, Pavol Rusnak
+| Informational
 | Draft
-|-
+|- style="background-color: #ffffcf"
 | [[bip-0044.mediawiki|44]]
 | Applications
 | Multi-Account Hierarchy for Deterministic Wallets
-| Slush
+| Marek Palatinus, Pavol Rusnak
 | Standard
-| Draft
-|-
+| Accepted
+|- style="background-color: #ffffcf"
 | [[bip-0045.mediawiki|45]]
 | Applications
 | Structure for Deterministic P2SH Multisignature Wallets
-| Manuel Araoz
+| Manuel Araoz, Ryan X. Charles, Matias Alejo Garcia
 | Standard
+| Accepted
+|-
+| [[bip-0047.mediawiki|47]]
+| Applications
+| Reusable Payment Codes for Hierarchical Deterministic Wallets
+| Justus Ranvier
+| Informational
 | Draft
 |-
-| [[bip-0050.mediawiki|50]]
+| [[bip-0049.mediawiki|49]]
+| Applications
+| Derivation scheme for P2WPKH-nested-in-P2SH based accounts
+| Daniel Weigl
 | Informational
+| Draft
+|- style="background-color: #cfffcf"
+| [[bip-0050.mediawiki|50]]
+|
 | March 2013 Chain Fork Post-Mortem
 | Gavin Andresen
 | Informational
-| Draft
-<!-- 50 series reserved for a group of post-mortems -->
+| Final
 |-
 | [[bip-0060.mediawiki|60]]
 | Peer Services
@@ -313,97 +320,118 @@ The applications layer specifies high level structures, abstractions, and conven
 | Amir Taaki
 | Standard
 | Draft
-|-
+|- style="background-color: #cfffcf"
 | [[bip-0061.mediawiki|61]]
 | Peer Services
-| "reject" P2P message
+| Reject P2P message
 | Gavin Andresen
 | Standard
 | Final
-|-
+|- style="background-color: #ffcfcf"
 | [[bip-0062.mediawiki|62]]
 | Consensus (soft fork)
 | Dealing with malleability
 | Pieter Wuille
 | Standard
-| Draft
-|-
-| 63
-| Applications
-| Stealth Addresses
-| Peter Todd
-| Standard
-| BIP number allocated
+| Withdrawn
 |-
 | [[bip-0064.mediawiki|64]]
 | Peer Services
-| getutxos message
+| getutxo message
 | Mike Hearn
 | Standard
 | Draft
-|-
+|- style="background-color: #cfffcf"
 | [[bip-0065.mediawiki|65]]
 | Consensus (soft fork)
 | OP_CHECKLOCKTIMEVERIFY
 | Peter Todd
 | Standard
-| Draft
-|-
+| Final
+|- style="background-color: #cfffcf"
 | [[bip-0066.mediawiki|66]]
 | Consensus (soft fork)
 | Strict DER signatures
 | Pieter Wuille
 | Standard
-| Draft
-|-
+| Final
+|- style="background-color: #ffffcf"
 | [[bip-0067.mediawiki|67]]
 | Applications
-| Deterministic P2SH multi-signature addresses
-| Thomas Kerin
+| Deterministic Pay-to-script-hash multi-signature addresses through public key sorting
+| Thomas Kerin, Jean-Pierre Rupp, Ruben de Vries
 | Standard
-| Draft
-|-
+| Accepted
+|- style="background-color: #cfffcf"
 | [[bip-0068.mediawiki|68]]
 | Consensus (soft fork)
-| Consensus-enforced transaction replacement signalled via sequence numbers
-| Mark Friedenbach
+| Relative lock-time using consensus-enforced sequence numbers
+| Mark Friedenbach, BtcDrak, Nicolas Dorier, kinoshitajona
+| Standard
+| Final
+|- style="background-color: #ffffcf"
+| [[bip-0069.mediawiki|69]]
+| Applications
+| Lexicographical Indexing of Transaction Inputs and Outputs
+| Kristov Atlas
+| Informational
+| Accepted
+|- style="background-color: #cfffcf"
+| [[bip-0070.mediawiki|70]]
+| Applications
+| Payment Protocol
+| Gavin Andresen, Mike Hearn
+| Standard
+| Final
+|- style="background-color: #cfffcf"
+| [[bip-0071.mediawiki|71]]
+| Applications
+| Payment Protocol MIME types
+| Gavin Andresen
+| Standard
+| Final
+|- style="background-color: #cfffcf"
+| [[bip-0072.mediawiki|72]]
+| Applications
+| bitcoin: uri extensions for Payment Protocol
+| Gavin Andresen
+| Standard
+| Final
+|- style="background-color: #cfffcf"
+| [[bip-0073.mediawiki|73]]
+| Applications
+| Use "Accept" header for response type negotiation with Payment Request URLs
+| Stephen Pair
+| Standard
+| Final
+|-
+| [[bip-0074.mediawiki|74]]
+| Applications
+| Allow zero value OP_RETURN in Payment Protocol
+| Toby Padilla
 | Standard
 | Draft
 |-
-| [[bip-0070.mediawiki|70]]
+| [[bip-0075.mediawiki|75]]
 | Applications
-| Payment protocol
-| Gavin Andresen
-| Standard
-| Final
-|-
-| [[bip-0071.mediawiki|71]]
-| Applications
-| Payment protocol MIME types
-| Gavin Andresen
-| Standard
-| Final
-|-
-| [[bip-0072.mediawiki|72]]
-| Applications
-| Payment protocol URIs
-| Gavin Andresen
-| Standard
-| Final
-|-
-| [[bip-0073.mediawiki|73]]
-| Applications
-| Use "Accept" header with Payment Request URLs
-| Stephen Pair
+| Out of Band Address Exchange using Payment Protocol Encryption
+| Justin Newton, Matt David, Aaron Voisine, James MacWhyte
 | Standard
 | Draft
 |-
 | [[bip-0080.mediawiki|80]]
-| Applications
+|
 | Hierarchy for Non-Colored Voting Pool Deterministic Multisig Wallets
-| Monetas
+| Justus Ranvier, Jimmy Song
 | Informational
-| Draft
+| Deferred
+|-
+| [[bip-0081.mediawiki|81]]
+|
+| Hierarchy for Colored Voting Pool Deterministic Multisig Wallets
+| Justus Ranvier, Jimmy Song
+| Informational
+| Deferred
 |-
 | [[bip-0083.mediawiki|83]]
 | Applications
@@ -413,18 +441,18 @@ The applications layer specifies high level structures, abstractions, and conven
 | Draft
 |-
 | [[bip-0099.mediawiki|99]]
-| Informational
+|
 | Motivation and deployment of consensus rule changes ([soft/hard]forks)
 | Jorge Timón
-| Informational / Process
+| Informational
 | Draft
-|-
+|- style="background-color: #ffcfcf"
 | [[bip-0101.mediawiki|101]]
 | Consensus (hard fork)
 | Increase maximum block size
 | Gavin Andresen
 | Standard
-| Draft
+| Withdrawn
 |-
 | [[bip-0102.mediawiki|102]]
 | Consensus (hard fork)
@@ -442,7 +470,7 @@ The applications layer specifies high level structures, abstractions, and conven
 |-
 | [[bip-0105.mediawiki|105]]
 | Consensus (hard fork)
-| Consensus based block size retargetting algorithm
+| Consensus based block size retargeting algorithm
 | BtcDrak
 | Standard
 | Draft
@@ -461,24 +489,38 @@ The applications layer specifies high level structures, abstractions, and conven
 | Standard
 | Draft
 |-
+| [[bip-0109.mediawiki|109]]
+| Consensus (hard fork)
+| Two million byte size limit with sigop and sighash limits
+| Gavin Andresen
+| Standard
+| Draft
+|- style="background-color: #ffffcf"
 | [[bip-0111.mediawiki|111]]
 | Peer Services
 | NODE_BLOOM service bit
 | Matt Corallo, Peter Todd
 | Standard
-| Draft
-|-
+| Accepted
+|- style="background-color: #cfffcf"
 | [[bip-0112.mediawiki|112]]
 | Consensus (soft fork)
 | CHECKSEQUENCEVERIFY
 | BtcDrak, Mark Friedenbach, Eric Lombrozo
 | Standard
-| Draft
-|-
+| Final
+|- style="background-color: #cfffcf"
 | [[bip-0113.mediawiki|113]]
 | Consensus (soft fork)
-| Median time-past as endpoint for locktime calculations
+| Median time-past as endpoint for lock-time calculations
 | Thomas Kerin, Mark Friedenbach
+| Standard
+| Final
+|-
+| [[bip-0114.mediawiki|114]]
+| Consensus (soft fork)
+| Merkelized Abstract Syntax Tree
+| Johnson Lau
 | Standard
 | Draft
 |-
@@ -504,32 +546,39 @@ The applications layer specifies high level structures, abstractions, and conven
 | Draft
 |-
 | [[bip-0123.mediawiki|123]]
-| Process
+|
 | BIP Classification
 | Eric Lombrozo
-| Standard
+| Process
 | Draft
 |-
 | [[bip-0124.mediawiki|124]]
 | Applications
 | Hierarchical Deterministic Script Templates
 | Eric Lombrozo, William Swanson
-| Standard
+| Informational
 | Draft
-|-
+|- style="background-color: #ffffcf"
 | [[bip-0125.mediawiki|125]]
-| Peer Services
+| Applications
 | Opt-in Full Replace-by-Fee Signaling
-| David Harding, Peter Todd
+| David A. Harding, Peter Todd
 | Standard
-| Draft
+| Accepted
 |-
+| [[bip-0126.mediawiki|126]]
+|
+| Best Practices for Heterogeneous Input Script Transactions
+| Kristov Atlas
+| Informational
+| Draft
+|- style="background-color: #ffffcf"
 | [[bip-0130.mediawiki|130]]
 | Peer Services
 | sendheaders message
 | Suhas Daftuar
 | Standard
-| Draft
+| Accepted
 |-
 | [[bip-0131.mediawiki|131]]
 | Consensus (hard fork)
@@ -537,12 +586,26 @@ The applications layer specifies high level structures, abstractions, and conven
 | Chris Priest
 | Standard
 | Draft
-|-
+|- style="background-color: #ffcfcf"
 | [[bip-0132.mediawiki|132]]
-| Process
+|
 | Committee-based BIP Acceptance Process
 | Andy Chase
 | Process
+| Withdrawn
+|-
+| [[bip-0133.mediawiki|133]]
+| Peer Services
+| feefilter message
+| Alex Morcos
+| Standard
+| Draft
+|-
+| [[bip-0134.mediawiki|134]]
+| Consensus (hard fork)
+| Flexible Transactions
+| Tom Zander
+| Standard
 | Draft
 |-
 | [[bip-0140.mediawiki|140]]
@@ -564,7 +627,7 @@ The applications layer specifies high level structures, abstractions, and conven
 | Address Format for Segregated Witness
 | Johnson Lau
 | Standard
-| Draft
+| Deferred
 |-
 | [[bip-0143.mediawiki|143]]
 | Consensus (soft fork)
@@ -578,6 +641,47 @@ The applications layer specifies high level structures, abstractions, and conven
 | Segregated Witness (Peer Services)
 | Eric Lombrozo, Pieter Wuille
 | Standard
-| Draft 
+| Draft
+|-
+| [[bip-0145.mediawiki|145]]
+| API/RPC
+| getblocktemplate Updates for Segregated Witness
+| Luke Dashjr
+| Standard
+| Draft
+|-
+| [[bip-0146.mediawiki|146]]
+| Consensus (soft fork)
+| Dealing with signature encoding malleability
+| Johnson Lau, Pieter Wuille
+| Standard
+| Draft
+|-
+| [[bip-0147.mediawiki|147]]
+| Consensus (soft fork)
+| Dealing with dummy stack element malleability
+| Johnson Lau
+| Standard
+| Draft
+|-
+| [[bip-0150.mediawiki|150]]
+| Peer Services
+| Peer Authentication
+| Jonas Schnelli
+| Standard
+| Draft
+|-
+| [[bip-0151.mediawiki|151]]
+| Peer Services
+| Peer-to-Peer Communication Encryption
+| Jonas Schnelli
+| Standard
+| Draft
+|-
+| [[bip-0152.mediawiki|152]]
+| Peer Services
+| Compact Block Relay
+| Matt Corallo
+| Standard
+| Draft
 |}
-

--- a/scripts/buildtable.pl
+++ b/scripts/buildtable.pl
@@ -31,9 +31,6 @@ my %MiscField = (
 	'Resolution' => undef,
 );
 
-my %ValidLayer = (
-	Process => undef,
-);
 my %ValidStatus = (
 	Draft => undef,
 	Deferred => undef,
@@ -106,8 +103,6 @@ while (++$bipnum <= $topbip) {
 			} else {
 				$type = $val;
 			}
-		} elsif ($field eq 'Layer') {  # BIP 123
-			die "Invalid layer $val in $fn" unless exists $ValidLayer{$val};
 		} elsif (exists $DateField{$field}) {
 			die "Invalid date format in $fn" unless $val =~ /^20\d{2}\-(?:0\d|1[012])\-(?:[012]\d|30|31)$/;
 		} elsif (exists $EmailField{$field}) {


### PR DESCRIPTION
Also: It's unclear where to draw the lines for API/RPC. The previous draft had Stratum (which is being removed here since there sadly isn't a BIP yet) as Applications and GBT as API/RPC, when both protocols serve the same fundamental purpose.

Need to get this cleaned up to move forward on both it as well as BIP 2...

@CodeShark 