### PR TITLE
bip-0039-wordlists : Typos, capitalization and trailing whitespace.

### DIFF
--- a/bip-0039/bip-0039-wordlists.md
+++ b/bip-0039/bip-0039-wordlists.md
@@ -12,15 +12,15 @@
 
 ###Japanese
 
-1. **Developers implementing phrase generation or checksum verification must separate words using ideographic spaces / accommodate users inputting ideographic spaces.**  
-(UTF-8 bytes: **0xE38080**; C/C+/Java: **"\u3000"**; Python: **u"\u3000"**)  
+1. **Developers implementing phrase generation or checksum verification must separate words using ideographic spaces / accommodate users inputting ideographic spaces.**
+(UTF-8 bytes: **0xE38080**; C/C+/Java: **"\u3000"**; Python: **u"\u3000"**)
 However, code that only accepts Japanese phrases but does not generate or verify them should be fine as is.
 This is because when generating the seed, normalization as per the spec will
 automatically change the ideographic spaces into normal ASCII spaces, so as long as your code never shows the user an ASCII space
 separated phrase or tries to split the phrase input by the user, dealing with ASCII or Ideographic space is the same.
 
-2. Word-wrapping doesn't work well, so making sure that words only word-wrap at one of the  
-ideographic spaces may be a necessary step. As a long word split in two could be mistaken easily  
+2. Word-wrapping doesn't work well, so making sure that words only word-wrap at one of the
+ideographic spaces may be a necessary step. As a long word split in two could be mistaken easily
 for two smaller words (This would be a problem with any of the 3 character sets in Japanese)
 
 ###Spanish
@@ -41,9 +41,9 @@ uniformity, we propose to use normal ASCII spaces (0x20) to separate words as pe
 Credits: @Kirvx @NicolasDorier @ecdsa @EricLarch
 ([The pull request](https://github.com/bitcoin/bips/issues/152))
 
-1.  High priority on simple and common french words.
+1.  High priority on simple and common French words.
 2.  Only words with 5-8 letters.
-3.  A word is fully recognizable by typing the first 4 letters (special french characters "é-è" are considered equal to "e", for exemple "museau" and "musée" can not be together).
+3.  A word is fully recognizable by typing the first 4 letters (special French characters "é-è" are considered equal to "e", for example "museau" and "musée" can not be together).
 4.  Only infinitive verbs, adjectives and nouns.
 5.  No pronouns, no adverbs, no prepositions, no conjunctions, no interjections (unless a noun/adjective is also popular than its interjection like "mince;chouette").
 6.  No numeral adjectives.
@@ -65,7 +65,7 @@ Credits: @paoloaga @Polve
 
 Words chosen using the following rules:
 
-1. Simple and common italian words.
+1. Simple and common Italian words.
 2. Length between 4 and 8 characters.
 3. First 4 letters must be unique between all words.
 4. No accents or special characters.
@@ -76,8 +76,8 @@ Words chosen using the following rules:
 9. No words with double vocals (like: lineetta).
 10. No words already used in other language mnemonic sets.
 11. If 3 of the first 4 letters are already used in the same sequence in another mnemonic word, there must be at least other 3 different letters.
-12. If 3 of the first 4 letters are already used in the same sequence in another mnemonic word, there not must be the same sequence of 3 or more letters.
+12. If 3 of the first 4 letters are already used in the same sequence in another mnemonic word, there must not be the same sequence of 3 or more letters.
 
-Rules 11 and 12 prevent the selection words that are not different enough. This makes each word more recognizable among others and less error prone. For example: the wordlist contains "atono", then "atomo" is rejected, but "atomico" is good. 
+Rules 11 and 12 prevent the selection words that are not different enough. This makes each word more recognizable among others and less error prone. For example: the wordlist contains "atono", then "atomo" is rejected, but "atomico" is good.
 
 All the words have been manually selected and automatically checked against the rules.


### PR DESCRIPTION
* "there not must" => "there must not"
* "exemple" => "example"
* Capitalize "French", "Italian"
* Trailing whitespace removal.