### PR TITLE
Add SegWit v0 (P2WPKH+P2WSH) filter type

### DIFF
--- a/bip-0158.mediawiki
+++ b/bip-0158.mediawiki
@@ -264,7 +264,10 @@ against the decompressed GCS contents. See
 === Block Filters ===
 
 This BIP defines one initial filter type:
-* Basic (<code>0x00</code>)
+* Basic (<code>0x00</code>) AND (<code>0x01</code>)
+** <code>M = 784931</code>
+** <code>P = 19</code>
+* P2WPKH (<code>0x02</code>)
 ** <code>M = 784931</code>
 ** <code>P = 19</code>
 

--- a/bip-0158.mediawiki
+++ b/bip-0158.mediawiki
@@ -263,7 +263,7 @@ against the decompressed GCS contents. See
 
 === Block Filters ===
 
-This BIP defines one initial filter type:
+This BIP defines current filter types:
 * Basic (<code>0x00</code>) AND (<code>0x01</code>)
 ** <code>M = 784931</code>
 ** <code>P = 19</code>

--- a/bip-0158.mediawiki
+++ b/bip-0158.mediawiki
@@ -267,9 +267,10 @@ This BIP defines current filter types:
 * Basic (<code>0x00</code>) AND (<code>0x01</code>)
 ** <code>M = 784931</code>
 ** <code>P = 19</code>
-* P2WPKH (<code>0x02</code>)
+* V0 (<code>0x02</code>)
 ** <code>M = 784931</code>
 ** <code>P = 19</code>
+* Invalid (<code>0xFF</code>)
 
 ==== Contents ====
 


### PR DESCRIPTION
- Add `0x01` to the `Basic` filter type to reflect Bitcoin Core's codebase.
- Add `0xFF`, `Invalid` filter filter type to reflect Bitcoin Core's codebase.
- Add new `0x02`, `V0` filter type, which incorporates `P2WPKH`+`P2WSH` scripts to map to PR https://github.com/bitcoin/bitcoin/pull/18223. Thus this PR cannot be merged until https://github.com/bitcoin/bitcoin/pull/18223 PR is merged.