### PR TITLE
BIP174: Input Finalizer finalized fields clarifications

### DIFF
--- a/bip-0174.mediawiki
+++ b/bip-0174.mediawiki
@@ -447,7 +447,7 @@ Or, for participants performing fA(psbt) and fB(psbt): Combine(fA(psbt), fB(psbt
 ===Input Finalizer===
 
 The Input Finalizer must only accept a PSBT.
-For each input, the Input Finalizer determines if the input has enough data to pass validation. If it does, it must construct the scriptSig and scriptWitness and place them into the input key-value map.
+For each input, the Input Finalizer determines if the input has enough data to pass validation. If it does, it must construct the <tt>0x07</tt> Finalized scriptSig and <tt>0x08</tt> Finalized scriptWitness and place them into the input key-value map.
 All other data except the UTXO and unknown fields in the input key-value map should be cleared from the PSBT. The UTXO should be kept to allow Transaction Extractors to verify the final network serialized transaction.
 
 ===Transaction Extractor===


### PR DESCRIPTION
While the Transaction Extractor section calls out the 0x05 Finalized scriptSig and 0x06 Finalized scriptWitness, this wasn’t as clear in the Input Finalizer section. 