### PR TITLE
[Trivial] BIP-70 Fixing sipa's gist proposal url

### DIFF
--- a/bip-0070.mediawiki
+++ b/bip-0070.mediawiki
@@ -314,7 +314,7 @@ http://datatracker.ietf.org/wg/jose/
 Wikipedia's page on Invoices: http://en.wikipedia.org/wiki/Invoice
 especially the list of Electronic Invoice standards
 
-sipa's payment protocol proposal: https://gist.github.com/1237788
+sipa's payment protocol proposal: https://gist.github.com/sipa/1237788
 
 ThomasV's "Signed Aliases" proposal : http://ecdsa.org/bitcoin_URIs.html
 


### PR DESCRIPTION
Came across "broken" url. This should have given a 404, but there is actually a user `1237788`. 