### PR TITLE
Mark BIP-0043 as final

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -230,13 +230,13 @@ Those proposing changes should consider that ultimately consent may rest with th
 | Pieter Wuille
 | Standard
 | Final
-|-
+|- style="background-color: #cfffcf"
 | [[bip-0043.mediawiki|43]]
 | Applications
 | Purpose Field for Deterministic Wallets
 | Marek Palatinus, Pavol Rusnak
 | Informational
-| Draft
+| Final
 |- style="background-color: #ffffcf"
 | [[bip-0044.mediawiki|44]]
 | Applications

--- a/bip-0043.mediawiki
+++ b/bip-0043.mediawiki
@@ -6,7 +6,7 @@
           Pavol Rusnak <stick@satoshilabs.com>
   Comments-Summary: No comments yet.
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0043
-  Status: Draft
+  Status: Final
   Type: Informational
   Created: 2014-04-24
 </pre>


### PR DESCRIPTION
Widely in use and used by BIPs 44, 45, 47, 49, 80, 81, 84, and 175 according to [luke-jr](https://github.com/bitcoin/bips/pull/912#issuecomment-621894238)

@prusnak @slush0 Please acknowledge.