### PR TITLE
New BIP: Add OpenRPC Service Discovery To JSON-RPC Services

### DIFF
--- a/bip-032xx.mediawiki
+++ b/bip-032xx.mediawiki
@@ -1,0 +1,58 @@
+= Add OpenRPC Service Discovery To JSON-RPC Services =
+<pre>
+  BIP: ??
+  Layer: API/RPC
+  Title: Add OpenRPC Service Discovery To JSON-RPC Services
+  Author: Shane Jonas <shane.j@etclabs.org>
+          Zachary Belford <zachary.b@etclabs.org>
+  Comments-Summary: No comments yet.
+  Comments-URI: ?
+  Status: Draft
+  Type: Standards Track
+  Created: 2019-04-02
+  License: Apache-2.0
+</pre>
+== Abstract ==
+
+=== What is this? ===
+
+This is a proposal to add [https://github.com/open-rpc/spec OpenRPC] support to existing and future JSON-RPC services by adding the method [https://github.com/open-rpc/spec#service-discovery-method <code>rpc.discover</code>] to the projects [https://www.jsonrpc.org/specification JSON-RPC] APIs, enabling automation and tooling.
+
+== Motivation ==
+
+This was first proposed [https://github.com/etclabscore/ECIPs/blob/master/ECIPs/ECIP-1053.md here as an ECIP], but the benefits of this kind of tooling is apparent across Bitcoin, Ethereum Classic, Ethereum and other JSON-RPC accessible blockchains.
+
+=== What is the problem? ===
+
+* Maintenance time and accuracy on:
+** documentation
+** APIs
+** clients
+* Not all JSON-RPC servers return the same methods or return the same version of the API.
+* There is nothing that provides both human ''and'' machine-readable interfaces to be able to interact with JSON-RPC.
+* Communication between services in different programming languages is not easy.
+* Implementation usually comes at the cost of user experience consuming the API.
+
+== Implementation ==
+
+=== How do I Solve the problem? ===
+
+JSON-RPC APIs can support the OpenRPC specification by implementing a service discovery method that will return the [https://github.com/open-rpc/spec#openrpc-document OpenRPC document] for the JSON-RPC API. The method MUST be named <code>rpc.discover</code>. The <code>rpc.</code> prefix is a reserved method prefix for [https://www.jsonrpc.org/specification JSON-RPC 2.0 Specification] system extensions.
+
+=== Use Case ===
+
+This is the vision for the use case of OpenRPC and how it would relate to Bitcoin:
+
+[[File:https://user-images.githubusercontent.com/364566/55451229-e9eb4780-5586-11e9-9af1-f1097171c837.png|thumb|none|alt=BitcoinOpenRPC|BitcoinOpenRPC]]
+
+== Specification ==
+
+=== What is OpenRPC? ===
+
+The [https://github.com/open-rpc/spec OpenRPC] Specification defines a standard, programming language-agnostic interface description for [https://www.jsonrpc.org/specification JSON-RPC 2.0] APIs, which allows both humans and computers to discover and understand the capabilities of a service without requiring access to source code, additional documentation, or inspection of network traffic. When properly defined via OpenRPC, a consumer can understand and interact with the remote service with a minimal amount of implementation logic, and share these logic patterns across use cases. Similar to what interface descriptions have done for lower-level programming, the OpenRPC Specification removes guesswork in calling a service.
+
+==== Structure ====
+
+This is the structure of an OpenRPC Document:
+
+[[File:https://github.com/open-rpc/design/raw/master/diagrams/structure/OpenRPC_structure.png|thumb|none|alt=openrpc-spec-structure|openrpc-spec-structure]]

--- a/bip-032xx.mediawiki
+++ b/bip-032xx.mediawiki
@@ -56,3 +56,22 @@ The [https://github.com/open-rpc/spec OpenRPC] Specification defines a standard,
 This is the structure of an OpenRPC Document:
 
 [[File:https://github.com/open-rpc/design/raw/master/diagrams/structure/OpenRPC_structure.png|thumb|none|alt=openrpc-spec-structure|openrpc-spec-structure]]
+
+== Rationale ==
+
+=== Why would we do this? ===
+
+Services need to figure out how to talk to each other. If we really want to build the next generation of automation, then having up to date libraries, documented APIs, and modern tools are going to provide easy discovery, on-boarding, and enable end user and developer interaction.
+
+Use cases for machine-readable [https://www.jsonrpc.org/specification JSON-RPC 2.0] API definition documents include, but are not limited to:
+
+* A common vocabulary and document will keep developers, testers, architects, and technical writers all in sync.
+* Server stubs/skeletons generated in many languages
+* Clients generated in many languages
+* Mock Server generated in many languages
+* Tests generated in many languages
+* Documentation Generation
+
+== Alternative ==
+
+[https://github.com/open-rpc/spec OpenRPC] documents just describe [https://www.jsonrpc.org/specification JSON-RPC] APIs services, and are represented in JSON format. These documents may be produced and served statically OR generated dynamically from an application and returned via the [https://github.com/open-rpc/spec#service-discovery-method <code>rpc.discover</code>] method. This gives projects and communities the flexibility to adopt tools before the [https://github.com/open-rpc/spec#service-discovery-method <code>rpc.discover</code>] method is implemented.


### PR DESCRIPTION
This is a proposal to add [OpenRPC](https://github.com/open-rpc/spec) to JSON-RPC services needed to interact with the Bitcoin blockchain.

The [OpenRPC](https://github.com/open-rpc/spec) Specification defines a standard, programming language-agnostic interface description for [JSON-RPC 2.0](https://www.jsonrpc.org/specification) APIs, which allows both humans and computers to discover and understand the capabilities of a service without requiring access to source code, additional documentation, or inspection of network traffic.