### PR TITLE
BIP 158: Fix mediawiki syntax typo, Remove remnants of the second filter type

### DIFF
--- a/bip-0158.mediawiki
+++ b/bip-0158.mediawiki
@@ -19,7 +19,7 @@ This BIP describes a structure for compact filters on block data, for use in the
 BIP 157 light client protocol<ref>bip-0157.mediawiki</ref>. The filter
 construction proposed is an alternative to Bloom filters, as used in BIP 37,
 that minimizes filter size by using Golomb-Rice coding for compression. This
-document specifies two initial types of filters based on this construction that
+document specifies one initial filter type based on this construction that
 enables basic wallets and applications with more advanced smart contracts.
 
 == Motivation ==
@@ -284,7 +284,7 @@ We exclude all outputs that start with <code>OP_RETURN</code> in order to allow
 filters to easily be committed to in the future via a soft-fork. A likely area
 for future commitments is an additional <code>OP_RETURN</code> output in the
 coinbase transaction similar to the current witness commitment
-<ref>https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki</rev>. By
+<ref>https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki</ref>. By
 excluding all <code>OP_RETURN</code> outputs we avoid a circular dependency
 between the commitment, and the item being committed to.
 
@@ -322,7 +322,7 @@ This BIP allocates a new service bit:
 |-
 | NODE_COMPACT_FILTERS
 | style="white-space: nowrap;" | <code>1 << 6</code>
-| If enabled, the node MUST respond to all BIP 157 messages for filter types <code>0x00</code> and <code>0x01</code>
+| If enabled, the node MUST respond to all BIP 157 messages for filter type <code>0x00</code>
 |}
 
 == Compatibility ==


### PR DESCRIPTION
Fixes #779. This is a render issue in `<ref>` tag (c.f. https://en.bitcoin.it/w/index.php?title=BIP_0158&oldid=66816#Contents, This syntax error causes the rendering on GitHub to fail: https://github.com/bitcoin/bips/blob/b1b248fc6ade930c4c716eb9fed1b48be6796356/bip-0158.mediawiki#GolombCoded_Set_MultiMatch)
Fixes #783 
Fixes #799 