### PR TITLE
BIP-322 updates

### DIFF
--- a/bip-0322.mediawiki
+++ b/bip-0322.mediawiki
@@ -178,3 +178,47 @@ Thanks to David Harding, Jim Posen, Kalle Rosenbaum, Pieter Wuille, and many oth
 == Copyright ==
 
 This document is licensed under the Creative Commons CC0 1.0 Universal license.
+
+== Test vectors ==
+
+* <code>STANDARD_SCRIPT_VERIFY_FLAGS = 01ffdf (131039)</code>
+* <code>address = 2MsnqGxX7Abtn4b379MEpkDaD3VbNKQosd8</code>
+* <code>message = "hello world"</code>
+* <code>sighash = 7b66a1861b4e179e1dbab4702e26bcefeabf1cada7cccc97b6ebaec89a035d84</code> (<code>sha256d("Bitcoin Message:hello world")</code>)
+
+A possible proof is:
+
+* HEX: <code>dfff01000117160014689bbb5d76774321c652832ea209958fa1770b330247304402204368b119399d33b9bc9beef06d713becefd3ac508dc95ff62d1859d4912960c7022063d88ddc648faed710b3f870b7a839fdc1b3bfc3c3bd065df51bbbd8c386c81c012102b4e4c6d5021576a5c0bc4535890c3f17e1ff23a94eac87beb0a5e8747c42d920</code>
+* Base64: <code>3/8BAAEXFgAUaJu7XXZ3QyHGUoMuogmVj6F3CzMCRzBEAiBDaLEZOZ0zubyb7vBtcTvs79OsUI3JX/YtGFnUkSlgxwIgY9iN3GSPrtcQs/hwt6g5/cGzv8PDvQZd9Ru72MOGyBwBIQK05MbVAhV2pcC8RTWJDD8X4f8jqU6sh76wpeh0fELZIA==</code>
+
+Split into components:
+
+{|class="wikitable" style="text-align: center;"
+|-
+!Type
+!Length
+!Name
+!Value
+!Comment
+|-
+|Uint32||4||flags||<code>dfff0100</code>||standard flags used in signing
+|-
+|Uint8||1||entries||<code>01</code>||1 entry
+|-
+|VarInt||1-8||scriptsiglen||<code>17</code>||23 byte scriptsig
+|-
+|Uint8[32]||32||scriptsig||<code>160014689bbb5d76774321c652832ea209958fa1770b33</code>||ScriptSig data
+|-
+|VarInt||1-8||witlen||<code>02</code>||2 entries in witness stack
+|-
+|VarInt||1-8||entry1len||<code>47</code>||71 byte entry
+|-
+|Uint8[71]||71||entry1||<code>304402204368b119399d33b9bc9beef06d713becefd3ac50
+8dc95ff62d1859d4912960c7022063d88ddc648faed710b3
+f870b7a839fdc1b3bfc3c3bd065df51bbbd8c386c81c01</code>||Witness stack item 1
+|-
+|VarInt||1-8||entry2len||<code>21</code>||33 byte entry
+|-
+|Uint8[33]||33||entry2||<code>02b4e4c6d5021576a5c0bc4535890c3f17e1ff23a94eac87
+beb0a5e8747c42d920</code>||Witness stack item 2
+|}

--- a/bip-0322.mediawiki
+++ b/bip-0322.mediawiki
@@ -23,7 +23,7 @@ The current message signing standard only works for P2PKH (1...) addresses. By e
 
 A new structure <code>SignatureProof</code> is added, which is a simple serializable scriptSig & witness container.
 
-Two actions "Sign" and "Verify" are defined along with two *purposes* "SignMessage" and "ProveFunds".
+Two actions "Sign" and "Verify" are defined along with one ''purpose'', "SignMessage", with the ability to expand in the future to add a potential "ProveFunds" purpose.
 
 === SignatureProof container ===
 
@@ -36,11 +36,7 @@ Two actions "Sign" and "Verify" are defined along with two *purposes* "SignMessa
 |-
 |Uint32||4||flags||standard flags (1-to-1 with standard flags in Bitcoin Core)
 |-
