### PR TITLE
fix grammar error

### DIFF
--- a/bip-0045.mediawiki
+++ b/bip-0045.mediawiki
@@ -62,7 +62,7 @@ Hardened derivation is used at this level.
 
 The index of the party creating a P2SH multisig address. The indices can
 be determined independently by lexicographically sorting the purpose public
-keys of each cosigner. Each cosigner creates addresses on it's own branch,
+keys of each cosigner. Each cosigner creates addresses on its own branch,
 even though they have independent extended master public key, as explained 
 in the "Address generation" section.
 


### PR DESCRIPTION
"it's" is the contraction of "it" and "is". "its" should be used for ownership