### PR TITLE
BIP66: link to disclosure of consensus failure bug

### DIFF
--- a/bip-0066.mediawiki
+++ b/bip-0066.mediawiki
@@ -142,3 +142,6 @@ An implementation for the reference client is available at https://github.com/bi
 
 This document is extracted from the previous BIP62 proposal, which had input from various people, in particular Greg Maxwell and Peter Todd, who gave feedback about this document as well. 
 
+==Disclosures==
+
+* Subsequent to the network-wide adoption and enforcement of this BIP, the author [https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2015-July/009697.html disclosed] that strict DER signatures provided an indirect solution to a consensus bug he had previously discovered.


### PR DESCRIPTION
BIP author: @sipa

Recently, a developer learning about Bitcoin contacted me with some questions about BIP66 and I discovered through our conversation that he wasn't aware of what I believe is this important context for the soft fork.  I sent him a link, but I'd like to propose linking to it directly from the BIP for the historical record.

I know modifying *final* BIPs is frowned upon, so if this is unacceptable, I'll add it instead to the wiki page indicated by the Comments-URI field.