-|VarInt||1-8||msglen||Number of bytes in message string, excluding NUL termination
-|-
-|Char*||[msglen]||msg||The message being signed for all subjects, excluding NUL termination
-|-
-|Uint8||1||entries||Number of proof entries<ref><strong>Why support multiple proofs?</strong> In particular with proof of funds, it is non-trivial to check a large number of individual proofs (one per UTXO) for duplicates. Software could be written to do so, but it seems more efficient to build this check into the specification itself.</ref>
+|Uint8||1||entries||number of proof entries<ref><strong>Why support multiple proofs?</strong> It is non-trivial to check a large number of individual proofs for duplicates. Software could be written to do so, but it seems more efficient to build this check into the specification itself.</ref>
 |}
 
 The above is followed by [entries] number of signature entries:
@@ -56,9 +52,9 @@ The above is followed by [entries] number of signature entries:
 |-
 |Uint8*||[scriptsiglen]||scriptsig||ScriptSig data
 |-
-|VarInt||1-8||witlen||Number of bytes in witness data
+|VarInt||1-8||witlen||Number of entries in witness stack
 |-
-|Uint8*||[witlen]||wit||Witness
+|Uint8[]*||[witlen]||wit||Witness stack, as [witlen] uint8* vectors, each one prepended with a varint of its size
 |}
 
 In some cases, the scriptsig or wit may be empty. If both are empty, the proof is incomplete.
@@ -80,36 +76,24 @@ A verification call will return a result code according to the table below.
 |-
 |INVALID||One or more of the given proofs were invalid
 |-
-|SPENT||One or more of the claimed UTXO:s has been spent
-|-
 |ERROR||An error was encountered
 |}
 
 == Signing and Verifying ==
 
-Let there be an empty set `inputs` which is populated and tested at each call to one of the actions below.
+If the challenge consists of a single address and the address is in the P2PK(H) (legacy) format, sign using the legacy format (further information below). Otherwise continue as stated below.
+
+Let there be an empty set <code>inputs</code> which is populated and tested at each call to one of the actions below.
 
 === Purpose: SignMessage ===
 
 The "SignMessage" purpose generates a sighash based on a scriptPubKey and a message. It emits a VALID verification result code unless otherwise stated.
 
-# Return INVALID if scriptPubKey already exists in `inputs` set, otherwise insert it<ref><strong>Why track duplicates?</strong> Because a 3-entry proof is not proving 3 inputs unless they are all distinct</ref>
+# Return INVALID if scriptPubKey already exists in <code>inputs</code> set, otherwise insert it<ref><strong>Why track duplicates?</strong> Because a 3-entry proof is not proving 3 entries unless they are all distinct</ref>
 # Define the message pre-image as the sequence "Bitcoin Message:" concatenated with the message, encoded in UTF-8 using Normalization Form Compatibility Decomposition (NFKD)
 # Let sighash = sha256(sha256(scriptPubKey || pre-image))
 
-=== Purpose: ProveFunds ===
-
-The "ProveFunds" purpose generates a sighash and a scriptPubKey from a transaction, an output index, and a message. For multiple simultaneous proofs, it also requires access to the ordered list of proofs. It emits a VALID verification result code unless otherwise stated.
-
-# Let txid be the transaction ID of the transaction, and vout be the output index corresponding to the index of the output being spent
-# Return INVALID if the txid:vout pair already exists in `inputs` set, otherwise insert it
-# Return SPENT if the txid/vout is not a valid UTXO according to a Bitcoin node<ref><strong>Synced up or not?</strong> A normal verifier would use a synced up node. An auditor checking records from a client that were submitted in the past want to use a node that is synced up to the block corresponding to the proof, or the proof will fail, even if it may have been valid at the time of creation.</ref>
-# Extract scriptPubKey from transaction output
-# Define the message pre-image as the concatenation of the following components:<ref><strong>Why not just the UTXO data?</strong> We want the verifier to be able to challenge the prover with a custom message to sign, or anyone can reuse the POF proof for a set of UTXO:s once they have seen it, and the funds have not yet been spent</ref>
-#* the string "POF:"
-#* the message, encoded in UTF-8 using Normalization Form Compatibility Decomposition (NFKD), including the null terminating character (i.e. write strlen(message) + 1 bytes, for a C string)
-#* all transactions being proven for, as binary txid (little endian uint256) followed by index (little endian uint32), each separated by a single `0x00` byte
-# Let sighash = sha256(sha256(scriptPubKey || pre-image))
+A private key may be used directly to sign a message. In this case, its P2WPKH bech32 address shall be derived, and used as the input.
 
 === Action: Sign ===
 
