### PR TITLE
BIP 39: Update Rust implementation

### DIFF
--- a/bip-0039.mediawiki
+++ b/bip-0039.mediawiki
@@ -160,7 +160,7 @@ Ruby:
 * https://github.com/sreekanthgs/bip_mnemonic
 
 Rust:
-* https://github.com/infincia/bip39-rs
+* https://github.com/maciejhirsz/tiny-bip39/
 
 Swift:
 * https://github.com/CikeQiu/CKMnemonic


### PR DESCRIPTION
The currently listed Rust implementation of BIP 39 doesn't pass the reference implementation's test vectors.

See --> https://github.com/infincia/bip39-rs/issues/21