### PR TITLE
[Trivial] typo fix in bip-0032

### DIFF
--- a/bip-0032.mediawiki
+++ b/bip-0032.mediawiki
@@ -150,7 +150,7 @@ The total number of possible extended keypairs is almost 2<sup>512</sup>, but th
 * Calculate I = HMAC-SHA512(Key = "Bitcoin seed", Data = S)
 * Split I into two 32-byte sequences, I<sub>L</sub> and I<sub>R</sub>.
 * Use parse<sub>256</sub>(I<sub>L</sub>) as master secret key, and I<sub>R</sub> as master chain code.
-In case I<sub>L</sub> is 0 or ≥n, the master key is invalid.
+In case parse<sub>256</sub>(I<sub>L</sub>) is 0 or ≥n, the master key is invalid.
 
 <img src=bip-0032/derivation.png></img>
 


### PR DESCRIPTION
parse<sub>256</sub>(I<sub>L</sub>) to compare with an integer