### PR TITLE
BIP-174: add missing types to Appendix A; fix proprietary type names

### DIFF
--- a/bip-0174.mediawiki
+++ b/bip-0174.mediawiki
@@ -200,7 +200,7 @@ The currently defined per-input types are defined as follows:
 ** Value: The UTF-8 encoded commitment message string for the proof-of-reserves.  See [[bip-0127.mediawiki|BIP 127]] for more information.
 *** <tt>{porCommitment}</tt>
 
-* Type: Proprietary Use Type <tt>PSBT_INPUT_PROPRIETARY = 0xFC</tt>
+* Type: Proprietary Use Type <tt>PSBT_IN_PROPRIETARY = 0xFC</tt>
 ** Key: Variable length identifier prefix, followed by a subtype, followed by the key data itself.
 *** <tt>{0xFC}|<prefix>|{subtype}|{key data}</tt>
 ** Value: Any value data as defined by the proprietary type user.
@@ -228,7 +228,7 @@ determine which outputs are change outputs and verify that the change is returni
 ** Value: The master key fingerprint concatenated with the derivation path of the public key. The derivation path is represented as 32-bit little endian unsigned integer indexes concatenated with each other. Public keys are those needed to spend this output.
 *** <tt>{master key fingerprint}|{32-bit uint}|...|{32-bit uint}</tt>
 
-* Type: Proprietary Use Type <tt>PSBT_OUTPUT_PROPRIETARY = 0xFC</tt>
+* Type: Proprietary Use Type <tt>PSBT_OUT_PROPRIETARY = 0xFC</tt>
 ** Key: Variable length identifier prefix, followed by a subtype, followed by the key data itself.
 *** <tt>{0xFC}|<prefix>|{subtype}|{key data}</tt>
 ** Value: Any value data as defined by the proprietary type user.
@@ -748,6 +748,21 @@ Any data types, their associated scope and BIP number must be defined here
 | PSBT_GLOBAL_UNSIGNED_TX
 | BIP 174
 |-
+| Global
+| 1
+| PSBT_GLOBAL_XPUB
+| BIP 174
+|-
+| Global
+| 251
+| PSBT_GLOBAL_VERSION
+| BIP 174
+|-
+| Global
+| 252
+| PSBT_GLOBAL_PROPRIETARY
+| BIP 174
+|-
 | Input
 | 0
 | PSBT_IN_NON_WITNESS_UTXO
@@ -798,6 +813,11 @@ Any data types, their associated scope and BIP number must be defined here
 | PSBT_IN_POR_COMMITMENT
 | [[bip-0127.mediawiki|BIP 127]]
 |-
+| Input
+| 252
+| PSBT_IN_PROPRIETARY
+| BIP 174
+|-
 | Output
 | 0
 | PSBT_OUT_REDEEM_SCRIPT
@@ -811,5 +831,10 @@ Any data types, their associated scope and BIP number must be defined here
 | Output
 | 2
 | PSBT_OUT_BIP32_DERIVATION
+| BIP 174
+|-
+| Output
+| 252
+| PSBT_OUT_PROPRIETARY
 | BIP 174
 |}


### PR DESCRIPTION
PSBT_INPUT_PROPRIETARY -> PSBT_IN_PROPRIETARY

PSBT_OUTPUT_PROPRIETARY -> PSBT_OUT_PROPRIETARY

to be consistent with other in/out type names that use shortened `IN` and `OUT`