### PR TITLE
BIP 174: Clarify that global data can be for inputs and outputs

### DIFF
--- a/bip-0174.mediawiki
+++ b/bip-0174.mediawiki
@@ -108,7 +108,9 @@ The format of each key-value map is as follows:
 
 The first byte of each key specifies the type of the key-value pair. Some types are
 for global fields and other fields are for each input. The only required type in a
-PSBT is the transaction type, as defined below. The currently defined global types are as follows:
+PSBT is the transaction type, as defined below. All global types that can pertain to both
+inputs and outputs of a transaction can include data for both inputs and outputs of
+the transaction. The currently defined global types are as follows:
 
 {| class="wikitable" style="width: auto; text-align: center; font-size: smaller;
 table-layout: fixed;"
@@ -174,7 +176,8 @@ Value:
 | The public key
 | The master key fingerprint concatenated with the derivation path of the public key. The
 derivation path is represented as 32 bit unsigned integer indexes concatenated
-with each other. This must omit the index of the master key.
+with each other. This must omit the index of the master key. Public keys can be those that
+will be needed to sign any type of key hash input or is spent to by an output.
 | Key: 
 <pre>
 {0x03}|{public key}


### PR DESCRIPTION
Clarifies that global data fields redeem scripts, witness scripts,
and hd keypaths can be used for data necessary for both the inputs
and outputs of the transaction.