### PR TITLE
remove duplicated paragraph

### DIFF
--- a/bip-0069.mediawiki
+++ b/bip-0069.mediawiki
@@ -30,11 +30,6 @@ Since wallet clients are left to their own devices to determine this ordering, t
 For example, a wallet client might naively order inputs based on when addresses were added to a wallet by the user through importing or random generation.
 Many wallets will place spending outputs first and change outputs second, leaking information about both the sender and receiver’s finances to passive blockchain observers.
 Such information should remain private not only for the benefit of consumers, but in higher order financial systems must be kept secret to prevent fraud.
-Currently, there is no clear standard for how wallet clients ought to order transaction inputs and outputs.
-Since wallet clients are left to their own devices to determine this ordering, they often leak information about their users’ finances.
-For example, a wallet client might naively order inputs based on when addresses were added to a wallet by the user through importing or random generation.
-Many wallets will place spending outputs first and change outputs second, leaking information about both the sender and receiver’s finances to passive blockchain observers.
-Such information should remain private not only for the benefit of consumers, but in higher order financial systems must be kept secret to prevent fraud.
 A researcher recently demonstrated this principle when he detected that Bitstamp leaked information when creating exchange transactions, enabling potential espionage among traders. [1]
 
 One way to address these privacy weaknesses is by randomizing the order of inputs and outputs. [2]


### PR DESCRIPTION
The first paragraph under Motivation was duplicated. This trivial edit removes the redundant text to leave a single instance.