### PR TITLE
BIP 173: Adds link to SLIP-0173

### DIFF
--- a/bip-0173.mediawiki
+++ b/bip-0173.mediawiki
@@ -262,6 +262,12 @@ P2PKH addresses can be used.
 * Fancy decoder that localizes errors:
 ** [https://github.com/sipa/bech32/tree/master/ecc/javascript For JavaScript] ([http://bitcoin.sipa.be/bech32/demo/demo.html demo website])
 
+==Registered Human-readable Prefixes==
+
+SatoshiLabs maintains a full list of registered human-readable parts for other cryptocurrencies:
+
+[https://github.com/satoshilabs/slips/blob/master/slip-0173.md SLIP-0173 : Registered human-readable parts for BIP-0173]
+
 ==Appendices==
 
 ===Test vectors===


### PR DESCRIPTION
SLIP-0173 lists registered human-readable parts for BIP-0173, keeping the BIPs free of other cryptocurrency information. This echoes SLIP/BIP-0044 with registered coin types for HD wallet derivation paths.