### PR TITLE
BIP-199 Fix list formatting

### DIFF
--- a/bip-0199.mediawiki
+++ b/bip-0199.mediawiki
@@ -38,8 +38,7 @@ The script takes the following form:
 
 ===Interaction===
 
-* Victor (the "buyer") and Peggy (the "seller") exchange public keys and mutually agree upon a timeout threshold.  Peggy provides a hash digest.  Both parties can now 
-construct the script and P2SH address for the HTLC.
+* Victor (the "buyer") and Peggy (the "seller") exchange public keys and mutually agree upon a timeout threshold.  Peggy provides a hash digest.  Both parties can now construct the script and P2SH address for the HTLC.
 * Victor sends funds to the P2SH address.
 * Either:
 ** Peggy spends the funds, and in doing so, reveals the preimage to Victor in the transaction; OR


### PR DESCRIPTION
The sentence "Both parties can now construct the script and P2SH address for the HTLC." was broken with part appearing below the list item.