### PR TITLE
bip38 typo: specifid -> specified

### DIFF
--- a/bip-0038.mediawiki
+++ b/bip-0038.mediawiki
@@ -170,7 +170,7 @@ To recalculate the address:
 # Derive ''passfactor'' using scrypt with ''ownerentropy'' and the user's passphrase and use it to recompute ''passpoint''
 # Derive decryption key for ''pointb'' using scrypt with ''passpoint'', ''addresshash'', and ''ownerentropy''
 # Decrypt ''encryptedpointb'' to yield ''pointb''
-# ECMultiply ''pointb'' by ''passfactor''. Use the resulting EC point as a public key and hash it into ''address'' using either compressed or uncompressed public key methodology as specifid in ''flagbyte''.
+# ECMultiply ''pointb'' by ''passfactor''. Use the resulting EC point as a public key and hash it into ''address'' using either compressed or uncompressed public key methodology as specified in ''flagbyte''.
 
 =====Decryption=====
 # Collect encrypted private key and passphrase from user.


### PR DESCRIPTION
There was a small typo in the bip38 specification. If I'm not totally mistaken the word should be "specified" (not specifid)
Thx