### PR TITLE
BIP125: rephrase rule 2 for clarity

### DIFF
--- a/bip-0125.mediawiki
+++ b/bip-0125.mediawiki
@@ -51,7 +51,7 @@ transaction) that spends one or more of the same inputs if,
 
 # The original transactions signal replaceability explicitly or through inheritance as described in the above Summary section.
 
-# The replacement transaction does not contain any new unconfirmed inputs that did not previously appear in the mempool. (Unconfirmed inputs are inputs spending outputs from currently unconfirmed transactions.)
+# The replacement transaction may only include an unconfirmed input if that input was included in one of the original transactions.  (An unconfirmed input spends an output from a currently-unconfirmed transaction.)
 
 # The replacement transaction pays an absolute fee of at least the sum paid by the original transactions.
 


### PR DESCRIPTION
It's been reported that the double negative in rule 2 is confusing people (including myself, on re-read).  This PR revises out both negatives and, I believe, significantly improves clarity.

For reference, this document was based on the implementation in Bitcoin Core 0.12.0, which includes [these lines](https://github.com/bitcoin/bitcoin/blob/v0.12.0/src/main.cpp#L1134):

```cpp
            for (unsigned int j = 0; j < tx.vin.size(); j++)
            {
                // We don't want to accept replacements that require low
                // feerate junk to be mined first. Ideally we'd keep track of
                // the ancestor feerates and make the decision based on that,
                // but for now requiring all new inputs to be confirmed works.
                if (!setConflictsParents.count(tx.vin[j].prevout.hash))
                {
                    // Rather than check the UTXO set - potentially expensive -
                    // it's cheaper to just check if the new input refers to a
                    // tx that's in the mempool.
                    if (pool.mapTx.find(tx.vin[j].prevout.hash) != pool.mapTx.end())
                        return state.DoS(0, error("AcceptToMemoryPool: replacement %s adds unconfirmed input, idx %d",
                                                  hash.ToString(), j),
                                         REJECT_NONSTANDARD, "replacement-adds-unconfirmed");
              }
```

Changing this was suggested by @jnewbery, who also reviewed the code in master with me (which is the same but is moved to `validation.cpp`).

CC: @petertodd 

Request to BIP editor @luke-jr: I think your usually policy is to merge policy-acceptable changes to BIPs solely based on the requests of their authors.  As a co-author, I request this be left open for at least one week (December 13th) to give @petertodd a chance to comment if he wants.