### PR TITLE
Mandatory de-activation of forced segwit deployment

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -728,6 +728,13 @@ Those proposing changes should consider that ultimately consent may rest with th
 | Sean Bowe, Daira Hopwood
 | Standard
 | Draft
+|-
+| [[bip-0200.mediawiki|200]]
+| Applications
+| Mandatory de-activation of forced segwit deployment
+| @movrcx
+| Standard
+| Draft
 |}
 
 <!-- IMPORTANT!  See the instructions at the top of this page, do NOT JUST add BIPs here! -->

--- a/README.mediawiki
+++ b/README.mediawiki
@@ -414,6 +414,13 @@ Those proposing changes should consider that ultimately consent may rest with th
 | Informational
 | Draft
 |-
+| [[bip-0091.mediawiki|91]]
+| Consensus (soft fork)
+| Reduced threshold Segwit MASF
+| James Hilliard
+| Standard
+| Draft
+|-
 | [[bip-0099.mediawiki|99]]
 |
 | Motivation and deployment of consensus rule changes ([soft/hard]forks)

--- a/bip-0091.mediawiki
+++ b/bip-0091.mediawiki
@@ -3,6 +3,8 @@
   Layer: Consensus (soft fork)
   Title: Reduced threshold Segwit MASF
   Author: James Hilliard <james.hilliard1@gmail.com>
+  Comments-Summary: No comments yet.
+  Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0091
   Status: Draft
   Type: Standards Track
   Created: 2017-05-22

--- a/bip-0091.mediawiki
+++ b/bip-0091.mediawiki
@@ -1,7 +1,7 @@
 <pre>
   BIP: 91
   Layer: Consensus (soft fork)
-  Title: Reduced signalling threshold activation of existing segwit deployment
+  Title: Reduced threshold Segwit MASF
   Author: James Hilliard <james.hilliard1@gmail.com>
   Status: Draft
   Type: Standards Track

