### PR TITLE
[trivial] BIP-69: Update reference [1] link to bitcoinmagazine.com

### DIFF
--- a/bip-0069.mediawiki
+++ b/bip-0069.mediawiki
@@ -146,7 +146,7 @@ Outputs:
 
 ==References==
 
-* [[https://bitcoinmagazine.com/20273/bitstamp-exchange-activity-trackable-due-multisig-wallet-implementation/|1: Bitstamp Info Leak]]
+* [[https://bitcoinmagazine.com/articles/bitstamp-exchange-activity-trackable-due-multisig-wallet-implementation-1430860151|1: Bitstamp Info Leak]]
 * [[https://github.com/OpenBitcoinPrivacyProject/wallet-ratings/blob/master/2015-1/criteria.md|2: OBPP Random Indexing as Countermeasure]]
 * [[https://github.com/aantonop/bitcoinbook/blob/develop/ch05.asciidoc|3: Mastering Bitcoin]]
 * [[https://en.bitcoin.it/wiki/Script|4: Bitcoin Wiki on Script]]


### PR DESCRIPTION
The [previous link](https://bitcoinmagazine.com/20273/bitstamp-exchange-activity-trackable-due-multisig-wallet-implementation) for reference [1] was broken. A [new link](https://bitcoinmagazine.com/articles/bitstamp-exchange-activity-trackable-due-multisig-wallet-implementation-1430860151.) to the same article fixes this. 