### PR TITLE
BIP 103: Mark as withdrawn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 os: linux
 language: generic
-sudo: false
 script:
     - scripts/link-format-chk.sh
     - scripts/buildtable.pl >/tmp/table.mediawiki || exit 1

--- a/README.mediawiki
+++ b/README.mediawiki
@@ -469,13 +469,13 @@ Those proposing changes should consider that ultimately consent may rest with th
 | Jeff Garzik
 | Standard
 | Rejected
-|-
+|- style="background-color: #ffcfcf"
 | [[bip-0103.mediawiki|103]]
 | Consensus (hard fork)
 | Block size following technological growth
 | Pieter Wuille
 | Standard
-| Draft
+| Withdrawn
 |-
 | [[bip-0104.mediawiki|104]]
 | Consensus (hard fork)

--- a/bip-0103.mediawiki
+++ b/bip-0103.mediawiki
@@ -5,7 +5,7 @@
   Author: Pieter Wuille <pieter.wuille@gmail.com>
   Comments-Summary: No comments yet.
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0103
-  Status: Draft
+  Status: Withdrawn
   Type: Standards Track
   Created: 2015-07-21
   License: BSD-2-Clause


### PR DESCRIPTION
Obviously it expired, but also see comment here: https://github.com/bitcoin/bips/pull/504#issuecomment-540776823