### PR TITLE
Fix a link of BIP 0060

### DIFF
--- a/bip-0060.mediawiki
+++ b/bip-0060.mediawiki
@@ -13,7 +13,7 @@
 
 ==Abstract==
 
-[[BIP 0037]] introduced a new flag to version messages which says whether to relay new transaction messages to that node.
+[[bip-0037.mediawiki|BIP 0037]] introduced a new flag to version messages which says whether to relay new transaction messages to that node.
 
 The protocol version was upgraded to 70001, and the (now accepted) BIP 0037 became implemented.
 


### PR DESCRIPTION
There was an invalid link pointing to BIP 0037.