### PR TITLE
BIP 112: fix typo 

### DIFF
--- a/bip-0112.mediawiki
+++ b/bip-0112.mediawiki
@@ -32,7 +32,7 @@ When executed, if any of the following conditions are true, the script interpret
 ** the transaction version is less than 2; or
 ** the transaction input sequence number disable flag (1 << 31) is set; or
 ** the relative lock-time type is not the same; or
-** the top stack item is greater than the transaction sequence (when masked according to the BIP68);
+** the top stack item is greater than the transaction input sequence (when masked according to the BIP68);
 
 Otherwise, script execution will continue as if a NOP had been executed.
 


### PR DESCRIPTION
The sequence is relative to the input, not the transaction. This may cause confusion