@@ -118,6 +102,8 @@ The "Sign" action takes as input a purpose. It returns a signature or fails.
 # Obtain the sighash and scriptPubKey from the purpose; FAIL if not VALID
 # Derive the private key privkey for the scriptPubKey; FAIL if not VALID
 # Generate and return a signature sig with privkey=privkey, sighash=sighash
+
+The resulting signature proof should be encoded using base64 encoding.
 
 === Action: Verify ===
 
@@ -139,13 +125,39 @@ Note that the order of the entries in the proof must match the order of the entr
 * If a verification call returns ERROR or INVALID, return ERROR or INVALID immediately, ignoring as yet unverified entries
 * After all verifications complete,
 ** return INCONCLUSIVE if any verification call returned INCONCLUSIVE
-** return SPENT if any verification call returned SPENT
 ** return INCOMPLETE if the INCOMPLETE flag is set
 ** return VALID
 
+== Legacy format ==
+
+The legacy format is restricted to the legacy P2PK(H) address format, and restricted to one single challenge (address).
+
+Any other input (e.g. multiple addresses, or non-P2PK(H) address format(s)) must be signed using the new format described above.
+
+=== Signing ===
+
+Given the P2PK(H) address <code>a</code> and the message <code>m</code>:
+# let <code>p</code> be the pubkey-hash contained in <code>a</code>
+# let <code>x</code> be the private key associated with <code>p</code>
+# let <code>digest</code> be <code>SHA56d("Bitcoin Signed Message:\n"||m)</code>
+# create a compact signature <code>sig</code> (aka "recoverable ECDSA signature") using <code>x</code> on <code>digest</code>
+
+The resulting proof is <code>sig</code>, serialized using the base64 encoding.
+
+=== Verifying ===
+
+Given the P2PK(H) address <code>a</code>, the message <code>m</code>, and the compact signature <code>sig</code>:
+
+# let <code>p</code> be the pubkey-hash contained in <code>a</code>
+# let <code>digest</code> be <code>SHA56d("Bitcoin Signed Message:\n"||m)</code>
+# attempt pubkey recovery for <code>digest</code> using the signature <code>sig</code> and store the resulting pubkey into <code>Q</code>
+## fail verification if pubkey recovery above fails
+# let <code>q</code> be the pubkey-hash of <code>Q</code>
+# if <code>p == q</code>, the proof is valid, otherwise it is invalid
+
 == Compatibility ==
 
-This specification is not backwards compatible with the legacy signmessage/verifymessage specification. However, legacy addresses (1...) may be used in this implementation without any problems.
+This specification is backwards compatible with the legacy signmessage/verifymessage specification through the special case as described above.
 
 == Rationale ==
 
@@ -153,16 +165,15 @@ This specification is not backwards compatible with the legacy signmessage/verif
 
 == Reference implementation ==
 
-To do.
+# Pull request to Bitcoin Core: https://github.com/bitcoin/bitcoin/pull/16440
 
 == Acknowledgements ==
 
-TODO
+Thanks to David Harding, Jim Posen, Kalle Rosenbaum, Pieter Wuille, and many others for their feedback on the specification.
 
 == References ==
 
 # Original mailing list thread: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2018-March/015818.html
-# Pull request, with comments: https://github.com/bitcoin/bips/pull/725
 
 == Copyright ==
 


### PR DESCRIPTION
* Remove ProveFunds purpose (with a note about extensibility) and fix the serialization format.
* Add legacy fallback for P2PK(H) addresses, and flip "Backwards Compatibility" section.
* Note about signing using privkeys directly.
* Add Test Vector
