### PR TITLE
BIP 114: Add DROP after CLTV/CSV opcodes in flattened branches

### DIFF
--- a/bip-0114.mediawiki
+++ b/bip-0114.mediawiki
@@ -212,9 +212,9 @@ The following is the "Hashed TIme-Lock Contract" example in [[bip-0112.mediawiki
     CHECKSIG
 
 To create a MAST Root, it is flattened to 3 mutually exclusive branches:
-    HASH160 <R-HASH> EQUALVERIFY "24h" CHECKSEQUENCEVERIFY <Alice's pubkey> CHECKSIGVERIFY
+    HASH160 <R-HASH> EQUALVERIFY "24h" CHECKSEQUENCEVERIFY DROP <Alice's pubkey> CHECKSIGVERIFY
     HASH160 <Commit-Revocation-Hash> EQUALVERIFY <Bob's pubkey> CHECKSIGVERIFY
-    "Timestamp" CHECKLOCKTIMEVERIFY <Bob's pubkey> CHECKSIGVERIFY
+    "Timestamp" CHECKLOCKTIMEVERIFY DROP <Bob's pubkey> CHECKSIGVERIFY
 
 which significantly improves readability and reduces the witness size when it is redeemed.
 


### PR DESCRIPTION
In the HTLC example https://github.com/bitcoin/bips/blob/master/bip-0114.mediawiki#hashed-time-lock-contract I think there DROP is required after the CSV / CLTV opcodes

There was branch by the same author @jl2012 to make CSV/CLTV actually pop from the stack in MAST, but the behavior is not described or referred to in BIP114 at the moment.