### PR TITLE
BIP114: Fix spelling of "Merkle"

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -507,7 +507,7 @@ Those proposing changes should consider that ultimately consent may rest with th
 |-
 | [[bip-0114.mediawiki|114]]
 | Consensus (soft fork)
-| Merkelized Abstract Syntax Tree
+| Merklized Abstract Syntax Tree
 | Johnson Lau
 | Standard
 | Draft

--- a/bip-0114.mediawiki
+++ b/bip-0114.mediawiki
@@ -1,7 +1,7 @@
 <pre>
   BIP: 114
   Layer: Consensus (soft fork)
-  Title: Merkelized Abstract Syntax Tree
+  Title: Merklized Abstract Syntax Tree
   Author: Johnson Lau <jl2012@xbt.hk>
   Comments-Summary: No comments yet.
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0114
@@ -27,8 +27,8 @@ The [[bip-0016.mediawiki|BIP16]] (Pay-to-script-hash, "P2SH") fixes the first 3 
 
 The [[bip-0141.mediawiki|BIP141]] defines 2 new types of scripts that support segregated witness. The pay-to-witness-script-hash (P2WSH) is similar to P2SH is many ways. By supplying the script in witness, P2WSH restores the original 10,000 byte script limit. However, it still requires publishing of unexecuted branches.
 
-===Merkelized Abstract Syntax Tree===
-The idea of Merkelized Abstract Syntax Tree (MAST) is to use a Merkle tree to encode branches in a script. When spending, users may provide only the branches they are executing, and hashes that connect the branches to the fixed size Merkel root. This reduces the size of redemption stack from O(n) to O(log n) (n as the number of branches). This enables complicated redemption conditions that is currently not possible due to the script size and opcode limit, improves privacy by hiding unexecuted branches, and allows inclusion of non-consensus enforced data with very low or no additional cost.
+===Merklized Abstract Syntax Tree===
+The idea of Merklized Abstract Syntax Tree (MAST) is to use a Merkle tree to encode branches in a script. When spending, users may provide only the branches they are executing, and hashes that connect the branches to the fixed size Merkle root. This reduces the size of redemption stack from O(n) to O(log n) (n as the number of branches). This enables complicated redemption conditions that is currently not possible due to the script size and opcode limit, improves privacy by hiding unexecuted branches, and allows inclusion of non-consensus enforced data with very low or no additional cost.
 
 ==Specification==
 In [[bip-0141.mediawiki|BIP141]], witness programs with a version byte of 1 or larger are considered to be anyone-can-spend scripts. The following new validation rules are applied if the witness program version byte is 1 and the program size is 32 bytes.<ref>If the version byte is 1, but the witness program is not 32 bytes, no further interpretation of the witness program or witness stack happens. This is reserved for future extensions.</ref> The witness program is the <code>MAST Root</code>.


### PR DESCRIPTION
* "Merkel root" => "Merkle root"
* "Merkelized" => "Merklized" (per https://github.com/bitcoin/bips/pull/552#issuecomment-317951710)

@jl2012