### PR TITLE
Adding payment_base to the derivation path as an extra step of security 

### DIFF
--- a/bip-0039.mediawiki
+++ b/bip-0039.mediawiki
@@ -157,7 +157,7 @@ Ruby:
 * https://github.com/sreekanthgs/bip_mnemonic
 
 Rust:
- * https://github.com/infincia/bip39-rs
+* https://github.com/infincia/bip39-rs
 
 Swift:
 * https://github.com/CikeQiu/CKMnemonic

--- a/bip-0175.mediawiki
+++ b/bip-0175.mediawiki
@@ -74,7 +74,7 @@ Hardened derivation is used at this level.
 
 ===Payment address generation===
 
-For a given contract documents denoted by c<sub>1</sub> ,...,c<sub>n</sub>, payment base extended public key denoted by <code>payment_base</code>, and cryptographic hash function denoted by <code>h</code>.
+For a given contract documents denoted by c<sub>1</sub>,...,c<sub>n</sub>, payment base extended public key denoted by <code>payment_base</code>, and cryptographic hash function denoted by <code>h</code>.
 
 1. Compute cryptographic hashes for all contract documents, by applying the hash function.
 
@@ -84,9 +84,9 @@ For a given contract documents denoted by c<sub>1</sub> ,...,c<sub>n</sub>, paym
 
   hash_1,...,hash_n
 
-3. Concatenate the sorted hashes and apply the hash function.
+3. Prepend payment_base and concatenate the sorted hashes and apply the hash function.
 
-  h(hash_1+...+hash_n)
+  h(payment_base+hash_1+...+hash_n)
 
 4. Compute a partial BIP32 derivation path from the combined hash as defined in Hash to Partial Derivation Path Mapping procedure below.
 
@@ -171,28 +171,28 @@ document 2:
 
 3. Concatenate hashes and apply the hash function.
 
-  concatenated hash:
-  2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7aefcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9
+  concatenated hash: payment_base
+  xpub6B3JSEWjqm5GgfzcjPwBixxLPzi15pFM3jq4E4yCzXXUFS5MFdXiSdw7b5dbdPGHuc7c1V4zXbbFRtc9G1njMUt9ZvMdGVGYQSQsurD6HAW2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7aefcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9
   combined hash:
-  ec321de56af3b66fb49e89cfe346562388af387db689165d6f662a3950286a57
+  310057788c6073640dc222466d003411cd5c1cc0bf2803fc6ebbfae03ceb4451
 
 4. Compute the partial BIP32 derivation path of the combined hash.
 
-  60466/7653/27379/46703/46238/35279/58182/22051/34991/14461/46729/5725/28518/10809/20520/27223
+  12544/22392/35936/29540/3522/8774/27904/13329/52572/7360/48936/1020/28347/64224/15595/17489
 
 5. Prepend <code>payment_base</code> to <code>contract_hash</code> derivation path.
 
-  contract_base_pub/60466/7653/27379/46703/46238/35279/58182/22051/34991/14461/46729/5725/28518/10809/20520/27223
+  contract_base_pub/12544/22392/35936/29540/3522/8774/27904/13329/52572/7360/48936/1020/28347/64224/15595/17489
   or
-  m/175'/0'/60466/7653/27379/46703/46238/35279/58182/22051/34991/14461/46729/5725/28518/10809/20520/27223
+  m/175'/0'/12544/22392/35936/29540/3522/8774/27904/13329/52572/7360/48936/1020/28347/64224/15595/17489
 
 6. Compute public extended key.
 
-  xpub6hML7vSU2Hwww9ctwrwt4ijnhJr4n6XaMRox1nnF3PvZKuF1SZoTymnKQHrF9fp2nWJSqv5ZjJSxJJQ8A3PKcBUWhGvTFmuRKpycSCr5coz
+  xpub6hefaATTG5LbcwyPDvmNfnkyzefoM2TJDoo5astH7Gvs1g8vZURviBWvAvBnWc2CNb8ybJ6mDpnQYVsvNSZ3oUmbssX3rUVG97TFYa6AXVk
 
 7. Compute address of the public extended key (P2PKH).
 
-  1HYjhPTtMmpBJBd5tVepZDAVdvPA7o8KHJ
+  1C7f322izqMqLzZzfzkPAjxBzprxDi47Yf
 
 
 ====Verification example (negative test)====
@@ -207,29 +207,33 @@ document 1:
 
   baa5a0964d3320fbc0c6a922140453c8513ea24ab8fd0577034804a967248096
 
-2. Apply the hash function a second time (list of one item).
+2. Prepend payment_base
+
+  xpub6B3JSEWjqm5GgfzcjPwBixxLPzi15pFM3jq4E4yCzXXUFS5MFdXiSdw7b5dbdPGHuc7c1V4zXbbFRtc9G1njMUt9ZvMdGVGYQSQsurD6HAWbaa5a0964d3320fbc0c6a922140453c8513ea24ab8fd0577034804a967248096
+
+2. Apply hash function
 
   3a08605829413ce0bf551b08d21e4a28dbda6e407f90eff1c448e839050c73a1
 
 3. Compute the partial derivation path.
 
