### PR TITLE
Version prefixes for Segwit xpubs

### DIFF
--- a/bip-0032.mediawiki
+++ b/bip-0032.mediawiki
@@ -149,8 +149,8 @@ Extended public and private keys are serialized as follows:
 |0x049d7878 
 |-
 |testnet P2WPKH nested in P2SH (upub/uprv) 
-|0x044a5262|
-|0x044a4e28|
+|0x044a5262
+|0x044a4e28
 |-
 |mainnet P2WPKH (zpub/zprv)
 |0x04b24746

--- a/bip-0032.mediawiki
+++ b/bip-0032.mediawiki
@@ -131,6 +131,7 @@ The first 32 bits of the identifier are called the key fingerprint.
 Extended public and private keys are serialized as follows:
 * 4 byte: version bytes
 
+
 | Wallet Type | Version bytes of Private keys | Version bytes for Public Keys |
 | ----------- | ----------------------------- | ------------------------------|
 | mainnet (xpub/xprv) | 0x0488B21E | 0x0488ADE4 |

--- a/bip-0032.mediawiki
+++ b/bip-0032.mediawiki
@@ -129,14 +129,24 @@ The first 32 bits of the identifier are called the key fingerprint.
 ===Serialization format===
 
 Extended public and private keys are serialized as follows:
-* 4 byte: version bytes (mainnet: 0x0488B21E public, 0x0488ADE4 private; testnet: 0x043587CF public, 0x04358394 private)
+* 4 byte: version bytes
+
+mainnet (xpub/xprv): 0x0488B21E public,0x0488ADE4 private
+testnet (tpub/tprv): 0x043587CF public, 0x04358394 private
+
+mainnet P2WPKH nested in P2SH (ypub/yprv): 0x049d7cb2 public, 0x049d7878 private
+testnet P2WPKH nested in P2SH (upub/uprv): 0x044a5262 public, 0x044a4e28 private
+
+mainnet P2WPKH (zpub/zprv): 0x04b24746 public, 0x04b2430c private
+testnet P2WPKH (vpub/vprv): 0x045f18bc public, 0x045f18bc private 
+ 
 * 1 byte: depth: 0x00 for master nodes, 0x01 for level-1 derived keys, ....
 * 4 bytes: the fingerprint of the parent's key (0x00000000 if master key)
 * 4 bytes: child number. This is ser<sub>32</sub>(i) for i in x<sub>i</sub> = x<sub>par</sub>/i, with x<sub>i</sub> the key being serialized. (0x00000000 if master key)
 * 32 bytes: the chain code
 * 33 bytes: the public key or private key data (ser<sub>P</sub>(K) for public keys, 0x00 || ser<sub>256</sub>(k) for private keys)
 
-This 78 byte structure can be encoded like other Bitcoin data in Base58, by first adding 32 checksum bits (derived from the double SHA-256 checksum), and then converting to the Base58 representation. This results in a Base58-encoded string of up to 112 characters. Because of the choice of the version bytes, the Base58 representation will start with "xprv" or "xpub" on mainnet, "tprv" or "tpub" on testnet.
+This 78 byte structure can be encoded like other Bitcoin data in Base58, by first adding 32 checksum bits (derived from the double SHA-256 checksum), and then converting to the Base58 representation. This results in a Base58-encoded string of up to 112 characters. Because of the choice of the version bytes, the Base58 representation will start with "_prv" or "_pub" with exact prefixes indicated in paranthesis
 
 Note that the fingerprint of the parent only serves as a fast way to detect parent and child nodes in software, and software must be willing to deal with collisions. Internally, the full 160-bit identifier could be used.
 

--- a/bip-0032.mediawiki
+++ b/bip-0032.mediawiki
@@ -131,14 +131,16 @@ The first 32 bits of the identifier are called the key fingerprint.
 Extended public and private keys are serialized as follows:
 * 4 byte: version bytes
 
-mainnet (xpub/xprv): 0x0488B21E public,0x0488ADE4 private
-testnet (tpub/tprv): 0x043587CF public, 0x04358394 private
 
-mainnet P2WPKH nested in P2SH (ypub/yprv): 0x049d7cb2 public, 0x049d7878 private
-testnet P2WPKH nested in P2SH (upub/uprv): 0x044a5262 public, 0x044a4e28 private
+| Wallet Type | Version bytes of Private keys | Version bytes for Public Keys |
+| mainnet (xpub/xprv) | 0x0488B21E | 0x0488ADE4 |
+| testnet (tpub/tprv) | 0x043587CF | 0x04358394 |
 
