### PR TITLE
BIP 158: fix minor formatting issues

### DIFF
--- a/bip-0158.mediawiki
+++ b/bip-0158.mediawiki
@@ -273,10 +273,8 @@ This BIP defines one initial filter type:
 The basic filter is designed to contain everything that a light client needs to
 sync a regular Bitcoin wallet. A basic filter MUST contain exactly the
 following items for each transaction in a block:
-* The previous output script (the script being spent) for each input, except
-  for the coinbase transaction.
-* The scriptPubKey of each output, aside from all <code>OP_RETURN</code> output
-  scripts.
+* The previous output script (the script being spent) for each input, except for the coinbase transaction.
+* The scriptPubKey of each output, aside from all <code>OP_RETURN</code> output scripts.
 
 Any "nil" items MUST NOT be included into the final set of filter elements.
 


### PR DESCRIPTION
The bullet points about the content of basic filters were partly rendered as monospaced:

![grafik](https://user-images.githubusercontent.com/91535/81205856-8cb49780-8fcb-11ea-86e1-b35c726aa2b2.png)


On PR branch:

![grafik](https://user-images.githubusercontent.com/91535/81205753-6bec4200-8fcb-11ea-8597-31f5152a5f0a.png)
