### PR TITLE
Set bit 10 and 11 for NODE_NETWORK_LIMITED_LOW, HIGH

### DIFF
--- a/bip-0159.mediawiki
+++ b/bip-0159.mediawiki
@@ -31,9 +31,9 @@ This BIP proposes two new service bits
 
 {|class="wikitable"
 |-
-| NODE_NETWORK_LIMITED_LOW || If signaled, the peer <I>MUST</I> be capable of serving at least the last 288 blocks (~2 day / the current minimum limit for Bitcoin Core).
+| NODE_NETWORK_LIMITED_LOW || bit 10 (0x400) || If signaled, the peer <I>MUST</I> be capable of serving at least the last 288 blocks (~2 day / the current minimum limit for Bitcoin Core).
 |-
-| NODE_NETWORK_LIMITED_HIGH || If signaled, the peer <I>MUST</i> be capable of serving at least the last 1152 blocks (~8 days)
+| NODE_NETWORK_LIMITED_HIGH || bit 11 (0x800) || If signaled, the peer <I>MUST</i> be capable of serving at least the last 1152 blocks (~8 days)
 |}
 
 The required behaviour when signaling both bits (<code>NODE_NETWORK_LIMITED_LOW & NODE_NETWORK_LIMITED_HIGH</code>) is currently undefined.


### PR DESCRIPTION
Bit 6 and 8 seems to be kidnapped by BCash and SW2x (without following the BIP process).
Therefore I consider 0-8 taken and leave 9 reserved and start at bit 10 for limited services.