### PR TITLE
Add BIP39 Swift implementation link

### DIFF
--- a/bip-0039.mediawiki
+++ b/bip-0039.mediawiki
@@ -161,6 +161,7 @@ Rust:
 
 Swift:
 * https://github.com/CikeQiu/CKMnemonic
+* https://github.com/yuzushioh/WalletKit
 
 C++:
 * https://github.com/libbitcoin/libbitcoin/blob/master/include/bitcoin/bitcoin/wallet/mnemonic.hpp


### PR DESCRIPTION
I added a BIP39 Swift implementation link.