### PR TITLE
BIP8: Fix pseudocode starting 1 block early

### DIFF
--- a/bip-0008.mediawiki
+++ b/bip-0008.mediawiki
@@ -127,7 +127,7 @@ Note that a block's state never depends on its own nVersion; only on that of its
 
         case STARTED:
             int count = 0;
-            walk = block.parent;
+            walk = block;
             for (i = 0; i < 2016; i++) {
                 walk = walk.parent;
                 if (walk.nVersion & 0xE0000000 == 0x20000000 && (walk.nVersion >> bit) & 1 == 1) {


### PR DESCRIPTION
I'm pretty sure this is what makes sense and what the reference implementation does.