-mainnet P2WPKH (zpub/zprv): 0x04b24746 public, 0x04b2430c private
-testnet P2WPKH (vpub/vprv): 0x045f18bc public, 0x045f18bc private 
+| mainnet P2WPKH nested in P2SH (ypub/yprv) | 0x049d7cb2 | 0x049d7878 |
+| testnet P2WPKH nested in P2SH (upub/uprv) | 0x044a5262 | 0x044a4e28 |
+
+| mainnet P2WPKH (zpub/zprv) | 0x04b24746 | 0x04b2430c |
+| testnet P2WPKH (vpub/vprv) | 0x045f18bc | 0x045f18bc | 
  
 * 1 byte: depth: 0x00 for master nodes, 0x01 for level-1 derived keys, ....
 * 4 bytes: the fingerprint of the parent's key (0x00000000 if master key)

--- a/bip-0032.mediawiki
+++ b/bip-0032.mediawiki
@@ -131,15 +131,35 @@ The first 32 bits of the identifier are called the key fingerprint.
 Extended public and private keys are serialized as follows:
 * 4 byte: version bytes
 
-
-| Wallet Type | Version bytes of Private keys | Version bytes for Public Keys |
-| ----------- | ----------------------------- | ------------------------------|
-| mainnet (xpub/xprv) | 0x0488B21E | 0x0488ADE4 |
-| testnet (tpub/tprv) | 0x043587CF | 0x04358394 |
-| mainnet P2WPKH nested in P2SH (ypub/yprv) | 0x049d7cb2 | 0x049d7878 |
-| testnet P2WPKH nested in P2SH (upub/uprv) | 0x044a5262 | 0x044a4e28 |
-| mainnet P2WPKH (zpub/zprv) | 0x04b24746 | 0x04b2430c |
-| testnet P2WPKH (vpub/vprv) | 0x045f18bc | 0x045f18bc | 
+{|
+!Wallet Type 
+!Version bytes of Private keys 
+!Version bytes for Public Keys 
+|-
+|mainnet (xpub/xprv)
+|0x0488B21E
+|0x0488ADE4 
+|-
+|testnet (tpub/tprv) 
+|0x043587CF
+|0x04358394
+|-
+|mainnet P2WPKH nested in P2SH (ypub/yprv) 
+|0x049d7cb2
+|0x049d7878 
+|-
+|testnet P2WPKH nested in P2SH (upub/uprv) 
+|0x044a5262|
+|0x044a4e28|
+|-
+|mainnet P2WPKH (zpub/zprv)
+|0x04b24746
+|0x04b2430c 
+|-
+|testnet P2WPKH (vpub/vprv)
+|0x045f18bc
+|0x045f18bc 
+|} 
  
 * 1 byte: depth: 0x00 for master nodes, 0x01 for level-1 derived keys, ....
 * 4 bytes: the fingerprint of the parent's key (0x00000000 if master key)

--- a/bip-0032.mediawiki
+++ b/bip-0032.mediawiki
@@ -131,14 +131,12 @@ The first 32 bits of the identifier are called the key fingerprint.
 Extended public and private keys are serialized as follows:
 * 4 byte: version bytes
 
-
 | Wallet Type | Version bytes of Private keys | Version bytes for Public Keys |
+| ----------- | ----------------------------- | ------------------------------|
 | mainnet (xpub/xprv) | 0x0488B21E | 0x0488ADE4 |
 | testnet (tpub/tprv) | 0x043587CF | 0x04358394 |
-
 | mainnet P2WPKH nested in P2SH (ypub/yprv) | 0x049d7cb2 | 0x049d7878 |
 | testnet P2WPKH nested in P2SH (upub/uprv) | 0x044a5262 | 0x044a4e28 |
-
 | mainnet P2WPKH (zpub/zprv) | 0x04b24746 | 0x04b2430c |
 | testnet P2WPKH (vpub/vprv) | 0x045f18bc | 0x045f18bc | 
  


### PR DESCRIPTION
## Motivation 
Segwit wallets are still using _xpub_  version prefix for segwit in p2sh/native segwit wallets. This is leading to incorrect address derivation from an xpub/xprv 

## Reference Discussion
- Thread from [bitcoin-dev](https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2017-September/014921.html) mailing list
- [Different bip32 prefixes for various output scripts](https://github.com/bitcoinjs/bitcoinjs-lib/issues/934) 

## Implementation
Already in use by [electrum](https://github.com/spesmilo/electrum/blob/b4d71e651b16a16afc427f87542b8fd9e05b66e3/lib/constants.py#L52), samouri and trezor