### PR TITLE
Propagate summary tone of BIP Comments to their applicable BIP preambles

### DIFF
--- a/bip-0038.mediawiki
+++ b/bip-0038.mediawiki
@@ -4,7 +4,7 @@
   Title: Passphrase-protected private key
   Author: Mike Caldwell <mcaldwell@swipeclock.com>
           Aaron Voisine <voisine@gmail.com>
-  Comments-Summary: No comments yet.
+  Comments-Summary: Unanimously Discourage for implementation
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0038
   Status: Draft (Some confusion applies: The announcements for this never made it to the list, so it hasn't had public discussion)
   Type: Standards Track

--- a/bip-0039.mediawiki
+++ b/bip-0039.mediawiki
@@ -6,7 +6,7 @@
           Pavol Rusnak <stick@satoshilabs.com>
           Aaron Voisine <voisine@gmail.com>
           Sean Bowe <ewillbefull@gmail.com>
-  Comments-Summary: No comments yet.
+  Comments-Summary: Unanimously Discourage for implementation
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0039
   Status: Proposed
   Type: Standards Track

--- a/bip-0042.mediawiki
+++ b/bip-0042.mediawiki
@@ -3,7 +3,7 @@
   Layer: Consensus (soft fork)
   Title: A finite monetary supply for Bitcoin
   Author: Pieter Wuille <pieter.wuille@gmail.com>
-  Comments-Summary: No comments yet.
+  Comments-Summary: Unanimously Recommended for implementation
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0042
   Status: Draft
   Type: Standards Track

--- a/bip-0044.mediawiki
+++ b/bip-0044.mediawiki
@@ -4,7 +4,7 @@
   Title: Multi-Account Hierarchy for Deterministic Wallets
   Author: Marek Palatinus <slush@satoshilabs.com>
           Pavol Rusnak <stick@satoshilabs.com>
-  Comments-Summary: No comments yet.
+  Comments-Summary: Mixed review (one person)
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0044
   Status: Proposed
   Type: Standards Track

--- a/bip-0047.mediawiki
+++ b/bip-0047.mediawiki
@@ -8,7 +8,7 @@ RECENT CHANGES:
   Layer: Applications
   Title: Reusable Payment Codes for Hierarchical Deterministic Wallets
   Author: Justus Ranvier <justus@openbitcoinprivacyproject.org>
-  Comments-Summary: No comments yet.
+  Comments-Summary: Unanimously Discourage for implementation
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0047
   Status: Draft
   Type: Informational

--- a/bip-0060.mediawiki
+++ b/bip-0060.mediawiki
@@ -3,7 +3,7 @@
   Layer: Peer Services
   Title: Fixed Length "version" Message (Relay-Transactions Field)
   Author: Amir Taaki <genjix@riseup.net>
-  Comments-Summary: No comments yet.
+  Comments-Summary: Discouraged for implementation (one person)
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0060
   Status: Draft
   Type: Standards Track

--- a/bip-0061.mediawiki
+++ b/bip-0061.mediawiki
@@ -3,7 +3,7 @@
   Layer: Peer Services
   Title: Reject P2P message
   Author: Gavin Andresen <gavinandresen@gmail.com>
-  Comments-Summary: No comments yet.
+  Comments-Summary: Controversial; some recommendation, and some discouragement
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0061
   Status: Final
   Type: Standards Track

--- a/bip-0074.mediawiki
+++ b/bip-0074.mediawiki
@@ -3,7 +3,7 @@
   Layer: Applications
   Title: Allow zero value OP_RETURN in Payment Protocol
   Author: Toby Padilla <tobypadilla@gmail.com>
-  Comments-Summary: No comments yet.
+  Comments-Summary: Unanimously Discourage for implementation
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0074
   Status: Draft
   Type: Standards Track

--- a/bip-0075.mediawiki
+++ b/bip-0075.mediawiki
@@ -6,7 +6,7 @@
           Matt David <mgd@mgddev.com>
           Aaron Voisine <voisine@gmail.com>
           James MacWhyte <macwhyte@gmail.com>
-  Comments-Summary: No comments yet.
+  Comments-Summary: Recommended for implementation (one person)
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0075
   Status: Draft
   Type: Standards Track

--- a/bip-0090.mediawiki
+++ b/bip-0090.mediawiki
@@ -3,7 +3,7 @@
   Layer: Consensus (hard fork)
   Title: Buried Deployments
   Author: Suhas Daftuar <sdaftuar@chaincode.com>
-  Comments-Summary: No comments yet.
+  Comments-Summary: Mostly Recommended for implementation, with some Discouragement
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0090
   Status: Draft
   Type: Informational

--- a/bip-0150.mediawiki
+++ b/bip-0150.mediawiki
@@ -3,7 +3,7 @@
   Layer: Peer Services
   Title: Peer Authentication
   Author: Jonas Schnelli <dev@jonasschnelli.ch>
-  Comments-Summary: No comments yet.
+  Comments-Summary: Discouraged for implementation (one person)
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0150
   Status: Draft
   Type: Standards Track

--- a/bip-0151.mediawiki
+++ b/bip-0151.mediawiki
@@ -3,7 +3,7 @@
   Layer: Peer Services
   Title: Peer-to-Peer Communication Encryption
   Author: Jonas Schnelli <dev@jonasschnelli.ch>
-  Comments-Summary: No comments yet.
+  Comments-Summary: Controversial; some recommendation, and some discouragement
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0151
   Status: Draft
   Type: Standards Track

--- a/bip-0152.mediawiki
+++ b/bip-0152.mediawiki
@@ -3,7 +3,7 @@
   Layer: Peer Services
   Title: Compact Block Relay
   Author: Matt Corallo <bip152@bluematt.me>
-  Comments-Summary: No comments yet.
+  Comments-Summary: Unanimously Recommended for implementation
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0152
   Status: Draft
   Type: Standards Track


### PR DESCRIPTION
Affects: BIPs 38, 39, 42, 47, 60, 61, 74, 75, 90, 150, 151, 152

Will merge after a week or so. Anyone who disagrees with the assessments may feel free to post on the Comments wiki and/or this PR by then.

For reference, BIP 2 specifies how to post comments: https://github.com/bitcoin/bips/blob/master/bip-0002.mediawiki#BIP_comments