### PR TITLE
BIP158: include the direct pkScript rather than its data pushes

### DIFF
--- a/bip-0158.mediawiki
+++ b/bip-0158.mediawiki
@@ -268,7 +268,7 @@ The basic filter is designed to contain everything that a light client needs to
 sync a regular Bitcoin wallet. A basic filter MUST contain exactly the following
 items for each transaction in a block:
 * The outpoint of each input, except for the coinbase transaction
-* Each data push in the scriptPubKey of each output, ''only if'' the scriptPubKey is parseable
+* The scriptPubKey of each output
 * The <code>txid</code> of the transaction itself
 
 The extended filter contains extra data that is meant to enable applications


### PR DESCRIPTION
In this commit, we modify regular filter construction slightly.  Rather
than including each pushed data in the script, we instead just include
the script directly, which will eventually be hashed. The rationale for
doing this is two-fold:

  * Most scripts today and in the foreseeable future will just be a
    commitment.

  * Including only the script itself and not the hash of the script
    reduces the worst case filter size. Otherwise, an attacker could
    include a bunch of 2 byte push datas and blow up the filter size for
    all nodes.