-  14856/24664/10561/15584/48981/6920/53790/18984/56282/28224/32656/61425/50248/59449/1292/29601
+  5338/54412/19213/962/30664/62597/11873/59874/56779/24089/54550/19585/28087/36422/18666/17562
 
 4. Prepend contract_base<sub>pub</sub> to contract_hash derivation path.
 
-  contract_base_pub/14856/24664/10561/15584/48981/6920/53790/18984/56282/28224/32656/61425/50248/59449/1292/29601
+  contract_base_pub/5338/54412/19213/962/30664/62597/11873/59874/56779/24089/54550/19585/28087/36422/18666/17562
   or
-  m/175'/0'/14856/24664/10561/15584/48981/6920/53790/18984/56282/28224/32656/61425/50248/59449/1292/29601
+  m/175'/0'/5338/54412/19213/962/30664/62597/11873/59874/56779/24089/54550/19585/28087/36422/18666/17562
 
 5. Compute public extended key.
 
-  xpub6gujKWRhegHXKZBkrprW55oSL6UxYhStxF5FtoUNa4KShLxLPDLQTS39XAwRhdCSvuAv2wogwukmfk3fS7CM6pT6QWwJHiCTw7RkwXMgThy
+  xpub6h9k2KqsMpwghxt7naj1puhGV1ZDC88sxvpYN1HibCf8yQZdPsuhYmmvdK32Kf2Lb3rS1sV8UcZ1f84DJEiXuVfLCAj4bC85aEUCxh38m8i
 
 7. Compute address of the public extended key (P2PKH).
 
-  162KDdRXa3KPgYkH3d1DDKfddacH1gn1n8
+  1QGe5LaDMAmHeibJbZBmZqhQDZSp7QCqSs
 
-8. As expected the address doesn't match the Bitcoin address from the last example <code>1LeYXs63uVSDu2XSb82xdEc7RumohCpB7Q</code>.
+8. As expected the address doesn't match the Bitcoin address from the last example <code>1C7f322izqMqLzZzfzkPAjxBzprxDi47Yf</code>.
 
 Verification operation will succeed only if we use identical documents to ones that have been used in the contract address generation.
 

--- a/bip-0175.mediawiki
+++ b/bip-0175.mediawiki
@@ -72,7 +72,7 @@ The coin type field is identical to the same field in BIP-0044.
 
 Hardened derivation is used at this level.
 
-===Payment Address Generation===
+===Payment address generation===
 
 For a given contract documents denoted by c<sub>1</sub> ,...,c<sub>n</sub>, payment base extended public key denoted by <code>payment_base</code>, and cryptographic hash function denoted by <code>h</code>.
 
@@ -100,7 +100,7 @@ For a given contract documents denoted by c<sub>1</sub> ,...,c<sub>n</sub>, paym
 
 7. Compute address of the public extended key (P2PKH) from step 6.
 
-===Payment Address Verification===
+===Payment address verification===
 
 For a given Bitcoin address, <code>payment_base</code> extended public key, contract documents denoted by c<sub>1</sub>,...,c<sub>n</sub>, and cryptographic hash function denoted by <code>h</code>, we can verify the integrity of the address by the following steps:
 
@@ -115,7 +115,7 @@ The merchant should actively monitor the blockchain for the payment to the payme
 Because the address is generated from the payment base and the contract, the merchant must implicitly agree to those terms in order to spend the funds.
 The act of making the payment to that address thus serves as a receipt for the customer.
 
-===Hash to Partial Derivation Path Mapping===
+===Hash to partial derivation path mapping===
 
 At this section, we define hash to partial BIP32 derivation path mapping procedure that maps between an arbitrary hex number to a partial BIP32 derivation path.
 
@@ -145,7 +145,7 @@ we can compute payment base as follows:
 
 In the below examples, we are going to use SHA256 as a cryptographic hash function, and the above contract base public key.
 
-====Payment address generation:====
+====Payment address generation====
 
 As an input, we have a contract that consists of two documents, below are contents:
 
@@ -195,7 +195,7 @@ document 2:
   1HYjhPTtMmpBJBd5tVepZDAVdvPA7o8KHJ
 
 
-====Verification example 1 (negative test):====
+====Verification example (negative test)====
 
 Similar to the input above, except this time we have a contract that consists of one document, below is the content:
 


### PR DESCRIPTION
Based on community feedback we are adding the payment_base as an extra layer of security and prevent mathematically possible contract forgery, with that being said it worth mentioning that this scenario could be very hard due to the fact that this BIP uses BIP32 derivation mechanism which uses hmac-sha512 and the fingerprint of pubkey - chain code.