### PR TITLE
Reject BIP-0099 (expired)

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -441,13 +441,13 @@ Those proposing changes should consider that ultimately consent may rest with th
 | Mark Friedenbach, Kalle Alm, BtcDrak
 | Standard
 | Draft
-|-
+|- style="background-color: #ffcfcf"
 | [[bip-0099.mediawiki|99]]
 |
 | Motivation and deployment of consensus rule changes ([soft/hard]forks)
 | Jorge Timón
 | Informational
-| Draft
+| Rejected
 |- style="background-color: #ffcfcf"
 | [[bip-0100.mediawiki|100]]
 | Consensus (hard fork)

--- a/bip-0099.mediawiki
+++ b/bip-0099.mediawiki
@@ -4,7 +4,7 @@
   Author: Jorge Timón <jtimon@jtimon.cc>
   Comments-Summary: No comments yet.
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0099
-  Status: Draft
+  Status: Rejected
   Type: Informational
   Created: 2015-06-20
   License: PD


### PR DESCRIPTION
The hard/soft-fork terminology, while widely used, is not clear cut, and given that this has not advanced, it would be best to reject this per BIP-0002 expiration rules.

@jtimon 