### PR TITLE
bip322: fix test-vectors

### DIFF
--- a/bip-0322.mediawiki
+++ b/bip-0322.mediawiki
@@ -230,14 +230,29 @@ All of the above, plus (subject to change):
 
 == Native segwit test vector ==
 
-* <code>address = bcrt1qe7nte4zk4ayly5tc53dtdjupgkz0lr8azx3rzz</code>
-* <code>message = hello</code>
-* <code>sighash = 790eef86c204f0bff969ff822121317aa34eff0215dbd30ccf031e7b2f3f0cc1</code> (<code>sha256d("Bitcoin Signed Message:\n:hello")</code>)
+<pre>
+address      = bcrt1qe7nte4zk4ayly5tc53dtdjupgkz0lr8azx3rzz
+scriptpubkey = 0014cfa6bcd456af49f25178a45ab6cb814584ff8cfd
+message      = hello
+preimage     = 0014cfa6bcd456af49f25178a45ab6cb814584ff8cfd426974636f696e205369
+               676e6564204d6573736167653a0a68656c6c6f
+               (scriptpubkey || "Bitcoin Signed Message:\nhello")
+sighash      = 790eef86c204f0bff969ff822121317aa34eff0215dbd30ccf031e7b2f3f0cc1
+               (sha256d(preimage), displayed in big-endian)
+</pre>
 
-A possible proof is:
+The proof becomes:
 
-* HEX: <code>01000000010002473044022075b4fb40421d55c55462879cb352a85eeb3af2138d3f02902c9143f12870f5f70220119c2995c1661138142f3899c1fd6d1af7e790e0e081be72db9ce7bf5b5b932901210290beccd02b73eca57467b2b6f1e47161a9b76a5e67586e7c1dee9ea6e2dcd869</code>
-* Base64: <code>AQAAAAEAAkcwRAIgdbT7QEIdVcVUYoecs1KoXus68hONPwKQLJFD8Shw9fcCIBGcKZXBZhE4FC84mcH9bRr355Dg4IG+ctuc579bW5MpASECkL7M0Ctz7KV0Z7K28eRxYam3al5nWG58He6epuLc2Gk=</code>
+<pre>
+HEX:    01000000010002473044022075b4fb40421d55c55462879cb352a85eeb3af2138d3f0290
+        2c9143f12870f5f70220119c2995c1661138142f3899c1fd6d1af7e790e0e081be72db9c
+        e7bf5b5b932901210290beccd02b73eca57467b2b6f1e47161a9b76a5e67586e7c1dee9e
+        a6e2dcd869
+
+Base64: AQAAAAEAAkcwRAIgdbT7QEIdVcVUYoecs1KoXus68hONPwKQLJFD8Shw9fcCIBGcKZXBZhE4
+        FC84mcH9bRr355Dg4IG+ctuc579bW5MpASECkL7M0Ctz7KV0Z7K28eRxYam3al5nWG58He6e
+        puLc2Gk=
+</pre>
 
 Split into components:
 


### PR DESCRIPTION
Test vector sighash was described as "sha256d(message)" but it is "sha256d(scriptpubkey || message_magic || message)". Also some formatting changes. (Sorry, I realized this after re-reading the BIP post-merge of last PR)