### PR TITLE
BIP174: Fix wrong description about Proprietary Use Type

### DIFF
--- a/bip-0174.mediawiki
+++ b/bip-0174.mediawiki
@@ -132,7 +132,7 @@ The currently defined global types are as follows:
 ** Value: The 32-bit little endian unsigned integer representing the version number of this PSBT. If ommitted, the version number is 0.
 *** <tt>{32-bit int}</tt>
 
-* Type: Version Number <tt>PSBT_GLOBAL_PROPRIETARY = 0xFC</tt>
+* Type: Proprietary Use Type <tt>PSBT_GLOBAL_PROPRIETARY = 0xFC</tt>
 ** Key: Variable length identifier prefix, followed by a subtype, followed by the key data itself.
 *** <tt>{0xFC}|<prefix>|{subtype}|{key data}</tt>
 ** Value: Any value data as defined by the proprietary type user.
@@ -200,7 +200,7 @@ The currently defined per-input types are defined as follows:
 ** Value: The UTF-8 encoded commitment message string for the proof-of-reserves.  See [[bip-0127.mediawiki|BIP 127]] for more information.
 *** <tt>{porCommitment}</tt>
 
-* Type: Version Number <tt>PSBT_INPUT_PROPRIETARY = 0xFC</tt>
+* Type: Proprietary Use Type <tt>PSBT_INPUT_PROPRIETARY = 0xFC</tt>
 ** Key: Variable length identifier prefix, followed by a subtype, followed by the key data itself.
 *** <tt>{0xFC}|<prefix>|{subtype}|{key data}</tt>
 ** Value: Any value data as defined by the proprietary type user.
@@ -228,7 +228,7 @@ determine which outputs are change outputs and verify that the change is returni
 ** Value: The master key fingerprint concatenated with the derivation path of the public key. The derivation path is represented as 32 bit unsigned integer indexes concatenated with each other. Public keys are those needed to spend this output.
 *** <tt>{master key fingerprint}|{32-bit int}|...|{32-bit int}</tt>
 
-* Type: Version Number <tt>PSBT_OUTPUT_PROPRIETARY = 0xFC</tt>
+* Type: Proprietary Use Type <tt>PSBT_OUTPUT_PROPRIETARY = 0xFC</tt>
 ** Key: Variable length identifier prefix, followed by a subtype, followed by the key data itself.
 *** <tt>{0xFC}|<prefix>|{subtype}|{key data}</tt>
 ** Value: Any value data as defined by the proprietary type user.


### PR DESCRIPTION
About BIP-174, `PSBT_GLOBAL_PROPRIETARY`, `PSBT_INPUT_PROPRIETARY`, `PSBT_OUTPUT_PROPRIETARY` key description is incorrectly described as Version Number, so it fix to Proprietary Use Type.