### PR TITLE
BIP-0045 - Formatting use <code> tags

### DIFF
--- a/bip-0045.mediawiki
+++ b/bip-0045.mediawiki
@@ -16,7 +16,7 @@
 
 This BIP defines a structure for hierarchical deterministic P2SH multi-party
 multi-signature wallets (HDPM wallets from now on) based on the algorithm
-described in BIP-0032 (BIP32 from now on) and purpose scheme described in 
+described in BIP-0032 (BIP32 from now on) and purpose scheme described in
 BIP-0043 (BIP43 from now on).
 This BIP is a particular application of BIP43.
 
@@ -63,7 +63,7 @@ Hardened derivation is used at this level.
 The index of the party creating a P2SH multisig address. The indices can
 be determined independently by lexicographically sorting the purpose public
 keys of each cosigner. Each cosigner creates addresses on its own branch,
-even though they have independent extended master public key, as explained 
+even though they have independent extended master public key, as explained
 in the "Address generation" section.
 
 Note that the master public key is not shared amongst the cosigners. Only the
@@ -79,12 +79,12 @@ purpose public keys:
 03f76588e06c0d688617ef365d1e58a7f1aa84daa3801380b1e7f12acc9a69cd13
 </pre>
 
-it should use `m / 45 ' / 0 / *` for 
-`039863fb5f07b667d9b1ca68773c6e6cdbcac0088ffba9af46f6f6acd153d44463`, 
-`m / 45 ' / 1 / *` for
-`03a473275a750a20b7b71ebeadfec83130c014da4b53f1c4743fcf342af6589a38`,
-and `m / 45 ' / 2 / *` for
-`03f76588e06c0d688617ef365d1e58a7f1aa84daa3801380b1e7f12acc9a69cd13`,
+it should use <code>m / 45 ' / 0 / *</code> for
+<code>039863fb5f07b667d9b1ca68773c6e6cdbcac0088ffba9af46f6f6acd153d44463</code>,
+<code>m / 45 ' / 1 / *</code> for
+<code>03a473275a750a20b7b71ebeadfec83130c014da4b53f1c4743fcf342af6589a38</code>,
+and <code>m / 45 ' / 2 / *</code> for
+<code>03f76588e06c0d688617ef365d1e58a7f1aa84daa3801380b1e7f12acc9a69cd13</code>,
 as dictated by their lexicographical order.
 
 
@@ -102,7 +102,7 @@ chain is used for addresses which are not meant to be visible outside of the
 wallet and is used for return transaction change.
 
 For example, if cosigner 2 wants to generate a change address, he would use
-`m / 45 ' / 2 / 1 / *`, and `m / 45 ' / 2 / 0 / *` for a receive
+<code>m / 45 ' / 2 / 1 / *</code>, and <code>m / 45 ' / 2 / 0 / *</code> for a receive
 address.
 
 Non-hardened derivation is used at this level.
@@ -118,7 +118,7 @@ Non-hardened derivation is used at this level.
 Each party generates their own extended master keypair and shares the
 extended purpose' public key with the others, which is stored encrypted.
 Each party can generate any of the other's derived public keys, but only
-his own private keys. 
+his own private keys.
 
 ===Address Generation Procedure===
 When generating an address, each party can independently generate the N needed
@@ -137,18 +137,18 @@ others using the next index, and calculate the needed script for the address.
 
 Example: Cosigner #2 wants to receive a payment to the shared wallet. His last
 used index on his own branch is 4. Then, the path for the next receive
-address is `m/45'/2/0/5`. He uses this same path in all of the cosigners
+address is <code>m/45'/2/0/5</code>. He uses this same path in all of the cosigners
 trees to generate a public key for each one, and from that he gets the new
 p2sh address.
 ====Change address case====
 Again, each cosigner generates addresses only on his own branch. One of the
 n cosigners wants to create an outgoing payment, for which he'll need a change
 address. He generates a new address using the same procedure as above, but
-using a separate index to track the used change addresses. 
+using a separate index to track the used change addresses.
 
 Example: Cosigner #5 wants to send a payment from the shared wallet, for which
 he'll need a change address. His last used change index on his own branch is
-11. Then, the path for the next change address is `m/45'/5/1/12`. He uses
+11. Then, the path for the next change address is <code>m/45'/5/1/12</code>. He uses
 this same path in all of the cosigners trees to generate a public key for each
 one, and from that he gets the new p2sh address.
 
@@ -163,7 +163,7 @@ that specific address (using the same path that generated the public key in
 that address, but deriving the private key instead), and sign it. Once the
 proposal reaches m signatures, any cosigner can broadcast it to the network,
 becoming final. The specifics of how this proposal is structured, and the
-protocol to accept or reject it, belong to another BIP, in my opinion. 
+protocol to accept or reject it, belong to another BIP, in my opinion.
 
 ===Address discovery===
 
@@ -171,8 +171,8 @@ When the master seed is imported from an external source the software should
 start to discover the addresses in the following manner:
 
 # for each cosigner:
-# derive the cosigner's node (`m / 45' / cosigner_index`)
-# for both the external and internal chains on this node (`m / 45' / cosigner_index / 0` and `m / 45' / cosigner_index / 1`):
+# derive the cosigner's node (<code>m / 45' / cosigner_index</code>)
+# for both the external and internal chains on this node (<code>m / 45' / cosigner_index / 0</code> and <code>m / 45' / cosigner_index / 1</code>):
 # scan addresses of the chain; respect the gap limit described below
 
 Please note that the algorithm uses the transaction history, not address
@@ -182,7 +182,7 @@ even if the earlier ones don't have transactions
 
 ===Address gap limit===
 
-Address gap limit is currently set to 20. If the software hits 20 unused 
+Address gap limit is currently set to 20. If the software hits 20 unused
 addresses (no transactions associated with that address) in a row, it expects
 there are no used addresses beyond this point and stops searching the address chain.
 
@@ -198,7 +198,7 @@ parties. Here are some explanations about the design decisions made.
 The reason for using separate branches for each cosigner is we don't want
 two of them generating the same address and receiving simultaneous payments
 to it. The ideal case is that each address receives at most one payment,
-requested by the corresponding cosigner. 
+requested by the corresponding cosigner.
 
 ==Examples==
 


### PR DESCRIPTION
Existing doc uses \`\` around code. Proper format calls for `<code>` tags.