### PR TITLE
[BIP158] Fix test vector link

### DIFF
--- a/bip-0158.mediawiki
+++ b/bip-0158.mediawiki
@@ -433,7 +433,7 @@ gcs_match_any(key: [16]byte, compressed_set: []byte, targets: [][]byte, P: uint,
 
 == Appendix C: Test Vectors ==
 
-Test vectors for a P value of 20 on five testnet blocks, including the filters and filter headers, can be found [[bip-0158/testnet-20.csv|here]]. The code to generate these vectors for P values of 1 through 32 can be found [[bip-0158/gentestvectors.go|here]].
+Test vectors for a P value of 19 on five testnet blocks, including the filters and filter headers, can be found [[bip-0158/testnet-19.json|here]]. The code to generate these vectors for P values of 1 through 32 can be found [[bip-0158/gentestvectors.go|here]].
 
 == References ==
 


### PR DESCRIPTION
Test Vector link is old (P = 20), so replace it new one(P = 19).