### PR TITLE
[BIP197] Fix description of Refund Period

### DIFF
--- a/bip-0197.mediawiki
+++ b/bip-0197.mediawiki
@@ -130,7 +130,7 @@ In the case of a default or the lender not accepting the borrower repayment, the
 In the case that either the lender or borrower don’t accept the bid, the lender can seize a percentage of the collateral. The amount is dependent on the amount of collateral locked in the Seizable Collateral and Refundable Collateral script as described in this BIP. During this period, the borrower can also refund the funds locked in the Refundable Collateral script.
 
 ===Refund Period===
-In the case that the lender does not seize the collateral locked in the Seizable Collateral script, then the borrower can refund the funds locked in the Refundable Collateral script.
+In the case that the lender does not seize the collateral locked in the Seizable Collateral script, then the borrower can refund the funds locked in the Seizable Collateral script.
 
 ==Rationale==
 


### PR DESCRIPTION
Since Seizable Collateral script have condition that can be refund by the borrower after the Seizure Period, Therefore, I think,  Seizable Collateral script is correct that the borrower can refund in Refund Period.