### PR TITLE
Stop UASF enforcement if SegWit has IsLockedIn state.

### DIFF
--- a/bip-0148.mediawiki
+++ b/bip-0148.mediawiki
@@ -30,7 +30,7 @@ It is hoped that miners will respond to this BIP by activating segwit early, bef
 
 All times are specified according to median past time.
 
-This BIP will be activate between midnight August 1st 2017 (epoch time 1501545600) and midnight November 15th 2017 (epoch time 1510704000) if the existing segwit deployment is not activated before epoch time 1501545600. This BIP will cease to be active when the existing segwit deployment activates.
+This BIP will be active between midnight August 1st 2017 (epoch time 1501545600) and midnight November 15th 2017 (epoch time 1510704000) if the existing segwit deployment is not locked-in or activated before epoch time 1501545600. This BIP will cease to be active when segwit is locked-in.
 
 While this BIP is active, all blocks must set the nVersion header top 3 bits to 001 together with bit field (1<<1) (according to the existing segwit deployment). Blocks that do not signal as required will be rejected.
 

--- a/bip-0148.mediawiki
+++ b/bip-0148.mediawiki
@@ -37,14 +37,22 @@ While this BIP is active, all blocks must set the nVersion header top 3 bits to 
 === Reference implementation ===
 
 <pre>
+// Check if Segregated Witness is Locked In
+bool IsWitnessLockedIn(const CBlockIndex* pindexPrev, const Consensus::Params& params)
+{
+    LOCK(cs_main);
+    return (VersionBitsState(pindexPrev, params, Consensus::DEPLOYMENT_SEGWIT, versionbitscache) == THRESHOLD_LOCKED_IN);
+}
+
 // BIP148 mandatory segwit signalling.
 int64_t nMedianTimePast = pindex->GetMedianTimePast();
 if ( (nMedianTimePast >= 1501545600) &&  // Tue 01 Aug 2017 00:00:00 UTC
      (nMedianTimePast <= 1510704000) &&  // Wed 15 Nov 2017 00:00:00 UTC
-     (!IsWitnessEnabled(pindex->pprev, chainparams.GetConsensus())) )  // Segwit is not active
+     (!IsWitnessLockedIn(pindex->pprev, chainparams.GetConsensus()) &&  // Segwit is not locked in
+      !IsWitnessEnabled(pindex->pprev, chainparams.GetConsensus())) )   // and is not active.
 {
-    bool fVersionBits = (pindex->nVersion & VERSIONBITS_TOP_MASK) == VERSIONBITS_TOP_BITS; // BIP9 bit set
-    bool fSegbit = (pindex->nVersion & VersionBitsMask(chainparams.GetConsensus(), Consensus::DEPLOYMENT_SEGWIT)) != 0; // segwit bit set
+    bool fVersionBits = (pindex->nVersion & VERSIONBITS_TOP_MASK) == VERSIONBITS_TOP_BITS;
+    bool fSegbit = (pindex->nVersion & VersionBitsMask(chainparams.GetConsensus(), Consensus::DEPLOYMENT_SEGWIT)) != 0;
     if (!(fVersionBits && fSegbit)) {
         return state.DoS(0, error("ConnectBlock(): relayed block must signal for segwit, please upgrade"), REJECT_INVALID, "bad-no-segwit");
     }

--- a/bip-0148.mediawiki
+++ b/bip-0148.mediawiki
@@ -38,13 +38,14 @@ While this BIP is active, all blocks must set the nVersion header top 3 bits to 
 
 <pre>
 // BIP148 mandatory segwit signalling.
-if (pindex->GetMedianTimePast() >= 1501545600 && // Tue 1 Aug 2017 00:00:00 UTC
-    pindex->GetMedianTimePast() <= 1510704000 && // Wed 15 Nov 2017 00:00:00 UTC
-    !IsWitnessEnabled(pindex->pprev, chainparams.GetConsensus()))
+int64_t nMedianTimePast = pindex->GetMedianTimePast();
+if ( (nMedianTimePast >= 1501545600) &&  // Tue 01 Aug 2017 00:00:00 UTC
+     (nMedianTimePast <= 1510704000) &&  // Wed 15 Nov 2017 00:00:00 UTC
+     (!IsWitnessEnabled(pindex->pprev, chainparams.GetConsensus())) )  // Segwit is not active
 {
-    // versionbits topbit and segwit flag must be set.
-    if ((pindex->nVersion & VERSIONBITS_TOP_MASK) != VERSIONBITS_TOP_BITS ||
-        (pindex->nVersion & VersionBitsMask(chainparams.GetConsensus(), Consensus::DEPLOYMENT_SEGWIT)) == 0) {
+    bool fVersionBits = (pindex->nVersion & VERSIONBITS_TOP_MASK) == VERSIONBITS_TOP_BITS; // BIP9 bit set
+    bool fSegbit = (pindex->nVersion & VersionBitsMask(chainparams.GetConsensus(), Consensus::DEPLOYMENT_SEGWIT)) != 0; // segwit bit set
+    if (!(fVersionBits && fSegbit)) {
         return state.DoS(0, error("ConnectBlock(): relayed block must signal for segwit, please upgrade"), REJECT_INVALID, "bad-no-segwit");
     }
 }


### PR DESCRIPTION
Includes basic refactor.

No-need to calculate the GetMedianTimePast() value twice.