### PR TITLE
Added working Pharo Smalltalk implementation

### DIFF
--- a/bip-0039.mediawiki
+++ b/bip-0039.mediawiki
@@ -156,6 +156,9 @@ JavaScript:
 * https://github.com/bitpay/bitcore-mnemonic
 * https://github.com/bitcoinjs/bip39 (used by [[https://github.com/blockchain/My-Wallet-V3/blob/v3.8.0/src/hd-wallet.js#L121-L146|blockchain.info]])
 
+Pharo Smalltalk:
+* https://github.com/eMaringolo/pharo-bip39mnemonic
+
 Ruby:
 * https://github.com/sreekanthgs/bip_mnemonic
 


### PR DESCRIPTION
This implementation is compliant with the spec allowing the creation of new mnemonics from an entropy from 128 to 256 bits, from mnemonic words or from the the raw entropy+checksum bytes.

Supports English, Spanish, Italian and French, and passes all tests from the Python reference implementation.

