### PR TITLE
Specify which 1 byte push op codes are valid

### DIFF
--- a/bip-0141.mediawiki
+++ b/bip-0141.mediawiki
@@ -83,7 +83,7 @@ If all transactions in a block do not have witness data, the commitment is optio
 
 === Witness program ===
 
-A <code>scriptPubKey</code> (or <code>redeemScript</code> as defined in BIP16/P2SH) that consists of a 1-byte push opcode (for 0 to 16) followed by a data push between 2 and 40 bytes gets a new special meaning. The value of the first push is called the "version byte". The following byte vector pushed is called the "witness program".
+A <code>scriptPubKey</code> (or <code>redeemScript</code> as defined in BIP16/P2SH) that consists of a valid 1-byte push opcode (<code>OP_0,OP_1,OP_2...,OP_16</code>) followed by a data push between 2 and 40 bytes gets a new special meaning. The value of the first push is called the "version byte". The following byte vector pushed is called the "witness program".
 
 There are two cases in which witness validation logic are triggered. Each case determines the location of the witness version byte and program, as well as the form of the scriptSig:
 # Triggered by a <code>scriptPubKey</code> that is exactly a push of a version byte, plus a push of a witness program. The scriptSig must be exactly empty or validation fails. (''"native witness program"'')

--- a/bip-0141.mediawiki
+++ b/bip-0141.mediawiki
@@ -83,7 +83,7 @@ If all transactions in a block do not have witness data, the commitment is optio
 
 === Witness program ===
 
-A <code>scriptPubKey</code> (or <code>redeemScript</code> as defined in BIP16/P2SH) that consists of a valid 1-byte push opcode (<code>OP_0,OP_1,OP_2...,OP_16</code>) followed by a data push between 2 and 40 bytes gets a new special meaning. The value of the first push is called the "version byte". The following byte vector pushed is called the "witness program".
+A <code>scriptPubKey</code> (or <code>redeemScript</code> as defined in BIP16/P2SH) that consists of a select subset of opcodes (<code>OP_0,OP_1,OP_2,...,OP_16</code>) followed by a data push between 2 and 40 bytes gets a new special meaning. The value of the first push is called the "version byte". The following byte vector pushed is called the "witness program".
 
 There are two cases in which witness validation logic are triggered. Each case determines the location of the witness version byte and program, as well as the form of the scriptSig:
 # Triggered by a <code>scriptPubKey</code> that is exactly a push of a version byte, plus a push of a witness program. The scriptSig must be exactly empty or validation fails. (''"native witness program"'')


### PR DESCRIPTION
This adds documentation to BIP141 about which 1 byte push op codes are valid for segwit. This is needed because `OP_1NEGATE` is a 1 byte push op code, but is NOT a valid 1 byte push op code for segwit. See the implementation here for why `OP_1NEGATE` is not valid: https://github.com/bitcoin/bitcoin/blob/14d01309bed59afb08651f2b701ff90371b15b20/src/script/script.cpp#L228