### PR TITLE
BIP 144: Old serialization format must be used on empty witness

### DIFF
--- a/bip-0144.mediawiki
+++ b/bip-0144.mediawiki
@@ -79,7 +79,7 @@ The serialization has the following structure:
 
 Parsers supporting this BIP will be able to distinguish between the old serialization format (without the witness) and this one. The marker byte is set to zero so that this structure will never parse as a valid transaction in a parser that does not support this BIP. If parsing were to succeed, such a transaction would contain no inputs and a single output.
 
-If the witness is empty, the old serialization format should be used. 
+If the witness is empty, the old serialization format must be used. 
 
 Currently, the only witness objects type supported are script witnesses which consist of a stack of byte arrays. It is encoded as a var_int item count followed by each item encoded as a var_int length followed by a string of bytes. Each txin has its own script witness. The number of script witnesses is not explicitly encoded as it is implied by txin_count. Empty script witnesses are encoded as a zero byte. The order of the script witnesses follows the same order as the associated txins.
 


### PR DESCRIPTION
At least Bitcoin Core requires the old serialization format in that case, so to pretend that it is optional will only lead to confusion.