### PR TITLE
BIP-173: fix typo in "Created" date

### DIFF
--- a/bip-0173.mediawiki
+++ b/bip-0173.mediawiki
@@ -8,7 +8,7 @@
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0173
   Status: Draft
   Type: Informational
-  Created: 2016-03-20
+  Created: 2017-03-20
   License: BSD-2-Clause
   Replaces: 142
 </pre>


### PR DESCRIPTION
I can't find much about bech32 anywhere, before March 2017.

Based on the date of this commit, I think there is a typo in the date. https://github.com/sipa/bech32/commit/52b5a0fa6d3174c4150393fb7d6b58d34b4f5e0b