### PR TITLE
BIP174: Remove misleading sentence

### DIFF
--- a/bip-0174.mediawiki
+++ b/bip-0174.mediawiki
@@ -205,7 +205,7 @@ determine which outputs are change outputs and verify that the change is returni
 * Type:  BIP 32 Derivation Path <tt>PSBT_OUT_BIP32_DERIVATION = 0x02</tt>
 ** Key: The public key
 *** <tt>{0x02}|{public key}</tt>
-** Value: The master key fingerprint concatenated with the derivation path of the public key. The derivation path is represented as 32 bit unsigned integer indexes concatenated with each other. This must omit the index of the master key. Public keys are those needed to spend this output.
+** Value: The master key fingerprint concatenated with the derivation path of the public key. The derivation path is represented as 32 bit unsigned integer indexes concatenated with each other. Public keys are those needed to spend this output.
 *** <tt>{master key fingerprint}|{32-bit int}|...|{32-bit int}</tt>
 
 The transaction format is specified as follows:


### PR DESCRIPTION
The sentence seems to suggest that the "master key fingerprint" can be the fingerprint of any intermediate node on the derivation path, which isn't true.