### PR TITLE
typo 'ECSDA' changed to correct 'ECDSA'

### DIFF
--- a/bip-0032.mediawiki
+++ b/bip-0032.mediawiki
@@ -122,7 +122,7 @@ Each leaf node in the tree corresponds to an actual key, while the internal node
 
 ===Key identifiers===
 
-Extended keys can be identified by the Hash160 (RIPEMD160 after SHA256) of the serialized ECSDA public key K, ignoring the chain code. This corresponds exactly to the data used in traditional Bitcoin addresses. It is not advised to represent this data in base58 format though, as it may be interpreted as an address that way (and wallet software is not required to accept payment to the chain key itself).
+Extended keys can be identified by the Hash160 (RIPEMD160 after SHA256) of the serialized ECDSA public key K, ignoring the chain code. This corresponds exactly to the data used in traditional Bitcoin addresses. It is not advised to represent this data in base58 format though, as it may be interpreted as an address that way (and wallet software is not required to accept payment to the chain key itself).
 
 The first 32 bits of the identifier are called the key fingerprint.
 


### PR DESCRIPTION
Elliptic curve digital signature algorithm