### PR TITLE
Simplify UASF Activation Logic, and update specification.

### DIFF
--- a/bip-0148.mediawiki
+++ b/bip-0148.mediawiki
@@ -30,7 +30,7 @@ It is hoped that miners will respond to this BIP by activating segwit early, bef
 
 All times are specified according to median past time.
 
-This BIP will be active between midnight August 1st 2017 (epoch time 1501545600) and midnight November 15th 2017 (epoch time 1510704000) if the existing segwit deployment is not locked-in or activated before epoch time 1501545600. This BIP will cease to be active when segwit is locked-in.
+If the existing segwit deployment is not locked-in or activated before August 1st 2017 (epoch time 1501545600), this BIP will become active untill segwit is locked-in.
 
 While this BIP is active, all blocks must set the nVersion header top 3 bits to 001 together with bit field (1<<1) (according to the existing segwit deployment). Blocks that do not signal as required will be rejected.
 
@@ -47,7 +47,6 @@ bool IsWitnessLockedIn(const CBlockIndex* pindexPrev, const Consensus::Params& p
 // BIP148 mandatory segwit signalling.
 int64_t nMedianTimePast = pindex->GetMedianTimePast();
 if ( (nMedianTimePast >= 1501545600) &&  // Tue 01 Aug 2017 00:00:00 UTC
-     (nMedianTimePast <= 1510704000) &&  // Wed 15 Nov 2017 00:00:00 UTC
      (!IsWitnessLockedIn(pindex->pprev, chainparams.GetConsensus()) &&  // Segwit is not locked in
       !IsWitnessEnabled(pindex->pprev, chainparams.GetConsensus())) )   // and is not active.
 {


### PR DESCRIPTION
Updated BIP 148 Activation Logic, as the timeout of this BIP is completely redundant.