### PR TITLE
BIP0173: Include bech32 prefix for regtest mode

### DIFF
--- a/bip-0173.mediawiki
+++ b/bip-0173.mediawiki
@@ -203,10 +203,11 @@ addresses) are ever introduced, having a fully generic old address type availabl
 permit reinterpreting the resulting scriptPubKeys using the old address
 format, with lost funds as a result if bitcoins are sent to them.</ref> is a Bech32 encoding of:
 
-* The human-readable part "bc"<ref>'''Why use 'bc' as human-readable part and not 'btc'?''' 'bc' is shorter.</ref> for mainnet, and "tb"<ref>'''Why use 'tb' as human-readable part for testnet?''' It was chosen to
-be of the same length as the mainnet counterpart (to simplify
-implementations' assumptions about lengths), but still be visually
-distinct.</ref> for testnet.
+* The human-readable part "bc"<ref>'''Why use 'bc' as human-readable part and not
+'btc'?''' 'bc' is shorter.</ref> for mainnet, "tb"<ref>'''Why use 'tb' as
+human-readable part for testnet?''' It was chosen to be of the same length as the
+mainnet counterpart (to simplify implementations' assumptions about lengths), but
+still be visually distinct.</ref> for testnet and "bcrt" for regression testing.
 * The data-part values:
 ** 1 value: the witness version
 ** A conversion of the the 2-to-40-byte witness program (as defined by [https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki BIP141]) to base32:


### PR DESCRIPTION
A mismatch between implementation occurred on the bech32 prefix for
regtest mode.  Bitcoin Core decided to use the `bcrt` prefix in order
for it to be distinguishable from the testnet prefix.  btcd on the other
hand uses the same prefix as testnet because of lack of a separate
prefix specified in this BIP.

Core: https://github.com/bitcoin/bitcoin/issues/12314
btcd: https://github.com/btcsuite/btcd/pull/1150