### PR TITLE
linter: avoid false positives such as C++ lambda exprs by only detect…

### DIFF
--- a/scripts/link-format-chk.sh
+++ b/scripts/link-format-chk.sh
@@ -10,7 +10,7 @@ ECODE=0
 FILES=""
 for fname in $(git diff --name-only HEAD $(git merge-base HEAD master)); do
     if [[ $fname == *.mediawiki ]]; then
-        GRES=$(grep -n '](' $fname)
+        GRES=$(grep -n '](http' $fname)
         if [ "$GRES" != "" ]; then
             if [ $ECODE -eq 0 ]; then
                 >&2 echo "Github Mediawiki format writes link as [URL text], not as [text](url):"


### PR DESCRIPTION
…ing links starting with 'http'

Ping @luke-jr: this  makes the linter unable to detect relative links but I think it's good enough, and avoids the false positive in #875.