### PR TITLE
Final BIP-0159 (NODE_NETWORK_LIMITED service bit)

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -812,13 +812,13 @@ Those proposing changes should consider that ultimately consent may rest with th
 | Olaoluwa Osuntokun, Alex Akselrod
 | Standard
 | Draft
-|-
+|- style="background-color: #cfffcf"
 | [[bip-0159.mediawiki|159]]
 | Peer Services
 | NODE_NETWORK_LIMITED service bit
 | Jonas Schnelli
 | Standard
-| Draft
+| Final
 |-
 | [[bip-0171.mediawiki|171]]
 | Applications

--- a/bip-0159.mediawiki
+++ b/bip-0159.mediawiki
@@ -5,7 +5,7 @@
   Author: Jonas Schnelli <dev@jonasschnelli.ch>
   Comments-Summary: No comments yet.
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0159
-  Status: Draft
+  Status: Final
   Type: Standards Track
   Created: 2017-05-11
   License: BSD-2-Clause


### PR DESCRIPTION
The linked Bitcoin Core PR has been merged.