### PR TITLE
BIP 158: kill off remnants of filter type 0x01.

### DIFF
--- a/bip-0158.mediawiki
+++ b/bip-0158.mediawiki
@@ -323,7 +323,7 @@ This BIP allocates a new service bit:
 |-
 | NODE_COMPACT_FILTERS
 | style="white-space: nowrap;" | <code>1 << 6</code>
-| If enabled, the node MUST respond to all BIP 157 messages for filter types <code>0x00</code> and <code>0x01</code>
+| If enabled, the node MUST respond to all BIP 157 messages for filter type <code>0x00</code>.
 |}
 
 == Compatibility ==


### PR DESCRIPTION
The Signaling section of the BIP still requires support for filter type 0x01, which has been removed from the BIP.

The change to remove filter type 0x01 is here: https://github.com/bitcoin/bips/commit/4a85759f0229450f4a63b9404dfe8e8c10bdc92e#diff-367f1ff45d7efb5c6774e4112cd17489

It appears at though this reference simply was missed in the change.

@Roasbeef @aakselrod 