### PR TITLE
Update the BIP 9 assignments doc to reflect mainnet segwit activation

### DIFF
--- a/bip-0009/assignments.mediawiki
+++ b/bip-0009/assignments.mediawiki
@@ -29,7 +29,7 @@ State can be defined, active, failed. Dates are in UTC.
 | 1
 | 2016-11-15 00:00:00
 | 2017-11-15 00:00:00
-| -
+| active since #481824
 | 2016-05-01 00:00:00
 | 2017-05-01 00:00:00
 | active since #834624


### PR DESCRIPTION
This is just a small clerical change to update the BIP 9 assignments "living document" with information about when SegWit activation on mainnet. I wasn't exactly clear about which height to use -- SegWit was activated at 481824 (which is what I included in this PR) but SW transactions didn't become valid on mainnet until 494784. I'm using the activation height as that's my understanding of the intent here.