### PR TITLE
Fix pseudocode on bip-0158

### DIFF
--- a/bip-0158.mediawiki
+++ b/bip-0158.mediawiki
@@ -166,13 +166,14 @@ this is a table of Golomb-Rice coded values using <code>P=2</code>:
 <pre>
 golomb_encode(stream, x: uint64, P: uint):
     let q = x >> P
+    let r = (x & ((1 << p)-1))
 
     while q > 0:
         write_bit(stream, 1)
         q--
     write_bit(stream, 0)
 
-    write_bits_big_endian(stream, x, P)
+    write_bits_big_endian(stream, r, P)
 
 golomb_decode(stream, P: uint) -> uint64:
     let q = 0


### PR DESCRIPTION
The `golomb_encode` function should encode `r` instead of `x`.