### PR TITLE
Fix links in bip-0119.mediawiki

### DIFF
--- a/bip-0119.mediawiki
+++ b/bip-0119.mediawiki
@@ -536,14 +536,14 @@ for older node versions that can be patched but not upgraded to a newer major re
 
 
 == References ==
-*[[https://utxos.org|utxos.org informational site]]
-*[[https://youtu.be/YxsjdIl0034?t=2451|Scaling Bitcoin Presentation]]
-*[[https://bitcoinops.org/en/newsletters/2019/05/29/|Optech Newsletter Covering OP_CHECKOUTPUTSHASHVERIFY]]
-*[[https://cyber.stanford.edu/sites/g/files/sbiybj9936/f/jeremyrubin.pdf|Structuring Multi Transaction Contracts in Bitcoin]]
-*[[https://github.com/jeremyrubin/lazuli]|Lazuli Notes (ECDSA based N-of-N Signatures for Certified Post-Dated UTXOs)]]
-*[[https://fc16.ifca.ai/bitcoin/papers/MES16.pdf|Bitcoin Covenants]]
-*[[https://bitcointalk.org/index.php?topic=278122.0|CoinCovenants using SCIP signatures, an amusingly bad idea.]]
-*[[https://fc17.ifca.ai/bitcoin/papers/bitcoin17-final28.pdf|Enhancing Bitcoin Transactions with Covenants]]
+*[https://utxos.org utxos.org informational site]
+*[https://www.youtube.com/watch?v=YxsjdIl0034&t=2451 Scaling Bitcoin Presentation]
+*[https://bitcoinops.org/en/newsletters/2019/05/29/ Optech Newsletter Covering OP_CHECKOUTPUTSHASHVERIFY]
+*[https://cyber.stanford.edu/sites/g/files/sbiybj9936/f/jeremyrubin.pdf Structuring Multi Transaction Contracts in Bitcoin]
+*[https://github.com/jeremyrubin/lazuli Lazuli Notes (ECDSA based N-of-N Signatures for Certified Post-Dated UTXOs)]
+*[https://fc16.ifca.ai/bitcoin/papers/MES16.pdf Bitcoin Covenants]
+*[https://bitcointalk.org/index.php?topic=278122.0 CoinCovenants using SCIP signatures, an amusingly bad idea.]
+*[https://fc17.ifca.ai/bitcoin/papers/bitcoin17-final28.pdf Enhancing Bitcoin Transactions with Covenants]
 
 
 ===Note on Similar Alternatives===


### PR DESCRIPTION
One of the links is a 404: https://github.com/jeremyrubin/lazuli]

And the string "youtu.be" is blacklisted (for unknown reason!?) by default mediawiki installations.

This commit fixes those issues and changes all links to use the same syntax.