### PR TITLE
BIP32: shuffle lines in recent changes to be chronological

### DIFF
--- a/bip-0032.mediawiki
+++ b/bip-0032.mediawiki
@@ -1,9 +1,9 @@
 RECENT CHANGES:
-* (24 Feb 2017) Added test vectors for hardened derivation with leading zeros
 * (16 Apr 2013) Added private derivation for i ≥ 0x80000000 (less risk of parent private key leakage)
 * (30 Apr 2013) Switched from multiplication by I<sub>L</sub> to addition of I<sub>L</sub> (faster, easier implementation)
 * (25 May 2013) Added test vectors
 * (15 Jan 2014) Rename keys with index ≥ 0x80000000 to hardened keys, and add explicit conversion functions.
+* (24 Feb 2017) Added test vectors for hardened derivation with leading zeros
 
 <pre>
   BIP: 32


### PR DESCRIPTION
I don't see this section in other BIPs, reversed chronological would be better.