### PR TITLE
readme: Clarify status for formally accepted BIPs

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -2,7 +2,7 @@ People wishing to submit BIPs, first should propose their idea or document to th
 
 We are fairly liberal with approving BIPs, and try not to be too involved in decision making on behalf of the community. The exception is in very rare cases of dispute resolution when a decision is contentious and cannot be agreed upon. In those cases, the conservative option will always be preferred.
 
-Having a BIP here does not make it a formally accepted standard until its status becomes Active. For a BIP to become Active requires the mutual consent of the community.
+Having a BIP here does not make it a formally accepted standard until its status becomes Final or Active.
 
 Those proposing changes should consider that ultimately consent may rest with the consensus of the Bitcoin users (see also: [https://en.bitcoin.it/wiki/Economic_majority economic majority]).
 


### PR DESCRIPTION
In the table there are some BIPs with a status of `Active`, and others
with a status of `Final`. Just wanted to submit this slight text change
for review to the README to indicate that both mean a BIP is formally
accepted.