### PR TITLE
Reject expired block size BIPs

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -476,34 +476,34 @@ Those proposing changes should consider that ultimately consent may rest with th
 | Pieter Wuille
 | Standard
 | Withdrawn
-|-
+|- style="background-color: #ffcfcf"
 | [[bip-0104.mediawiki|104]]
 | Consensus (hard fork)
 | 'Block75' - Max block size like difficulty
 | t.khan
 | Standard
-| Draft
-|-
+| Rejected
+|- style="background-color: #ffcfcf"
 | [[bip-0105.mediawiki|105]]
 | Consensus (hard fork)
 | Consensus based block size retargeting algorithm
 | BtcDrak
 | Standard
-| Draft
-|-
+| Rejected
+|- style="background-color: #ffcfcf"
 | [[bip-0106.mediawiki|106]]
 | Consensus (hard fork)
 | Dynamically Controlled Bitcoin Block Size Max Cap
 | Upal Chakraborty
 | Standard
-| Draft
-|-
+| Rejected
+|- style="background-color: #ffcfcf"
 | [[bip-0107.mediawiki|107]]
 | Consensus (hard fork)
 | Dynamic limit on the block size
 | Washington Y. Sanchez
 | Standard
-| Draft
+| Rejected
 |- style="background-color: #ffcfcf"
 | [[bip-0109.mediawiki|109]]
 | Consensus (hard fork)

--- a/bip-0104.mediawiki
+++ b/bip-0104.mediawiki
@@ -5,7 +5,7 @@
   Author: t.khan <teekhan42@gmail.com>
   Comments-Summary: No comments yet.
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0104
-  Status: Draft
+  Status: Rejected
   Type: Standards Track
   Created: 2017-01-13
   License: BSD-2-Clause

--- a/bip-0105.mediawiki
+++ b/bip-0105.mediawiki
@@ -5,7 +5,7 @@
   Author: BtcDrak <btcdrak@gmail.com>
   Comments-Summary: No comments yet.
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0105
-  Status: Draft
+  Status: Rejected
   Type: Standards Track
   Created: 2015-08-21
   License: PD

--- a/bip-0106.mediawiki
+++ b/bip-0106.mediawiki
@@ -5,7 +5,7 @@
   Author: Upal Chakraborty <bitcoin@upalc.com>
   Comments-Summary: No comments yet.
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0106
-  Status: Draft
+  Status: Rejected
   Type: Standards Track
   Created: 2015-08-24
 </pre>

--- a/bip-0107.mediawiki
+++ b/bip-0107.mediawiki
@@ -5,7 +5,7 @@
   Author: Washington Y. Sanchez <washington.sanchez@gmail.com>
   Comments-Summary: No comments yet.
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0107
-  Status: Draft
+  Status: Rejected
   Type: Standards Track
   Created: 2015-09-11
   License: PD


### PR DESCRIPTION
These BIPs all suggest changing the block size, they did not get consensus, they did not get a fork, they expired and are now only historically relevant. Marking them as expired per BIP-0002 expiration rules.