### PR TITLE
BIP 13: Remove broken link to "Base58 encoding"

### DIFF
--- a/bip-0013.mediawiki
+++ b/bip-0013.mediawiki
@@ -22,7 +22,7 @@ Enable "end-to-end" secure wallets and payments to fund escrow transactions or o
 
 ==Specification==
 
-The new bitcoin address type is constructed in the same manner as existing bitcoin addresses (see [[Base58Check encoding]]):
+The new bitcoin address type is constructed in the same manner as existing bitcoin addresses:
 
     base58-encode: [one-byte version][20-byte hash][4-byte checksum]
 


### PR DESCRIPTION
Alternatively, if the document previously linked-to still exists (I don't know), the link can be fixed.