### PR TITLE
[trivial] Correct typos in BIP 98

### DIFF
--- a/bip-0098.mediawiki
+++ b/bip-0098.mediawiki
@@ -176,7 +176,7 @@ In tabular form, these code values are:
 |}
 
 These 3-bit codes are packed into a byte array such that eight (8) codes would fit in every three (3) bytes.
-The order of filling a byte begins with the most significant bit <code>0x80</code> and ends with the lest significant bit <code>0x01</code>.
+The order of filling a byte begins with the most significant bit <code>0x80</code> and ends with the least significant bit <code>0x01</code>.
 Unless the number of inner nodes is a multiple of eight (8), there will be excess low-order bits in the final byte of serialization.
 These excess bits must be zero.
 
@@ -244,7 +244,7 @@ and is exactly equal to the number of inner nodes serialized as the beginning of
 The variable-length integer encoding has the property that serialized integers, sorted lexigraphically, will also be sorted numerically.
 Since the first serialized item is the number of inner nodes, sorting proofs lexigraphically has the effect of sorting the proofs by the amount of work required to verify.
 
-The number of hashes required as input for verification of a proof is N+1 minus the number of SKIP hashses,
+The number of hashes required as input for verification of a proof is N+1 minus the number of SKIP hashes,
 and can be quickly calculated without parsing the tree structure.
 
 The coding and packing rules for the serialized tree structure were also chosen to make lexigraphical comparison useful (or at least not meaningless).
@@ -264,7 +264,7 @@ which has the additional benefit of enabling log-space verification algorithms.
 ==Fast Merkle Lists==
 
 Many applications use a Merkle tree to provide indexing of, or compact membership proofs about the elements in a list.
-This ammendum specifies an algorithm that constructs a canonical balanced tree structure for lists of various lengths.
+This addendum specifies an algorithm that constructs a canonical balanced tree structure for lists of various lengths.
 It differs in a subtle but important way from the algorithm used by Satoshi so as to structurally prevent the vulnerability described in [1].
 
 # Begin with a list of arbitrary data strings.


### PR DESCRIPTION
Changes:

least <- lest
hashes <- hashses
addendum <- ammendum