### PR TITLE
Progress BIP173 to Proposed

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -749,13 +749,13 @@ Those proposing changes should consider that ultimately consent may rest with th
 | Luke Dashjr
 | Standard
 | Draft
-|-
+|- style="background-color: #ffffcf"
 | [[bip-0173.mediawiki|173]]
 | Applications
 | Base32 address format for native v0-16 witness outputs
 | Pieter Wuille, Greg Maxwell
 | Informational
-| Draft
+| Proposed
 |-
 | [[bip-0174.mediawiki|174]]
 | Applications

--- a/bip-0173.mediawiki
+++ b/bip-0173.mediawiki
@@ -6,7 +6,7 @@
           Greg Maxwell <greg@xiph.org>
   Comments-Summary: No comments yet.
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0173
-  Status: Draft
+  Status: Proposed
   Type: Informational
   Created: 2017-03-20
   License: BSD-2-Clause


### PR DESCRIPTION
I believe that the BIP173 standard is complete and won't functionally change anymore. As required by BIP2, I believe there are community plans to progress it to final (given that multiple wallet implementations support or plan to support it).