### PR TITLE
Fix single typo in BIP65 ("from" -> "form")

### DIFF
--- a/bip-0065.mediawiki
+++ b/bip-0065.mediawiki
@@ -136,7 +136,7 @@ transaction is created, tx3, to ensure that should the payee vanish the payor
 can get their deposit back. The process by which the refund transaction is
 created is currently vulnerable to transaction malleability attacks, and
 additionally, requires the payor to store the refund. Using the same
-scriptPubKey from as in the Two-factor wallets example solves both these issues.
+scriptPubKey form as in the Two-factor wallets example solves both these issues.
 
 
 ===Trustless Payments for Publishing Data===


### PR DESCRIPTION
Current text:
> Using the same scriptPubKey **from** as in the Two-factor wallets example solves both these issues.

Proposed text:
> Using the same scriptPubKey **form** as in the Two-factor wallets example solves both these issues.

