### PR TITLE
bip-0159: Fix NODE_NETWORK_LIMITED threshold

### DIFF
--- a/bip-0159.mediawiki
+++ b/bip-0159.mediawiki
@@ -42,7 +42,7 @@ Full nodes following this BIP <I>SHOULD</I> relay address/services (<code>addr</
 
 === Counter-measures for peer fingerprinting ===
 
-Peers may have different prune depths (depending on the peers configuration, disk space, etc.) which can result in a fingerprinting weakness (finding the prune depth through getdata requests). NODE_NETWORK_LIMITED supporting peers <I>SHOULD</I> avoid leaking the prune depth and therefore not serve blocks deeper than the signaled <code>NODE_NETWORK_LIMITED</code> threshold (244 blocks).
+Peers may have different prune depths (depending on the peers configuration, disk space, etc.) which can result in a fingerprinting weakness (finding the prune depth through getdata requests). NODE_NETWORK_LIMITED supporting peers <I>SHOULD</I> avoid leaking the prune depth and therefore not serve blocks deeper than the signaled <code>NODE_NETWORK_LIMITED</code> threshold (288 blocks).
 
 === Risks ===
 


### PR DESCRIPTION
The threshold seems to be 288 (2 * 144).  
https://github.com/jonasschnelli/bitcoin/blob/de74c625833bba8d8171a2d0dd6ede2e9d5da88b/src/validation.h#L207