### PR TITLE
Withdrawing BIP120/121 due to security issues during soft-forks

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -546,14 +546,14 @@ Those proposing changes should consider that ultimately consent may rest with th
 | Mark Friedenbach, Kalle Alm, BtcDrak
 | Standard
 | Draft
-|-
+|- style="background-color: #ffcfcf"
 | [[bip-0120.mediawiki|120]]
 | Applications
 | Proof of Payment
 | Kalle Rosenbaum
 | Standard
 | Withdrawn
-|-
+|- style="background-color: #ffcfcf"
 | [[bip-0121.mediawiki|121]]
 | Applications
 | Proof of Payment URI scheme

--- a/README.mediawiki
+++ b/README.mediawiki
@@ -552,14 +552,14 @@ Those proposing changes should consider that ultimately consent may rest with th
 | Proof of Payment
 | Kalle Rosenbaum
 | Standard
-| Draft
+| Withdrawn
 |-
 | [[bip-0121.mediawiki|121]]
 | Applications
 | Proof of Payment URI scheme
 | Kalle Rosenbaum
 | Standard
-| Draft
+| Withdrawn
 |-
 | [[bip-0122.mediawiki|122]]
 | Applications

--- a/bip-0120.mediawiki
+++ b/bip-0120.mediawiki
@@ -5,7 +5,7 @@
   Author: Kalle Rosenbaum <kalle@rosenbaum.se>
   Comments-Summary: No comments yet.
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0120
-  Status: Draft
+  Status: Withdrawn
   Type: Standards Track
   Created: 2015-07-28
 </pre>

--- a/bip-0121.mediawiki
+++ b/bip-0121.mediawiki
@@ -5,7 +5,7 @@
   Author: Kalle Rosenbaum <kalle@rosenbaum.se>
   Comments-Summary: No comments yet.
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0121
-  Status: Draft
+  Status: Withdrawn
   Type: Standards Track
   Created: 2015-07-27
 </pre>


### PR DESCRIPTION
There is an inherent problem with BIP120, Proof of Payment: If there is a soft fork, a server that verifies PoPs will accept a PoP as valid without checking any of the new Bitcoin rules.

For example, a server will be fooled by a segwit transaction, because the server doesn't have a witness to verify and consequently will accept any PoP with an empty scriptSig.

Since BIP121 depends on BIP120, that has to go too.