### PR TITLE
Slight clarification for replacement implementation

### DIFF
--- a/bip-0125.mediawiki
+++ b/bip-0125.mediawiki
@@ -51,11 +51,11 @@ transaction) that spends one or more of the same inputs if,
 
 # The original transactions signal replaceability explicitly or through inheritance as described in the above Summary section.
 
-# The replacement transaction pays an absolute higher fee than the sum paid by the original transactions.
-
 # The replacement transaction does not contain any new unconfirmed inputs that did not previously appear in the mempool. (Unconfirmed inputs are inputs spending outputs from currently unconfirmed transactions.)
 
-# The replacement transaction must pay for its own bandwidth in addition to the amount paid by the original transactions at or above the rate set by the node's minimum relay fee setting.  For example, if the minimum relay fee is 1 satoshi/byte and the replacement transaction is 500 bytes total, then the replacement must pay a fee at least 500 satoshis higher than the sum of the originals.
+# The replacement transaction pays an absolute fee of at least the sum paid by the original transactions.
+
+# The replacement transaction must also pay for its own bandwidth at or above the rate set by the node's minimum relay fee setting.  For example, if the minimum relay fee is 1 satoshi/byte and the replacement transaction is 500 bytes total, then the replacement must pay a fee at least 500 satoshis higher than the sum of the originals.
 
 # The number of original transactions to be replaced and their descendant transactions which will be evicted from the mempool must not exceed a total of 100 transactions.
 


### PR DESCRIPTION
Grouped the two sections explaining the fee evaluation, then removed a redundant clause in the middle of the latter paragraph that confused the meaning.

@harding @petertodd ping authors