### PR TITLE
BIP174: remove 'first byte is the type' comment for key data

### DIFF
--- a/bip-0174.mediawiki
+++ b/bip-0174.mediawiki
@@ -69,7 +69,7 @@ the length of that data. <tt>{..}</tt> indicates the raw data itself.
 |-
 | Key
 | byte[]
-| The key itself with the first byte being the type of the key-value pair
+| The Key itself
 |-
 | Value Length
 | Compact Size Unsigned Integer


### PR DESCRIPTION
As the key type is now defined as compact size integer, `At the beginning of each key is a compact size unsigned integer representing the type`, the comment in the first table in the document, about first byte of the key being the key type is no longer accurate.

As the structure of the key data is described further in the text after the table, and the comment that it starts with the compact size integer seems a bit long to be in that table, I think it is better to just remove the comment about the key data structure from the table, and leave the explanation to the text after the table.