### PR TITLE
BIP-158: Remove some remaining "extended" mentions

### DIFF
--- a/bip-0158.mediawiki
+++ b/bip-0158.mediawiki
@@ -322,7 +322,7 @@ This BIP allocates a new service bit:
 |-
 | NODE_COMPACT_FILTERS
 | style="white-space: nowrap;" | <code>1 << 6</code>
-| If enabled, the node MUST respond to all BIP 157 messages for filter types <code>0x00</code> and <code>0x01</code>
+| If enabled, the node MUST respond to all BIP 157 messages for filter type <code>0x00</code>
 |}
 
 == Compatibility ==


### PR DESCRIPTION
The `extended` filter type was removed in https://github.com/bitcoin/bips/pull/687, but some mentions were still present in the document. They can be confusing.