### PR TITLE
Replace elixir bip39 implementation

### DIFF
--- a/bip-0039.mediawiki
+++ b/bip-0039.mediawiki
@@ -138,7 +138,7 @@ Go:
 * https://github.com/tyler-smith/go-bip39
 
 Elixir:
-* https://github.com/izelnakri/mnemonic
+* https://github.com/aerosol/mnemo
 
 Objective-C:
 * https://github.com/nybex/NYMnemonic


### PR DESCRIPTION
Follow up to #883 

Advantages:

 - 100% test coverage + [CI](https://github.com/aerosol/mnemo/actions) set up
 - smaller tests that strictly address properties of the specs
 - documentation
 - [vectors.json](https://github.com/aerosol/mnemo/blob/master/priv/vectors.json) identical to [Trezor's](https://github.com/trezor/python-mnemonic/blob/master/vectors.json) + tests for seed verification with a passphrase
  - idiomatic code, no compilation warnings, no unnecessary conversions to strings containing binary numbers
  - flexible interface, e.g. works with raw binaries as well as hex-encoded
  - does not output 1.5M of text when running tests
  - does not confuse entropy with a private key
  - no commented out code
  - descriptive commit log

@prusnak let me know if you'd like me to squash the commits