### PR TITLE
BIP 32: Test vectors for leading zeros

### DIFF
--- a/bip-0032.mediawiki
+++ b/bip-0032.mediawiki
@@ -262,7 +262,7 @@ Seed (hex): fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c
 
 ===Test vector 3===
 
-These vectors test for the retention of leading zeros. See [bitpay/bitcore-lib#47](https://github.com/bitpay/bitcore-lib/issues/47) and [iancoleman/bip39#58](https://github.com/iancoleman/bip39/issues/58) for more information.
+These vectors test for the retention of leading zeros. See [https://github.com/bitpay/bitcore-lib/issues/47 bitpay/bitcore-lib#47] and [https://github.com/iancoleman/bip39/issues/58 iancoleman/bip39#58] for more information.
 
 Seed (hex): 4b381541583be4423346c643850da4b320e46a87ae3d2a4e6da11eba819cd4acba45d239319ac14f863b8d5ab5a0d0c64d2e8a1e7d1457df2e5a3c51c73235be
 * Chain m

--- a/bip-0032.mediawiki
+++ b/bip-0032.mediawiki
@@ -1,4 +1,5 @@
 RECENT CHANGES:
+* (24 Feb 2017) Added test vectors for hardened derivation with leading zeros
 * (16 Apr 2013) Added private derivation for i ≥ 0x80000000 (less risk of parent private key leakage)
 * (30 Apr 2013) Switched from multiplication by I<sub>L</sub> to addition of I<sub>L</sub> (faster, easier implementation)
 * (25 May 2013) Added test vectors
@@ -258,6 +259,18 @@ Seed (hex): fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c
 * Chain m/0/2147483647<sub>H</sub>/1/2147483646<sub>H</sub>/2
 ** ext pub: xpub6FnCn6nSzZAw5Tw7cgR9bi15UV96gLZhjDstkXXxvCLsUXBGXPdSnLFbdpq8p9HmGsApME5hQTZ3emM2rnY5agb9rXpVGyy3bdW6EEgAtqt
 ** ext prv: xprvA2nrNbFZABcdryreWet9Ea4LvTJcGsqrMzxHx98MMrotbir7yrKCEXw7nadnHM8Dq38EGfSh6dqA9QWTyefMLEcBYJUuekgW4BYPJcr9E7j
+
+===Test vector 3===
+
+These vectors test for the retention of leading zeros. See [bitpay/bitcore-lib#47](https://github.com/bitpay/bitcore-lib/issues/47) and [iancoleman/bip39#58](https://github.com/iancoleman/bip39/issues/58) for more information.
+
+Seed (hex): 4b381541583be4423346c643850da4b320e46a87ae3d2a4e6da11eba819cd4acba45d239319ac14f863b8d5ab5a0d0c64d2e8a1e7d1457df2e5a3c51c73235be
+* Chain m
+** ext pub: xpub661MyMwAqRbcEZVB4dScxMAdx6d4nFc9nvyvH3v4gJL378CSRZiYmhRoP7mBy6gSPSCYk6SzXPTf3ND1cZAceL7SfJ1Z3GC8vBgp2epUt13
+** ext prv: xprv9s21ZrQH143K25QhxbucbDDuQ4naNntJRi4KUfWT7xo4EKsHt2QJDu7KXp1A3u7Bi1j8ph3EGsZ9Xvz9dGuVrtHHs7pXeTzjuxBrCmmhgC6
+* Chain m/0<sub>H</sub>
+** ext pub: xpub68NZiKmJWnxxS6aaHmn81bvJeTESw724CRDs6HbuccFQN9Ku14VQrADWgqbhhTHBaohPX4CjNLf9fq9MYo6oDaPPLPxSb7gwQN3ih19Zm4Y
+** ext prv: xprv9uPDJpEQgRQfDcW7BkF7eTya6RPxXeJCqCJGHuCJ4GiRVLzkTXBAJMu2qaMWPrS7AANYqdq6vcBcBUdJCVVFceUvJFjaPdGZ2y9WACViL4L
 
 ==Implementations==
 


### PR DESCRIPTION
These additional test vectors will ensure all future implementations are compliant with bip32.

See https://github.com/iancoleman/bip39/issues/58 and https://github.com/bitpay/bitcore-lib/issues/47

Possibly these test vectors may be useful also:

[bitcoinjs-lib test for this issue](https://github.com/bitcoinjs/bitcoinjs-lib/blob/4b4f32ffacb1b6e269ac3f16d68dba803c564c16/test/fixtures/hdnode.json#L180)

[bitcore-lib test for this issue (pending merge)](https://github.com/bitpay/bitcore-lib/pull/97/commits/b79a9b274ae8b48701daf5a1284e4f9035c3df0d#diff-c78032f7e0957dc3eebfc586843c6430R224)