### PR TITLE
Fix bip85

### DIFF
--- a/bip-0085.mediawiki
+++ b/bip-0085.mediawiki
@@ -188,12 +188,7 @@ OUTPUT:
 ===HD-Seed WIF===
 Application number: 2'
 
-Uses 256 bits of entropy as the secret exponent to derive a private key and encode as a compressed WIF which will be used as the hdseed for Bitcoin Core wallets.
-
-There is a very small chance that you'll make an invalid key that is zero or bigger than the order of the curve. If this occurs, software should hard fail (forcing users should iterate to the next index).
-
-From BIP32:
-> In case parse<sub>256</sub>(I<sub>L</sub>) is 0 or ≥ n, the resulting key is invalid, and one should proceed with the next value for i. (Note: this has probability lower than 1 in 2<sup>127</sup>.)
+Uses 256 bits[1] of entropy as the secret exponent to derive a private key and encode as a compressed WIF which will be used as the hdseed for Bitcoin Core wallets.
 
 Path format is <code>m/83696968'/2'/{index}'</code>
 
@@ -208,12 +203,7 @@ OUTPUT
 ===XPRV===
 Application number: 32'
 
-Taking 64 bytes of the HMAC digest, the first 32 bytes are the chain code, and second 32 bytes are the private key for BIP32 XPRV value. Child number, depth, and parent fingerprint are forced to zero.
-
-There is a very small chance that you'll make an invalid key that is zero or bigger than the order of the curve. If this occurs, software should hard fail (forcing users should iterate to the next index).
-
-From BIP32:
-> In case parse<sub>256</sub>(I<sub>R</sub>) is 0 or ≥ n, the resulting key is invalid, and one should proceed with the next value for i. (Note: this has probability lower than 1 in 2<sup>127</sup>.)
+Taking 64 bytes of the HMAC digest, the first 32 bytes are the chain code, and second 32 bytes[1] are the private key for BIP32 XPRV value. Child number, depth, and parent fingerprint are forced to zero.
 
 Path format is <code>m/83696968'/32'/{index}'</code>
 
@@ -258,6 +248,13 @@ Many thanks to Peter Gray and Christopher Allen for their input, and to Peter fo
 ==References==
 
 BIP32, BIP39
+
+==Footnotes==
+
+[1] There is a very small chance that you'll make an invalid key that is zero or bigger than the order of the curve. If this occurs, software should hard fail (forcing users should iterate to the next index).
+
+From BIP32:
+> In case parse<sub>256</sub>(I<sub>L</sub>) is 0 or ≥ n, the resulting key is invalid, and one should proceed with the next value for i. (Note: this has probability lower than 1 in 2<sup>127</sup>.)
 
 ==Copyright==
 

--- a/bip-0085.mediawiki
+++ b/bip-0085.mediawiki
@@ -147,7 +147,7 @@ Words Table
 |}
 
 ====12 English words====
-BIP39 English 12 word mnemonic seed 
+BIP39 English 12 word mnemonic seed
 
 128 bits of entropy as input to BIP39 to derive 12 word mnemonic
 
@@ -193,7 +193,7 @@ Uses 256 bits of entropy as the secret exponent to derive a private key and enco
 There is a very small chance that you'll make an invalid key that is zero or bigger than the order of the curve. If this occurs, software should hard fail (forcing users should iterate to the next index).
 
 From BIP32:
-> In case parse<sub>256</sub>(I<sub>L</sub>) ≥ n or k<sub>i</sub> = 0, the resulting key is invalid, and one should proceed with the next value for i. (Note: this has probability lower than 1 in 2<sup>127</sup>.)
+> In case parse<sub>256</sub>(I<sub>L</sub>) is 0 or ≥ n, the resulting key is invalid, and one should proceed with the next value for i. (Note: this has probability lower than 1 in 2<sup>127</sup>.)
 
 Path format is <code>m/83696968'/2'/{index}'</code>
 
@@ -209,6 +209,11 @@ OUTPUT
 Application number: 32'
 
 Taking 64 bytes of the HMAC digest, the first 32 bytes are the chain code, and second 32 bytes are the private key for BIP32 XPRV value. Child number, depth, and parent fingerprint are forced to zero.
+
+There is a very small chance that you'll make an invalid key that is zero or bigger than the order of the curve. If this occurs, software should hard fail (forcing users should iterate to the next index).
+
+From BIP32:
+> In case parse<sub>256</sub>(I<sub>R</sub>) is 0 or ≥ n, the resulting key is invalid, and one should proceed with the next value for i. (Note: this has probability lower than 1 in 2<sup>127</sup>.)
 
 Path format is <code>m/83696968'/32'/{index}'</code>
 


### PR DESCRIPTION
1. changed `parse256(IL) ≥ n or ki = 0` --to-->  `parse256(IL) is 0 or ≥ n ` as there is no new child key `ki` created via `parse256(IL) + kpar (mod n)` therefore it should be clear that we want to check if `parse256(IL)` is not 0 as in master key generation (bip32) not some `ki` that is not even defined.

2. also added incorrect key warning to XPRV part where it should be checked either

3. incorrect key warning is now placed in footnotes