### PR TITLE
BIP 174: Specify that separator only appears at end of the map

### DIFF
--- a/bip-0174.mediawiki
+++ b/bip-0174.mediawiki
@@ -103,7 +103,7 @@ The format of each key-value map is as follows:
 | separator
 | char
 | <tt>0x00</tt>
-| Must be <tt>0x00</tt>.
+| Must be <tt>0x00</tt> at the end of the map.
 |}
 
 At the beginning of each key is a compact size unsigned integer representing the type.


### PR DESCRIPTION
This can be confusing where someone could think the separator separates the pairs and not the maps.