### PR TITLE
Use a smaller deployment period for BIP91 but don't enforce until active.

### DIFF
--- a/bip-0091.mediawiki
+++ b/bip-0091.mediawiki
@@ -28,11 +28,11 @@ This BIP provides a way for a simple majority of miners to coordinate activation
 
 ==Specification==
 
-While this BIP is active or locked in, all blocks must set the nVersion header top 3 bits to 001 together with bit field (1<<1) (according to the existing segwit deployment). Blocks that do not signal as required will be rejected.
+While this BIP is active, all blocks must set the nVersion header top 3 bits to 001 together with bit field (1<<1) (according to the existing segwit deployment). Blocks that do not signal as required will be rejected.
 
 ==Deployment==
 
-This BIP will be deployed by a "version bits" with an 80%(this can be adjusted if desired) 538 block activation threshold and 672 block confirmation window BIP9 with the name "segsignal" and using bit 4.
+This BIP will be deployed by a "version bits" with an 80%(this can be adjusted if desired) 269 block activation threshold and 336 block confirmation window BIP9 with the name "segsignal" and using bit 4.
 
 This BIP will have a start time of midnight June 1st, 2017 (epoch time 1496275200) and timeout on midnight November 15th 2017 (epoch time 1510704000). This BIP will cease to be active when segwit is locked-in.
 
@@ -43,8 +43,8 @@ This BIP will have a start time of midnight June 1st, 2017 (epoch time 149627520
 consensus.vDeployments[Consensus::DEPLOYMENT_SEGSIGNAL].bit = 4;
 consensus.vDeployments[Consensus::DEPLOYMENT_SEGSIGNAL].nStartTime = 1496275200; // June 1st, 2017.
 consensus.vDeployments[Consensus::DEPLOYMENT_SEGSIGNAL].nTimeout = 1510704000; // November 15th, 2017.
-consensus.vDeployments[Consensus::DEPLOYMENT_SEGSIGNAL].nOverrideMinerConfirmationWindow = 672; // ~4.67 days
-consensus.vDeployments[Consensus::DEPLOYMENT_SEGSIGNAL].nOverrideRuleChangeActivationThreshold = 538; // 80%
+consensus.vDeployments[Consensus::DEPLOYMENT_SEGSIGNAL].nOverrideMinerConfirmationWindow = 336; // ~2.33 days
+consensus.vDeployments[Consensus::DEPLOYMENT_SEGSIGNAL].nOverrideRuleChangeActivationThreshold = 269; // 80%
 
 class VersionBitsConditionChecker : public AbstractThresholdConditionChecker {
 private:
@@ -74,18 +74,9 @@ public:
     uint32_t Mask(const Consensus::Params& params) const { return ((uint32_t)1) << params.vDeployments[id].bit; }
 };
 
-// Check if Segregated Witness is Locked In
-bool IsWitnessLockedIn(const CBlockIndex* pindexPrev, const Consensus::Params& params)
-{
-    LOCK(cs_main);
-    return (VersionBitsState(pindexPrev, params, Consensus::DEPLOYMENT_SEGWIT, versionbitscache) == THRESHOLD_LOCKED_IN);
-}
-
 // SEGSIGNAL mandatory segwit signalling.
-if ((VersionBitsState(pindex->pprev, chainparams.GetConsensus(), Consensus::DEPLOYMENT_SEGSIGNAL, versionbitscache) == THRESHOLD_ACTIVE ||
-     VersionBitsState(pindex->pprev, chainparams.GetConsensus(), Consensus::DEPLOYMENT_SEGSIGNAL, versionbitscache) == THRESHOLD_LOCKED_IN) &&
-     !IsWitnessLockedIn(pindex->pprev, chainparams.GetConsensus()) &&  // Segwit is not locked in
-     !IsWitnessEnabled(pindex->pprev, chainparams.GetConsensus()) ) // and is not active.
+if (VersionBitsState(pindex->pprev, chainparams.GetConsensus(), Consensus::DEPLOYMENT_SEGSIGNAL, versionbitscache) == THRESHOLD_ACTIVE &&
+    VersionBitsState(pindex->pprev, chainparams.GetConsensus(), Consensus::DEPLOYMENT_SEGWIT,    versionbitscache) == THRESHOLD_STARTED)
 {
     bool fVersionBits = (pindex->nVersion & VERSIONBITS_TOP_MASK) == VERSIONBITS_TOP_BITS;
     bool fSegbit = (pindex->nVersion & VersionBitsMask(chainparams.GetConsensus(), Consensus::DEPLOYMENT_SEGWIT)) != 0;


### PR DESCRIPTION
This gives a ~2 day upgrade period for miners to enforce mandatory signalling after lock-in and makes activation potentially faster.