--- a/bip-0091.mediawiki
+++ b/bip-0091.mediawiki
@@ -24,7 +24,7 @@ This document specifies a method to activate the existing BIP9 segwit deployment
 
 Segwit increases the blocksize, fixes transaction malleability, and makes scripting easier to upgrade as well as bringing many other [https://bitcoincore.org/en/2016/01/26/segwit-benefits/ benefits].
 
-This BIP provides a way for a simple majority of miners to coordinate activation of the existing segwit deployment with less than 95% hashpower. For a number of reasons a complete redeployment of segwit is difficulty to do until the existing deployment expires. This is due to 0.13.1+ having many segwit related features active already, including all the P2P components, the new network service flag, the witness-tx and block messages, compact blocks v2 and preferential peering. A redeployment of segwit will need to redefine all these things and doing so before expiry would greatly complicate testing.
+This BIP provides a way for a simple majority of miners to coordinate activation of the existing segwit deployment with less than 95% hashpower. For a number of reasons a complete redeployment of segwit is difficult to do until the existing deployment expires. This is due to 0.13.1+ having many segwit related features active already, including all the P2P components, the new network service flag, the witness-tx and block messages, compact blocks v2 and preferential peering. A redeployment of segwit will need to redefine all these things and doing so before expiry would greatly complicate testing.
 
 ==Specification==
 

--- a/bip-0091.mediawiki
+++ b/bip-0091.mediawiki
@@ -1,5 +1,5 @@
 <pre>
-  BIP: segsignal
+  BIP: 91
   Layer: Consensus (soft fork)
   Title: Reduced signalling threshold activation of existing segwit deployment
   Author: James Hilliard <james.hilliard1@gmail.com>

--- a/bip-0135.mediawiki
+++ b/bip-0135.mediawiki
@@ -388,9 +388,11 @@ By way of design it does not interfere with unknown (undefined) deployments.
 
 ==Reference implementation==
 
-A working reference implementation, including tests, can be found in this Pull Request:
+A working reference implementation, including tests, can be found in these Pull Requests:
 
-https://github.com/BitcoinUnlimited/BitcoinUnlimited/pull/458
+* https://github.com/BitcoinUnlimited/BitcoinUnlimited/pull/458
+
+* https://github.com/bitcoin/bitcoin/pull/10437
 
 Existing unit tests and regression tests have been left active to demonstrate
 backward compatibility of the default settings with BIP9.

--- a/bip-0200.mediawiki
+++ b/bip-0200.mediawiki
@@ -1,0 +1,91 @@
+<pre>
+  BIP: 200
+  Layer: Consensus (soft fork reversion)
+  Title: Mandatory de-activation of forced segwit deployment
+  Author: @movrcx <joshua2014@protonmail.ch>
+  Comments-Summary: No comments yet.
+  Comments-URI: TBD
+  Status: Draft
+  Type: Standards Track
+  Created: 2017-06-02
+  License: Public Domain (Unlicensed)
+</pre>
+
+==Abstract==
+
+This BIP supercedes BIP148 and outlines the methods and actions necessary to prevent unwanted network segmentation and forced isolation caused by non-consensual BIP148 and Segregated Witness deployment.
+
+The Bitcoin protocol was initially designed as a decentralized standard. Unfortunately BIP148 establishes and assigns significant standards-implementation authority to large and more influential commercial organizations and away from independent parties. The author of this proposal fully rejects BIP148 as being contrary to the spirit of Bitcoin and rejects the premise that overall Bitcoin consensus can be gained through a simple voting mechanism.
+
+BIP148 (UASF) additionally creates the scaffolding required for large influential groups to take ownership of the global Bitcoin protocol which is a significant departure from the original decentralized nature of Bitcoin. The presence of this scaffolding creates extraordinary risk of centralization within the Bitcoin community and must be resisted.
+
+This BIP takes a red-team-centric approach and proposes multiple legally acceptable covert and overt means to resist and eradicate BIP148 and SegWit from the global Bitcoin network in the event it is non-consensually activated. 
+
+==Definitions==
+
+"existing segwit deployment" refer to the BIP9 "segwit" deployment using bit 1, between November 15th 2016 and November 15th 2017 to activate BIP141, BIP143 and BIP147.
+
+==Motivation==
+
+BIP148 (UASF) relies significantly on the concept of forced voting in order to make enormous protocol altering decisions. Even now, miners who have chosen (or not chosen) to signal BIP148 are being independently and individually tracked by the same large commercial organizations who wish to forcably apply BIP148. Additionally the concept of forced public voting is authoritarian, breaks away from the concept of decentralization, and makes miners subject to financial bribery and other types of voter schemes and fraud.
+
+The author of this proposal suggests that significant consensus altering changes should not be applied without unanimous support by the greater Bitcoin community (especially those outside commercial organizations). In addition the author perceives the concept of forced consensus voting as contrary to the spirit of Bitcoin.
+
+==Specification==
+
+This BIP is active when implemented by a single node and will remain active until the last node is voluntarily deactivated.
+
+Three core and public strategies are contained within this document to disrupt forceable BIP148 and SegWit activation:
+
+===False Signaling Enabling Pre-Mature SegWit Activation===
+Miners who oppose BIP148 and Segregated Witness should falsely signal concurrence for Segregated Witness activation. As described within the the BIP148 (UASF) specification, miners who do not signal BIP148 are automatically segregated from the global network. False signaling prevents non-consensual forceable isolation and subsequent removal from the global Bitcoin network. Therefore those who conscientously reject BIP148 should falsely signal and refuse to be forceably subject to network isolation.
+
+===BIP148 Reference===
+<blockquote>
+While this BIP is active, all blocks must set the nVersion header top 3 bits to 001 together with bit field (1<<1) (according to the existing segwit deployment). Blocks that do not signal as required will be rejected.
+</blockquote>
+
+===Refusal of Chainsplit / Transaction Replay Countermeasures===
+The original author of BIP148 seeks to develop a means to isolate non-agreeing parties from the global Bitcoin network (this is a significant departure from the community-oriented nature of Bitcoin). Additionally anti-transaction replay functions have been concurrently proposed and developed by hardfork proponents in order to prevent catastrophic impacts in the event a chainsplit occurs (such as one that would result from BIP148). 
+
+BIP200 proposes to reject any and all transaction replay mitigations including BIP115 in order to make a non-miner supported chainsplit too financially dangerous to pursue. 
+
+===Mandatory De-activation of Segregated Witness===
+BIP200 seeks to falsely activate Segregated Witness and soon after revert and remove any Segregated Witness functionality. By facilitating a command and control communication system over coinbase transaction scripts it is possible to globally coordinate allied mining organizations to deactivate segregated witness. 
+
+The de-activation of Segregated Witness requires a multi-pronged effort to drain the illegitimate chain of utility and legitimacy. This proposal establishes a minimum 300 block wait period when allied miners and aligned individuals begin conversion of illegitimate BTC to other forms of assets while continuing to mine blocks signalling for Segregated Witness. The minimum block wait period may be signaled using a coinbase script C2 mechanism to establish consensus for de-activation of Segregated Witness.
+
+Upon completion of the wait period, BIP200 capable miners will return to the blockheight prior to Segregated Witness activation. Additionally anti-replay protections will be re-enabled and mining operations will proceed as normal.
+
+====  ====
+
+
+== Reference implementation ==
+
+See BIP148.
+
+''' OTHER IMPLEMENTATIONS TO BE PROVIDED LATER '''
+
+==Backwards Compatibility==
+
+This deployment is fully compatible will all previous Segregated Witness signaling proposals.
+
+==Rationale==
+
+BIP200 enables Segregated Witness de-activation and draining of value from an illegitimate chain after a subsequent non-consensual chainsplit activation occurs.
+
+==References==
+
+*[https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2017-March/013714.html Mailing list discussion]
+*[https://github.com/bitcoin/bitcoin/blob/v0.6.0/src/main.cpp#L1281-L1283 P2SH flag day activation]
+*[[bip-0009.mediawiki|BIP9 Version bits with timeout and delay]]
+*[[bip-0016.mediawiki|BIP16 Pay to Script Hash]]
+*[[bip-0141.mediawiki|BIP141 Segregated Witness (Consensus layer)]]
+*[[bip-0143.mediawiki|BIP143 Transaction Signature Verification for Version 0 Witness Program]]
+*[[bip-0147.mediawiki|BIP147 Dealing with dummy stack element malleability]]
+*[[bip-0148.mediawiki|Mandatory activation of segwit deployment]]
+*[https://bitcoincore.org/en/2016/01/26/segwit-benefits/ Segwit benefits]
+
+==Copyright==
+
+This BIP is released to the public domain, is unlicensed, and is provided without warranty.

--- a/bip-segsignal.mediawiki
+++ b/bip-segsignal.mediawiki
@@ -1,0 +1,88 @@
+<pre>
+  BIP: segsignal
+  Layer: Consensus (soft fork)
+  Title: Reduced signalling threshold activation of existing segwit deployment
+  Author: James Hilliard <james.hilliard1@gmail.com>
+  Status: Draft
+  Type: Standards Track
+  Created: 2017-05-22
+  License: BSD-3-Clause
+           CC0-1.0
+</pre>
+
+==Abstract==
+
+This document specifies a method to activate the existing BIP9 segwit deployment with a majority hashpower less than 95%.
+
+==Definitions==
+
+"existing segwit deployment" refer to the BIP9 "segwit" deployment using bit 1, between November 15th 2016 and November 15th 2017 to activate BIP141, BIP143 and BIP147.
+
+==Motivation==
+
+Segwit increases the blocksize, fixes transaction malleability, and makes scripting easier to upgrade as well as bringing many other [https://bitcoincore.org/en/2016/01/26/segwit-benefits/ benefits].
+
+This BIP provides a way for a simple majority of miners to coordinate activation of the existing segwit deployment with less than 95% hashpower. For a number of reasons a complete redeployment of segwit is difficulty to do until the existing deployment expires. This is due to 0.13.1+ having many segwit related features active already, including all the P2P components, the new network service flag, the witness-tx and block messages, compact blocks v2 and preferential peering. A redeployment of segwit will need to redefine all these things and doing so before expiry would greatly complicate testing.
+
+==Specification==
+
+While this BIP is active, all blocks must set the nVersion header top 3 bits to 001 together with bit field (1<<1) (according to the existing segwit deployment). Blocks that do not signal as required will be rejected.
+
+==Deployment==
+
+This BIP will be deployed by a "version bits" with an 80%(this can be adjusted if desired) activation threshold BIP9 with the name "segsignal" and using bit 4.
+
+This BIP will have a start time of midnight June 1st, 2017 (epoch time 1496275200) and timeout on midnight November 15th 2017 (epoch time 1510704000). This BIP will cease to be active when segwit is locked-in.
+
+=== Reference implementation ===
+
+<pre>
+// Check if Segregated Witness is Locked In
+bool IsWitnessLockedIn(const CBlockIndex* pindexPrev, const Consensus::Params& params)
+{
+    LOCK(cs_main);
+    return (VersionBitsState(pindexPrev, params, Consensus::DEPLOYMENT_SEGWIT, versionbitscache) == THRESHOLD_LOCKED_IN);
+}
+
+// SEGSIGNAL mandatory segwit signalling.
+if ( VersionBitsState(pindex->pprev, chainparams.GetConsensus(), Consensus::DEPLOYMENT_SEGSIGNAL, versionbitscache) == THRESHOLD_ACTIVE &&
+     !IsWitnessLockedIn(pindex->pprev, chainparams.GetConsensus()) &&  // Segwit is not locked in
+     !IsWitnessEnabled(pindex->pprev, chainparams.GetConsensus()) ) // and is not active.
+{
+    bool fVersionBits = (pindex->nVersion & VERSIONBITS_TOP_MASK) == VERSIONBITS_TOP_BITS;
+    bool fSegbit = (pindex->nVersion & VersionBitsMask(chainparams.GetConsensus(), Consensus::DEPLOYMENT_SEGWIT)) != 0;
+    if (!(fVersionBits && fSegbit)) {
+        return state.DoS(0, error("ConnectBlock(): relayed block must signal for segwit, please upgrade"), REJECT_INVALID, "bad-no-segwit");
+    }
+}
+</pre>
+
+https://github.com/bitcoin/bitcoin/compare/0.14...jameshilliard:segsignal-v0.14.1
+
+==Backwards Compatibility==
+
+This deployment is compatible with the existing "segwit" bit 1 deployment scheduled between midnight November 15th, 2016 and midnight November 15th, 2017. Miners will need to upgrade their nodes to support segsignal otherwise they may build on top of an invalid block. While this bip is active users should either upgrade to segsignal or wait for additional confirmations when accepting payments.
+
+==Rationale==
+
+Historically we have used IsSuperMajority() to activate soft forks such as BIP66 which has a mandatory signalling requirement for miners once activated, this ensures that miners are aware of new rules being enforced. This technique can be leveraged to lower the signalling threshold of a soft fork while it is in the process of being deployed in a backwards compatible way.
+
+By orphaning non-signalling blocks during the BIP9 bit 1 "segwit" deployment, this BIP can cause the existing "segwit" deployment to activate without needing to release a new deployment.
+
+==References==
+
+*[https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2017-March/013714.html Mailing list discussion]
+*[https://github.com/bitcoin/bitcoin/blob/v0.6.0/src/main.cpp#L1281-L1283 P2SH flag day activation]
+*[[bip-0009.mediawiki|BIP9 Version bits with timeout and delay]]
+*[[bip-0016.mediawiki|BIP16 Pay to Script Hash]]
+*[[bip-0141.mediawiki|BIP141 Segregated Witness (Consensus layer)]]
+*[[bip-0143.mediawiki|BIP143 Transaction Signature Verification for Version 0 Witness Program]]
+*[[bip-0147.mediawiki|BIP147 Dealing with dummy stack element malleability]]
+*[[bip-0148.mediawiki|BIP148 Mandatory activation of segwit deployment]]
+*[[bip-0149.mediawiki|BIP149 Segregated Witness (second deployment)]]
+*[https://bitcoincore.org/en/2016/01/26/segwit-benefits/ Segwit benefits]
+
+==Copyright==
+
+This document is dual licensed as BSD 3-clause, and Creative Commons CC0 1.0 Universal.
+


### PR DESCRIPTION
This BIP supercedes BIP148 and outlines the methods and actions necessary to prevent unwanted network segmentation and forced isolation caused by non-consensual BIP148 and Segregated Witness deployment.