### PR TITLE
BIP 143: Unify coin unit

### DIFF
--- a/bip-0143.mediawiki
+++ b/bip-0143.mediawiki
@@ -551,7 +551,7 @@ These examples show that <code>FindAndDelete</code> for the signature is not app
     nLockTime: 00000000
   
   The input comes from a P2WSH witness program:
-    scriptPubKey : 00209e1be07558ea5cc8e02ed1d80c0911048afad949affa36d5c3951e3159dbea19, value: 200000
+    scriptPubKey : 00209e1be07558ea5cc8e02ed1d80c0911048afad949affa36d5c3951e3159dbea19, value: 0.00200000
     redeemScript : OP_CHECKSIGVERIFY <0x30450220487fb382c4974de3f7d834c1b617fe15860828c7f96454490edd6d891556dcc9022100baf95feb48f845d5bfc9882eb6aeefa1bc3790e39f59eaa46ff7f15ae626c53e01>
                    ad4830450220487fb382c4974de3f7d834c1b617fe15860828c7f96454490edd6d891556dcc9022100baf95feb48f845d5bfc9882eb6aeefa1bc3790e39f59eaa46ff7f15ae626c53e01
   


### PR DESCRIPTION
In the example of BIP 143, the unit of coin output only 'No FindAndDelete' is described with satoshi. so  changed it to the value of BTC unit according to other examples.

```
scriptPubKey : 00209e1be07558ea5cc8e02ed1d80c0911048afad949affa36d5c3951e3159dbea19, value: 200000
```

change to

```
scriptPubKey : 00209e1be07558ea5cc8e02ed1d80c0911048afad949affa36d5c3951e3159dbea19, value: 0.00200000
```