### PR TITLE
[BIP174] Add PSBT_GLOBAL_XPUB_SIGNATURE to BIP

### DIFF
--- a/bip-0174.mediawiki
+++ b/bip-0174.mediawiki
@@ -124,6 +124,12 @@ The currently defined global types are as follows:
 ** Value: The master key fingerprint as defined by BIP 32 concatenated with the derivation path of the public key. The derivation path is represented as 32 bit unsigned integer indexes concatenated with each other. The number of 32 bit unsigned integer indexes must match the depth provided in the extended public key.
 *** <tt>{master key fingerprint}|{32-bit int}|...|{32-bit int}</tt>
 
+* Type: Extended Public Key Signature <tt>PSBT_GLOBAL_XPUB_SIGNATURE = 0x02</tt>
+** Key: The type followed by the 33 byte compressed DER representation of the signing pubkey, followed by the 78 byte serialized extended public key to be signed as defined by BIP 32. Extended public keys are those that can be used to derive public keys used in the inputs and outputs of this transaction. It should be the public key at the highest hardened derivation index so that the unhardened child keys used in the transaction can be derived.
+*** <tt>{0x02}|{signing_pubkey}|{xpub}</tt>
+** Value: The 64 byte signature (r and s 32 bytes each) of `SHA256(SHA256(xpub))` (digest algorithm is double SHA256 and data to sign is 78 serialized extended public key) from the extended private key of the current signer derived from the signer's root to `m/2042083607'/959190427'/1400854130'/990526201'`.
+*** <tt>{signature}</tt>
+
 The currently defined per-input types are defined as follows:
 
 * Type: Non-Witness UTXO <tt>PSBT_IN_NON_WITNESS_UTXO = 0x00</tt>

--- a/bip-0174.mediawiki
+++ b/bip-0174.mediawiki
@@ -125,9 +125,9 @@ The currently defined global types are as follows:
 *** <tt>{master key fingerprint}|{32-bit int}|...|{32-bit int}</tt>
 
 * Type: Extended Public Key Signature <tt>PSBT_GLOBAL_XPUB_SIGNATURE = 0x02</tt>
-** Key: The type followed by the 33 byte compressed DER representation of the signing pubkey, followed by one byte with the required <tt>m</tt> value for a multisig (set 0 for non-multisig), followed by 1 or more 78 byte serialized extended public keys sorted in canonical order (must have number >= <tt>m</tt> value or exactly one if <tt>m == 0</tt>) as defined by BIP 32. Extended public keys are those that can be used to derive public keys used in the inputs and outputs of this transaction. It should be the public key at the highest hardened derivation index so that the unhardened child keys used in the transaction can be derived.
-*** <tt>{0x02}|{signing_pubkey}|{m}|{xpub}|...|{xpub}</tt>
-** Value: The 64 byte signature (r and s 32 bytes each) of <tt>SHA256(SHA256({m}|{xpub}|...|{xpub}))</tt> (digest algorithm is double SHA256 and data to sign is one byte <tt>m</tt> where 0 is for single sig and >=1 for multisig followed by <tt>n</tt> 78 serialized extended public keys sorted in canonical order where <tt>n >= m</tt> or <tt>n</tt> must be 1 if <tt>m == 0</tt>) from the extended private key of the current signer derived from the signer's root to <tt>m/2042083607'/959190427'/1400854130'/990526201'</tt>.
+** Key: The type followed by the first 4 bytes of the HASH160 of the compressed DER representation of the signing pubkey, followed by one byte with the required <tt>m</tt> value for a multisig (set 0 for non-multisig), followed by 1 or more 78 byte serialized extended public keys sorted in canonical order (must have number >= <tt>m</tt> value or exactly one if <tt>m == 0</tt>) as defined by BIP 32. Extended public keys are those that can be used to derive public keys used in the inputs and outputs of this transaction. It should be the public key at the highest hardened derivation index so that the unhardened child keys used in the transaction can be derived.
+*** <tt>{0x02}|{signing_pubkey_fingerprint}|{m}|{xpub}|...|{xpub}</tt>
+** Value: The 64 byte signature (r and s 32 bytes each) of <tt>SHA256(SHA256({m}|{xpub}|...|{xpub}))</tt> (digest algorithm is double SHA256 and data to sign is one byte <tt>m</tt> where 0 is for single sig and >=1 for multisig followed by <tt>n</tt> 78 serialized extended public keys sorted in canonical order where <tt>n >= m</tt> or <tt>n</tt> must be 1 if <tt>m == 0</tt>) from the extended private key of the current signer derived from the signer's root to <tt>m/2042083607'/959190427'/1400854130'/990526201'</tt> (Magic number, randomly picked only for low likelyhood of overlapping).
 *** <tt>{signature}</tt>
 
 The currently defined per-input types are defined as follows:
@@ -686,6 +686,11 @@ Any data types, their associated scope and BIP number must be defined here
 | Global
 | 0
 | PSBT_GLOBAL_UNSIGNED_TX
+| BIP 174
+|-
+| Global
+| 2
+| PSBT_GLOBAL_XPUB_SIGNATURE
 | BIP 174
 |-
 | Input

