### PR TITLE
added 'btc_hd_wallet' amongst implementations in bip32, bip39, bip85

### DIFF
--- a/bip-0032.mediawiki
+++ b/bip-0032.mediawiki
@@ -274,9 +274,9 @@ Seed (hex): 4b381541583be4423346c643850da4b320e46a87ae3d2a4e6da11eba819cd4acba45
 
 ==Implementations==
 
-Two Python implementations exist:
+Three Python implementations exist:
 
-PyCoin (https://github.com/richardkiss/pycoin) is a suite of utilities for dealing with Bitcoin that includes BIP0032 wallet features.  BIP32Utils (https://pypi.org/project/bip32utils/) is a library and command line interface specifically focused on BIP0032 wallets and scripting.
+PyCoin (https://github.com/richardkiss/pycoin) is a suite of utilities for dealing with Bitcoin that includes BIP0032 wallet features.  BIP32Utils (https://pypi.org/project/bip32utils/) is a library and command line interface specifically focused on BIP0032 wallets and scripting. btc_hd_wallet (https://github.com/scgbckbone/btc-hd-wallet) easy to use python HD (paper) wallet implementation.
 
 2 Java implementations exist: https://github.com/bitsofproof/supernode/blob/1.1/api/src/main/java/com/bitsofproof/supernode/api/ExtendedKey.java and https://github.com/bushidowallet/bushido-java-core/tree/master/src/main/java/com/bushidowallet/core/bitcoin/bip32
 

--- a/bip-0039.mediawiki
+++ b/bip-0039.mediawiki
@@ -175,3 +175,6 @@ C++:
 
 C (with Python/Java/Javascript bindings):
 * https://github.com/ElementsProject/libwally-core
+
+Python:
+* https://github.com/scgbckbone/btc-hd-wallet

--- a/bip-0085.mediawiki
+++ b/bip-0085.mediawiki
@@ -77,6 +77,8 @@ Python library implementation: [https://github.com/ethankosakovsky/bipentropy py
 
 Coldcard Firmware: [https://github.com/Coldcard/firmware/pull/39]
 
+btc_hd_wallet: [https://github.com/scgbckbone/btc-hd-wallet]
+
 ==Applications==
 
 Application number define how entropy will be used post processing. Some basic examples follow:
@@ -147,7 +149,7 @@ Words Table
 |}
 
 ====12 English words====
-BIP39 English 12 word mnemonic seed 
+BIP39 English 12 word mnemonic seed
 
 128 bits of entropy as input to BIP39 to derive 12 word mnemonic
 


### PR DESCRIPTION
I would like to add my HD (paper) wallet implementation to BIP{32,39,85}. It is written as a follow up to reading @jimmysong great book - Programming Bitcoin. 

I had some issues trying to figure out what is going on just by looking on some other python implementations so I decided to write my own as a part of learning process. It should be easy to read and has a heavy load of unit tests. I hope it will help some novice bitcoiners to make their learning curve less steep. 