### PR TITLE
Undefined name: bytearray_cmp --> bytearr_cmp

### DIFF
--- a/bip-0069/bip-0069_examples.py
+++ b/bip-0069/bip-0069_examples.py
@@ -49,7 +49,7 @@ def output_cmp(output_tuple1, output_tuple2):
 	elif (output_tuple1[0] > output_tuple2[0]):
 		return 1
 	#tie-breaker: scriptPubKey_byte_arr
-	return bytearray_cmp(output_tuple1[1], output_tuple2[1])
+	return bytearr_cmp(output_tuple1[1], output_tuple2[1])
 
 def sort_outputs(output_tuples):
 	return sorted(output_tuples, cmp=output_cmp)


### PR DESCRIPTION
As discussed in #619.  `bytearray_cmp` is and undefined name in this context which has the potential to raise NameError at runtime so use `bytearr_cmp()` (which is defined on line 4) instead.