--- a/bip-0174.mediawiki
+++ b/bip-0174.mediawiki
@@ -127,7 +127,7 @@ The currently defined global types are as follows:
 * Type: Extended Public Key Signature <tt>PSBT_GLOBAL_XPUB_SIGNATURE = 0x02</tt>
 ** Key: The type followed by the 33 byte compressed DER representation of the signing pubkey, followed by the 78 byte serialized extended public key to be signed as defined by BIP 32. Extended public keys are those that can be used to derive public keys used in the inputs and outputs of this transaction. It should be the public key at the highest hardened derivation index so that the unhardened child keys used in the transaction can be derived.
 *** <tt>{0x02}|{signing_pubkey}|{xpub}</tt>
-** Value: The 64 byte signature (r and s 32 bytes each) of `SHA256(SHA256(xpub))` (digest algorithm is double SHA256 and data to sign is 78 serialized extended public key) from the extended private key of the current signer derived from the signer's root to `m/2042083607'/959190427'/1400854130'/990526201'`.
+** Value: The 64 byte signature (r and s 32 bytes each) of <tt>SHA256(SHA256(xpub))</tt> (digest algorithm is double SHA256 and data to sign is 78 serialized extended public key) from the extended private key of the current signer derived from the signer's root to <tt>m/2042083607'/959190427'/1400854130'/990526201'</tt>.
 *** <tt>{signature}</tt>
 
 The currently defined per-input types are defined as follows:

--- a/bip-0174.mediawiki
+++ b/bip-0174.mediawiki
@@ -125,9 +125,9 @@ The currently defined global types are as follows:
 *** <tt>{master key fingerprint}|{32-bit int}|...|{32-bit int}</tt>
 
 * Type: Extended Public Key Signature <tt>PSBT_GLOBAL_XPUB_SIGNATURE = 0x02</tt>
-** Key: The type followed by the 33 byte compressed DER representation of the signing pubkey, followed by the 78 byte serialized extended public key to be signed as defined by BIP 32. Extended public keys are those that can be used to derive public keys used in the inputs and outputs of this transaction. It should be the public key at the highest hardened derivation index so that the unhardened child keys used in the transaction can be derived.
-*** <tt>{0x02}|{signing_pubkey}|{xpub}</tt>
-** Value: The 64 byte signature (r and s 32 bytes each) of <tt>SHA256(SHA256(xpub))</tt> (digest algorithm is double SHA256 and data to sign is 78 serialized extended public key) from the extended private key of the current signer derived from the signer's root to <tt>m/2042083607'/959190427'/1400854130'/990526201'</tt>.
+** Key: The type followed by the 33 byte compressed DER representation of the signing pubkey, followed by one byte with the required <tt>m</tt> value for a multisig (set 0 for non-multisig), followed by 1 or more 78 byte serialized extended public keys sorted in canonical order (must have number >= <tt>m</tt> value or exactly one if <tt>m == 0</tt>) as defined by BIP 32. Extended public keys are those that can be used to derive public keys used in the inputs and outputs of this transaction. It should be the public key at the highest hardened derivation index so that the unhardened child keys used in the transaction can be derived.
+*** <tt>{0x02}|{signing_pubkey}|{m}|{xpub}|...|{xpub}</tt>
+** Value: The 64 byte signature (r and s 32 bytes each) of <tt>SHA256(SHA256({m}|{xpub}|...|{xpub}))</tt> (digest algorithm is double SHA256 and data to sign is one byte <tt>m</tt> where 0 is for single sig and >=1 for multisig followed by <tt>n</tt> 78 serialized extended public keys sorted in canonical order where <tt>n >= m</tt> or <tt>n</tt> must be 1 if <tt>m == 0</tt>) from the extended private key of the current signer derived from the signer's root to <tt>m/2042083607'/959190427'/1400854130'/990526201'</tt>.
 *** <tt>{signature}</tt>
 
 The currently defined per-input types are defined as follows:


### PR DESCRIPTION
As discussed on the mailing list:
https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2019-June/thread.html#start
Search the page for the following subject:
`BIP174 extension proposal (Global Type: PSBT_GLOBAL_XPUB_SIGNATURE)`

- POR_COMMITMENT is also a separate BIP, but the encoding spec is listed here, so I am following suit.
- Maybe there could be a way to offload the encoding descriptions into a "this key will represent the BIP number" etc. but for now no such spec exists. I may create a new BIP to cover the usage of this data for wallets to implement a whitelist for output verification.

Here is the description of the imagined use case:

1. Securely verify the xpub of the warm / hot wallet.
2. Using the airgap signing tool, sign the xpub with all cold keys.
3. Upload the signature/xpub pairs to the online unsigned transaction
generator.
4. Include one keyval pair per coldkey/xpub pairing.
5. When offline signing, if the wallet detects there is a global keyval
XPUB_SIGNATURE with its pubkey in the key, it must verify that all outputs
have BIP32_DERIVATION and that it can verify the outputs through the
derivation, to the xpub, and to the signature.

The 0x01 global xpub entry allows HW wallet to verify change outputs.

This 0x02 global xpub signature will allow HW wallet to "verify" a whitelisted xpub that it has previously signed. Which is useful if HW wallets create some way for users to exchange xpubs securely. Instead of having to do the secure exchange every time, they would only need to do it once, then refer to the whitelist signature.

I was thinking of adding some extra data for a label which would also be signed, that way Trezor could say "Are you sure you want to pay Cindy?" instead of address verification.

Reducing address reuse is a two pronged motion of encouraging change address rotation (0x01) and encouraging people use new addresses every time (0x02 facilitates features that remove some friction)

Any comments are welcome.

Thanks.