### PR TITLE
bip158: update test vectors

### DIFF
--- a/bip-0158.mediawiki
+++ b/bip-0158.mediawiki
@@ -315,6 +315,8 @@ complete serialization of a filter is:
 * <code>N</code>, encoded as a <code>CompactSize</code>
 * The bytes of the compressed filter itself
 
+A zero element filter MUST be written as one byte containing zeroes.
+
 ==== Signaling ====
 
 This BIP allocates a new service bit:


### PR DESCRIPTION
Added test vector for block `1414221`. In particular this block has no output scripts other than `OP_RETURN`, and it's corresponding filter is `0x00`. Also updated the spec to clarify the same.