### PR TITLE
bip159: Clarify that there is only one threshold

### DIFF
--- a/bip-0159.mediawiki
+++ b/bip-0159.mediawiki
@@ -31,10 +31,10 @@ This BIP proposes a new service bit
 
 {|class="wikitable"
 |-
-| NODE_NETWORK_LIMITED || bit 10 (0x400) || If signaled, the peer <I>MUST</I> be capable of serving at least the last 288 blocks (~2 day / the current minimum limit for Bitcoin Core).
+| NODE_NETWORK_LIMITED || bit 10 (0x400) || If signaled, the peer <I>MUST</I> be capable of serving at least the last 288 blocks (~2 days).
 |}
 
-A safety buffer of additional 144 blocks to handle chain reorganizations <I>SHOULD</I> be taken into account when connecting to a peer signaling the <code>NODE_NETWORK_LIMITED</code> service bit.
+A safety buffer of 144 blocks to handle chain reorganizations <I>SHOULD</I> be taken into account when connecting to a peer signaling the <code>NODE_NETWORK_LIMITED</code> service bit.
 
 === Address relay ===
 
@@ -42,7 +42,7 @@ Full nodes following this BIP <I>SHOULD</I> relay address/services (<code>addr</
 
 === Counter-measures for peer fingerprinting ===
 
-Peers may have different prune depths (depending on the peers configuration, disk space, etc.) which can result in a fingerprinting weakness (finding the prune depth through getdata requests). NODE_NETWORK_LIMITED supporting peers <I>SHOULD</I> avoid leaking the prune depth and therefore not serve blocks deeper then the signaled <code>NODE_NETWORK_LIMITED</code> thresholds.
+Peers may have different prune depths (depending on the peers configuration, disk space, etc.) which can result in a fingerprinting weakness (finding the prune depth through getdata requests). NODE_NETWORK_LIMITED supporting peers <I>SHOULD</I> avoid leaking the prune depth and therefore not serve blocks deeper than the signaled <code>NODE_NETWORK_LIMITED</code> threshold (244 blocks).
 
 === Risks ===
 

--- a/bip-0159.mediawiki
+++ b/bip-0159.mediawiki
@@ -56,10 +56,8 @@ This proposal is backward compatible.
 
 == Reference implementation ==
 
-* https://github.com/bitcoin/bitcoin/pull/10387
-
-
-== References ==
+* https://github.com/bitcoin/bitcoin/pull/11740 (signaling)
+* https://github.com/bitcoin/bitcoin/pull/10387 (connection and relay)
 
 == Copyright ==
 


### PR DESCRIPTION
@jonasschnelli 

Changes:
* The last section mentions "thresholds", while only a single threshold of 244 is specified in the bip. Clarify by changing to "threshold"
* Remove internal Bitcoin Core implementation detail. This is not relevant for a bip.
* Remove word "additional" when referring to safety buffer, since the safety buffer is the only buffer and not an additional one.
* Remove empty section "references"
* Add missing link to signaling implementation.