### PR TITLE
Specify that points are added in the elliptic curve group

### DIFF
--- a/bip-0032.mediawiki
+++ b/bip-0032.mediawiki
@@ -90,7 +90,7 @@ The function CKDpub((K<sub>par</sub>, c<sub>par</sub>), i) &rarr; (K<sub>i</sub>
 ** If so (hardened child): return failure
 ** If not (normal child): let I = HMAC-SHA512(Key = c<sub>par</sub>, Data = ser<sub>P</sub>(K<sub>par</sub>) || ser<sub>32</sub>(i)).
 * Split I into two 32-byte sequences, I<sub>L</sub> and I<sub>R</sub>.
-* The returned child key K<sub>i</sub> is point(parse<sub>256</sub>(I<sub>L</sub>)) + K<sub>par</sub>.
+* The returned child key K<sub>i</sub> is point(parse<sub>256</sub>(I<sub>L</sub>)) + K<sub>par</sub> (where the plus indicates elliptic curve addition).
 * The returned chain code c<sub>i</sub> is I<sub>R</sub>.
 * In case parse<sub>256</sub>(I<sub>L</sub>) ≥ n or K<sub>i</sub> is the point at infinity, the resulting key is invalid, and one should proceed with the next value for i.
 


### PR DESCRIPTION
The returned child key in CKDpub is the result of elliptic curve addition, not 
regular or Cartesian addition of points.

This is non-trivial to non-mathematicians.