### PR TITLE
Reject BIP-0075 (three years inactivity)

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -378,13 +378,13 @@ Those proposing changes should consider that ultimately consent may rest with th
 | Toby Padilla
 | Standard
 | Draft
-|-
+|- style="background-color: #ffcfcf"
 | [[bip-0075.mediawiki|75]]
 | Applications
 | Out of Band Address Exchange using Payment Protocol Encryption
 | Justin Newton, Matt David, Aaron Voisine, James MacWhyte
 | Standard
-| Draft
+| Rejected
 |- style="background-color: #ffffcf"
 | [[bip-0079.mediawiki|79]]
 | Applications

--- a/bip-0075.mediawiki
+++ b/bip-0075.mediawiki
@@ -8,7 +8,7 @@
           James MacWhyte <macwhyte@gmail.com>
   Comments-Summary: Recommended for implementation (one person)
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0075
-  Status: Draft
+  Status: Rejected
   Type: Standards Track
   Created: 2015-11-20
   License: CC-BY-4.0


### PR DESCRIPTION
Per BIP-0002 expiration rules, this can be requested by anybody.