### PR TITLE
BIP 158: Updated Golomb-Rice Coded sets Reference Implementation link

### DIFF
--- a/bip-0158.mediawiki
+++ b/bip-0158.mediawiki
@@ -348,7 +348,7 @@ Light client: [https://github.com/lightninglabs/neutrino]
 
 Full-node indexing: https://github.com/Roasbeef/btcd/tree/segwit-cbf
 
-Golomb-Rice Coded sets: https://github.com/Roasbeef/btcutil/tree/gcs/gcs
+Golomb-Rice Coded sets: https://github.com/btcsuite/btcutil/blob/master/gcs
 
 == Appendix A: Alternatives ==
 


### PR DESCRIPTION
The current link references https://github.com/Roasbeef/btcutil/tree/gcs/gcs which is an out of date branch.

I've replaced this with https://github.com/btcsuite/btcutil/blob/master/gcs