### PR TITLE
Remove 'hard fork' designation on BIP 90

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -415,7 +415,7 @@ Those proposing changes should consider that ultimately consent may rest with th
 | Draft
 |-
 | [[bip-0090.mediawiki|90]]
-| Consensus (hard fork)
+|
 | Buried Deployments
 | Suhas Daftuar
 | Informational

--- a/bip-0090.mediawiki
+++ b/bip-0090.mediawiki
@@ -1,6 +1,5 @@
 <pre>
   BIP: 90
-  Layer: Consensus (hard fork)
   Title: Buried Deployments
   Author: Suhas Daftuar <sdaftuar@chaincode.com>
   Comments-Summary: Mostly Recommended for implementation, with some Discouragement


### PR DESCRIPTION
#478 added a label to BIP 90 that I disagree with.  While the term "hard fork" is sometimes used in the way defined in BIP 123, it also is used by many -- including the BIP 123 author -- to refer to consensus changes that require network-wide coordination in deployment to avoid a chain split[1], which is untrue for BIP 90.

As the whole purpose of this BIP is explain the type of consensus change that was made and point out that the network split risk is minimal, I don't accept the label "hard fork" as a useful or correct designation, and I think it does a disservice to our collective understanding of consensus changes to try to apply a label like this.

--

[1] From https://medium.com/@elombrozo/forks-signaling-and-activation-d60b6abda49a:

> Since hard forks loosen or eliminate existing rules, blocks which would have been rejected by the old rules are now accepted by nodes using the new rules. Examples include increasing the block reward, increasing the maximum base block size, changing the block header format, or changing the proof of work function. Nodes that do not update their rules will reject these blocks and will continue to follow only chains that enforce the old rules. This means that unless all nodes update, we will get a chain split.
