### PR TITLE
BIP 9: Misplaced table cells typo

### DIFF
--- a/bip-0009/assignments.mediawiki
+++ b/bip-0009/assignments.mediawiki
@@ -30,7 +30,6 @@ State can be defined, active, failed. Dates are in UTC.
 | 2016-11-15 00:00:00
 | 2017-11-15 00:00:00
 | active since #481824
-| -
 | 2016-05-01 00:00:00
 | 2017-05-01 00:00:00
 | active since #834624


### PR DESCRIPTION
Second row was created with an incorrect extra empty cell