### PR TITLE
Simplify UASF Activation Logic, and update specification.

### DIFF
--- a/bip-0148.mediawiki
+++ b/bip-0148.mediawiki
@@ -24,17 +24,26 @@ This document specifies a BIP16 like soft fork flag day activation of the segreg
 
 Segwit increases the blocksize, fixes transaction malleability, and makes scripting easier to upgrade as well as bringing many other [https://bitcoincore.org/en/2016/01/26/segwit-benefits/ benefits].
 
-It is hoped that miners will respond to this BIP by activating segwit early, before this BIP takes effect. Otherwise this BIP will cause the mandatory activation of the existing segwit deployment before the end of midnight November 15th 2017.
+It is hoped that miners will respond to this BIP by activating segwit early, before this BIP takes effect. Otherwise this BIP may cause the mandatory activation of the existing segwit deployment before the end of midnight November 15th 2017.
+
+This BIP mandatory enforces SegWit within one full 2016 block retagat intivals after August 1st 2017.
 
 ==Specification==
 
 All times are specified according to median past time.
 
-This BIP will be active between midnight August 1st 2017 (epoch time 1501545600) and midnight November 15th 2017 (epoch time 1510704000) if the existing segwit deployment is not locked-in or activated before epoch time 1501545600. This BIP will cease to be active when segwit is locked-in.
+This BIP removes the existing segwit deployment timeout.
+
+If the existing segwit deployment is not locked-in or activated before August 1st 2017 (epoch time 1501545600), this BIP will become active untill segwit is locked-in.
 
 While this BIP is active, all blocks must set the nVersion header top 3 bits to 001 together with bit field (1<<1) (according to the existing segwit deployment). Blocks that do not signal as required will be rejected.
 
 === Reference implementation ===
+
+In chainparams.cpp: Set BIP 9 flag to never time-out.
+
+- consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = 1493596800; // May 1st 2017
++ consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = 999999999999ULL; // Never (BIP 148)
 
 <pre>
 // Check if Segregated Witness is Locked In
@@ -47,7 +56,6 @@ bool IsWitnessLockedIn(const CBlockIndex* pindexPrev, const Consensus::Params& p
 // BIP148 mandatory segwit signalling.
 int64_t nMedianTimePast = pindex->GetMedianTimePast();
 if ( (nMedianTimePast >= 1501545600) &&  // Tue 01 Aug 2017 00:00:00 UTC
-     (nMedianTimePast <= 1510704000) &&  // Wed 15 Nov 2017 00:00:00 UTC
      (!IsWitnessLockedIn(pindex->pprev, chainparams.GetConsensus()) &&  // Segwit is not locked in
       !IsWitnessEnabled(pindex->pprev, chainparams.GetConsensus())) )   // and is not active.
 {


### PR DESCRIPTION
This Pull Request Enforces That SegWit is activated, even if the hash-rate is very very slow.