### PR TITLE
BIP-84 - Add Version Bytes Section

### DIFF
--- a/bip-0084.mediawiki
+++ b/bip-0084.mediawiki
@@ -56,6 +56,8 @@ To derive the P2WPKH address from the above calculated public key, we use the en
 
 When serializing extended keys, this scheme uses alternate version bytes. Extended public keys use <code>0x04b24746</code> to produce a "zpub" prefix, and private keys use <code>0x04b2430c</code> to produce a "zprv" prefix. Testnet uses <code>0x045f1cf6</code> "vpub" and <code>0x045f18bc</code> "vprv."
 
+Additional registered version bytes are listed in [[https://github.com/satoshilabs/slips/blob/master/slip-0132.md|SLIP-0132]].
+
 
 ==Backwards Compatibility==
 

--- a/bip-0084.mediawiki
+++ b/bip-0084.mediawiki
@@ -51,6 +51,12 @@ To derive the P2WPKH address from the above calculated public key, we use the en
     scriptPubKey: 0 <20-byte-key-hash>
                   (0x0014{20-byte-key-hash})
 
+
+===Extended Key Version===
+
+When serializing extended keys, this scheme uses alternate version bytes. Extended public keys use <code>0x04b24746</code> to produce a "zpub" prefix, and private keys use <code>0x04b2430c</code> to produce a "zprv" prefix.
+
+
 ==Backwards Compatibility==
 
 This BIP is not backwards compatible by design as described under [#considerations]. An incompatible wallet will not discover accounts at all and the user will notice that something is wrong.

--- a/bip-0084.mediawiki
+++ b/bip-0084.mediawiki
@@ -54,7 +54,7 @@ To derive the P2WPKH address from the above calculated public key, we use the en
 
 ===Extended Key Version===
 
-When serializing extended keys, this scheme uses alternate version bytes. Extended public keys use <code>0x04b24746</code> to produce a "zpub" prefix, and private keys use <code>0x04b2430c</code> to produce a "zprv" prefix.
+When serializing extended keys, this scheme uses alternate version bytes. Extended public keys use <code>0x04b24746</code> to produce a "zpub" prefix, and private keys use <code>0x04b2430c</code> to produce a "zprv" prefix. Testnet uses <code>0x045f1cf6</code> "vpub" and <code>0x045f18bc</code> "vprv."
 
 
 ==Backwards Compatibility==


### PR DESCRIPTION
The version bytes to produce "zpub" and "zprv" were not specified originally.

@prusnak 