### PR TITLE
BIP 103: Adjust to reflect a new start date

### DIFF
--- a/bip-0103.mediawiki
+++ b/bip-0103.mediawiki
@@ -37,16 +37,16 @@ The block size limitation is replaced by the function below, applied to the medi
 
 The sigop limit scales proportionally.
 
-It implements a series of block size steps, one every ~97 days, between January 2017 and July 2063, each increasing the maximum block size by 4.4%. This allows an overall growth of 17.7% per year.
+It implements a series of block size steps, one every ~97 days, between January 2018 and July 2064, each increasing the maximum block size by 4.4%. This allows an overall growth of 17.7% per year.
 
 <pre>
 uint32_t GetMaxBlockSize(int64_t nMedianTimePast) {
-    // The first step is on January 1st 2017.
-    if (nMedianTimePast < 1483246800) {
+    // The first step is on January 1st 2018.
+    if (nMedianTimePast < 1514782800) {
         return 1000000;
     }
     // After that, one step happens every 2^23 seconds.
-    int64_t step = (nMedianTimePast - 1483246800) >> 23;
+    int64_t step = (nMedianTimePast - 1514782800) >> 23;
     // Don't do more than 11 doublings for now.
     step = std::min<int64_t>(step, 175);
     // Every step is a 2^(1/16) factor.
@@ -63,7 +63,7 @@ uint32_t GetMaxBlockSize(int64_t nMedianTimePast) {
 
 ==Rationale==
 
-Waiting 1.5 years before the hard fork takes place should provide ample time to minimize the risk of a hard fork, if found uncontroversial.
+Waiting 10 months before the hard fork takes place should provide ample time to minimize the risk of a hard fork, if found uncontroversial.
 
 Because every increase (including the first) is only 4.4%, risk from large market or technological changes is minimized.
 


### PR DESCRIPTION
Since the original start date, January 1, 2017, has passed, this change updates it to exactly a year later.