### PR TITLE
Clarify SPV node usage of BIP 152

### DIFF
--- a/bip-0152.mediawiki
+++ b/bip-0152.mediawiki
@@ -185,6 +185,8 @@ Compact blocks version 2 is almost identical to version 1, but supports segregat
 
 # As high-bandwidth mode permits relaying of CMPCTBLOCK messages prior to full validation (requiring only that the block header is valid before relay), nodes SHOULD NOT ban a peer for announcing a new block with a CMPCTBLOCK message that is invalid, but has a valid header.  For avoidance of doubt, nodes SHOULD bump their peer-to-peer protocol version to 70015 or higher to signal that they will not ban or punish a peer for announcing compact blocks prior to full validation, and nodes SHOULD NOT announce a CMPCTBLOCK to a peer with a version number below 70015 before fully validating the block.
 
+# SPV nodes which implement this spec must consider the implications of accepting blocks which were not validated by the node which provided them. Especially SPV nodes which allow users to select a "trusted full node" to sync from may wish to avoid implementing this spec in high-bandwidth mode.
+
 ==Justification==
 
 ====Protocol design====


### PR DESCRIPTION
This does not change any implementation details of the protocol, only encourages SPV client authors to avoid high-bandwidth mode due to lack of validation.