### PR TITLE
travis: add a check for common mistake mediawiki links

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ os: linux
 language: generic
 sudo: false
 script:
+    - scripts/link-format-chk.sh
     - scripts/buildtable.pl >/tmp/table.mediawiki || exit 1
     - diff README.mediawiki /tmp/table.mediawiki | grep '^[<>] |' >/tmp/after.diff || true
     - if git checkout HEAD^ && scripts/buildtable.pl >/tmp/table.mediawiki 2>/dev/null; then diff README.mediawiki /tmp/table.mediawiki | grep '^[<>] |' >/tmp/before.diff || true; newdiff=$(diff -s /tmp/before.diff /tmp/after.diff -u | grep '^+'); if [ -n "$newdiff" ]; then echo "$newdiff"; exit 1; fi; else echo 'Cannot build previous commit table for comparison'; fi

--- a/scripts/link-format-chk.sh
+++ b/scripts/link-format-chk.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2019 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+# Check wrong mediawiki link format
+
+ECODE=0
+FILES=""
+for fname in $(git diff --name-only HEAD $(git merge-base HEAD master)); do
+    if [[ $fname == *.mediawiki ]]; then
+        GRES=$(grep -n '](' $fname)
+        if [ "$GRES" != "" ]; then
+            if [ $ECODE -eq 0 ]; then
+                >&2 echo "Github Mediawiki format writes link as [URL text], not as [text](url):"
+            fi
+            ECODE=1
+            echo "- $fname:$GRES"
+        fi
+    fi
+done
+exit $ECODE


### PR DESCRIPTION
Several BIPs have mistaken links in format [ text ] ( url ) which this travis check will detect and complain about.