### PR TITLE
Add a Swift implementation of BIP32 for iOS.

### DIFF
--- a/bip-0032.mediawiki
+++ b/bip-0032.mediawiki
@@ -298,6 +298,8 @@ A C# implementation is available at https://github.com/NicolasDorier/NBitcoin (E
 
 A Haskell implementation is available at https://github.com/haskoin/haskoin together with a CLI interface at https://github.com/np/hx
 
+A Swift implementation for iOS is available at https://github.com/askcoin/bitcoin-hd-swift , also available at Cocoapods.
+
 ==Acknowledgements==
 
 * Gregory Maxwell for the original idea of type-2 deterministic wallets, and many discussions about it.


### PR DESCRIPTION
Include BIP39 implementation and BIP32 implementation.  -- Askcoin team.