### PR TITLE
P2SH-P2WPKH redeem script must begin with 0x00

### DIFF
--- a/bip-0141.mediawiki
+++ b/bip-0141.mediawiki
@@ -179,8 +179,8 @@ Comparing with a traditional P2PKH output, the P2WPKH equivalent occupies 3 less
 The following example is the same P2WPKH, but nested in a BIP16 P2SH output.
 
     witness:      <signature> <pubkey>
-    scriptSig:    <0 <20-byte-key-hash>>
-                  (0x160014{20-byte-key-hash})
+    scriptSig:    0 <20-byte-key-hash>
+                  (0x0014{20-byte-key-hash})
     scriptPubKey: HASH160 <20-byte-script-hash> EQUAL
                   (0xA914{20-byte-script-hash}87)
 


### PR DESCRIPTION
This fixes the current description of the P2SH-P2WPKH redeem script, which incorrectly prepends 0x16 to the script. This contradicts the correct description in the [ Segwit Wallet Development Guide](https://bitcoincore.org/en/segwit_wallet_dev/#creation-of-p2sh-p2wpkh-address):

> The P2SH redeemScript is always 22 bytes. It starts with a OP_0, followed by a canonical push of the keyhash (i.e. 0x0014{20-byte keyhash})

The prepended 0x16 also results in the script being a single data push: the witness mechanism is not triggered, the script evaluates to TRUE and the TX is accepted by the network with no signature, creating a potentially dangerous gotcha for wallet developers.