### PR TITLE
BIP 32: Private key derivation operation order fix

### DIFF
--- a/bip-0032.mediawiki
+++ b/bip-0032.mediawiki
@@ -77,7 +77,7 @@ The function CKDpriv((k<sub>par</sub>, c<sub>par</sub>), i) &rarr; (k<sub>i</sub
 ** If so (hardened child): let I = HMAC-SHA512(Key = c<sub>par</sub>, Data = 0x00 || ser<sub>256</sub>(k<sub>par</sub>) || ser<sub>32</sub>(i)). (Note: The 0x00 pads the private key to make it 33 bytes long.)
 ** If not (normal child): let I = HMAC-SHA512(Key = c<sub>par</sub>, Data = ser<sub>P</sub>(point(k<sub>par</sub>)) || ser<sub>32</sub>(i)).
 * Split I into two 32-byte sequences, I<sub>L</sub> and I<sub>R</sub>.
-* The returned child key k<sub>i</sub> is parse<sub>256</sub>(I<sub>L</sub>) + k<sub>par</sub> (mod n).
+* The returned child key k<sub>i</sub> is (parse<sub>256</sub>(I<sub>L</sub>) + k<sub>par</sub>)mod n.
 * The returned chain code c<sub>i</sub> is I<sub>R</sub>.
 * In case parse<sub>256</sub>(I<sub>L</sub>) ≥ n or k<sub>i</sub> = 0, the resulting key is invalid, and one should proceed with the next value for i. (Note: this has probability lower than 1 in 2<sup>127</sup>.)
 


### PR DESCRIPTION
Added additional parentesis for clear understanding of the equation on this row. I am doing this proposition because I was stuck on this part for quite some time untill I understood that I furst need to add and then do the modular devision. I think that this way, the order of operations is more clear.