### PR TITLE
BIP-32: fix RFC link

### DIFF
--- a/bip-0032.mediawiki
+++ b/bip-0032.mediawiki
@@ -81,7 +81,7 @@ The function CKDpriv((k<sub>par</sub>, c<sub>par</sub>), i) &rarr; (k<sub>i</sub
 * The returned chain code c<sub>i</sub> is I<sub>R</sub>.
 * In case parse<sub>256</sub>(I<sub>L</sub>) ≥ n or k<sub>i</sub> = 0, the resulting key is invalid, and one should proceed with the next value for i. (Note: this has probability lower than 1 in 2<sup>127</sup>.)
 
-The HMAC-SHA512 function is specified in [http://tools.ietf.org/html/rfc4231 RFC 4231].
+The HMAC-SHA512 function is specified in [http://tools.ietf.org/html/rfc2104 RFC 2104].
 
 ====Public parent key &rarr; public child key====
 


### PR DESCRIPTION
RFC-4231 is the _ASN.1 identifiers and test vectors_ for HMAC-SHA functions whereas RFC-2104 is the _specification_.