### PR TITLE
[BIP 141] slight witness version byte push clarification

### DIFF
--- a/bip-0141.mediawiki
+++ b/bip-0141.mediawiki
@@ -83,7 +83,7 @@ If all transactions in a block do not have witness data, the commitment is optio
 
 === Witness program ===
 
-A <code>scriptPubKey</code> (or <code>redeemScript</code> as defined in BIP16/P2SH) that consists of a 1-byte push opcode (for 0 to 16) followed by a data push between 2 and 40 bytes gets a new special meaning. The value of the first push is called the "version byte". The following byte vector pushed is called the "witness program".
+A <code>scriptPubKey</code> (or <code>redeemScript</code> as defined in BIP16/P2SH) that consists of a push opcode, either OP_0 or between OP_1 and OP_16 inclusive(to push stack values 0 to 16) followed by a data push between 2 and 40 bytes gets a new special meaning. The value of the first push is called the "version byte". The following byte vector pushed is called the "witness program".
 
 There are two cases in which witness validation logic are triggered. Each case determines the location of the witness version byte and program, as well as the form of the scriptSig:
 # Triggered by a <code>scriptPubKey</code> that is exactly a push of a version byte, plus a push of a witness program. The scriptSig must be exactly empty or validation fails. (''"native witness program"'')


### PR DESCRIPTION
To me at least, 1-byte push could include `0x01` followed by the version number.