### PR TITLE
Allow to signal both bits and treat them independently

### DIFF
--- a/bip-0159.mediawiki
+++ b/bip-0159.mediawiki
@@ -36,8 +36,6 @@ This BIP proposes two new service bits
 | NODE_NETWORK_LIMITED_HIGH || bit 11 (0x800) || If signaled, the peer <I>MUST</i> be capable of serving at least the last 1152 blocks (~8 days)
 |}
 
-The required behaviour when signaling both bits (<code>NODE_NETWORK_LIMITED_LOW & NODE_NETWORK_LIMITED_HIGH</code>) is currently undefined.
-
 A safety buffer of additional 144 blocks to handle chain reorganizations <I>SHOULD</I> be taken into account when connecting to a peer signaling <code>NODE_NETWORK_LIMITED_*</code> service bits.
 
 === Address relay ===


### PR DESCRIPTION
The current BIP couples the two `NODE_NETWORK_LIMITED_*` bits by setting the state as undefined when signaling both bits. Ideally we can treat them independently which means signalling NODE_NETWORK_LIMITED_HIGH will always require to signal `NODE_NETWORK_LIMITED_LOW` as well.
The downside for this simplification is that we loose the possible third state (both bits set).