### PR TITLE
Update bip-0039 mediawiki page to use a working rust library

### DIFF
--- a/bip-0039.mediawiki
+++ b/bip-0039.mediawiki
@@ -160,7 +160,7 @@ Ruby:
 * https://github.com/sreekanthgs/bip_mnemonic
 
 Rust:
-* https://github.com/infincia/bip39-rs
+* https://github.com/maciejhirsz/tiny-bip39/
 
 Swift:
 * https://github.com/CikeQiu/CKMnemonic


### PR DESCRIPTION
The rust library for bip-0039 currently linked is broken and seemingly abandoned. The updated one is a maintained fork.