### PR TITLE
Remove erroneous prefix bits from BIP-0039 french wordlist

### DIFF
--- a/bip-0039/french.txt
+++ b/bip-0039/french.txt
@@ -1,4 +1,4 @@
-﻿abaisser
+abaisser
 abandon
 abdiquer
 abeille


### PR DESCRIPTION
This PR seeks to remove a strange prefix found in the french wordlist.

This can be confirmed with `hexdump -C -n 8 bip-0039/french.txt`.

    00000000  ef bb bf 61 62 61 69 73                           |...abais|

The first 8 bytes should be the word `abaisser`.

    00000000  61 62 61 69 73 73 65 72                           |abaisser|