### PR TITLE
BIP 174: clarify format of proprietary extensions.

### DIFF
--- a/bip-0174.mediawiki
+++ b/bip-0174.mediawiki
@@ -133,8 +133,8 @@ The currently defined global types are as follows:
 *** <tt>{32-bit uint}</tt>
 
 * Type: Proprietary Use Type <tt>PSBT_GLOBAL_PROPRIETARY = 0xFC</tt>
-** Key: Variable length identifier prefix, followed by a subtype, followed by the key data itself.
-*** <tt>{0xFC}|<prefix>|{subtype}|{key data}</tt>
+** Key: Compact size unsigned integer, followed by identifier prefix of that length, followed by a subtype, followed by the key data itself.
+*** <tt>{0xFC}|{prefixlen}|<prefix>|{subtype}|{key data}</tt>
 ** Value: Any value data as defined by the proprietary type user.
 *** <tt><data></tt>
 
@@ -201,8 +201,8 @@ The currently defined per-input types are defined as follows:
 *** <tt>{porCommitment}</tt>
 
 * Type: Proprietary Use Type <tt>PSBT_IN_PROPRIETARY = 0xFC</tt>
-** Key: Variable length identifier prefix, followed by a subtype, followed by the key data itself.
-*** <tt>{0xFC}|<prefix>|{subtype}|{key data}</tt>
+** Key: Compact size unsigned integer, followed by identifier prefix of that length, followed by a subtype, followed by the key data itself.
+*** <tt>{0xFC}|{prefixlen}|<prefix>|{subtype}|{key data}</tt>
 ** Value: Any value data as defined by the proprietary type user.
 *** <tt><data></tt>
 
@@ -229,8 +229,8 @@ determine which outputs are change outputs and verify that the change is returni
 *** <tt>{master key fingerprint}|{32-bit uint}|...|{32-bit uint}</tt>
 
 * Type: Proprietary Use Type <tt>PSBT_OUT_PROPRIETARY = 0xFC</tt>
-** Key: Variable length identifier prefix, followed by a subtype, followed by the key data itself.
-*** <tt>{0xFC}|<prefix>|{subtype}|{key data}</tt>
+** Key: Compact size unsigned integer, followed by identifier prefix of that length, followed by a subtype, followed by the key data itself.
+*** <tt>{0xFC}|{prefixlen}|<prefix>|{subtype}|{key data}</tt>
 ** Value: Any value data as defined by the proprietary type user.
 *** <tt><data></tt>
 
@@ -312,10 +312,10 @@ values are valid, then it does not matter which is chosen as either way the tran
 ===Proprietary Use Type===
 
 For all global, per-input, and per-output maps, the types <tt>0xFC</tt> is reserved for proprietary use.
-The proprietary use type requires keys that follow the type with a variable length string identifer, then a subtype.
+The proprietary use type requires keys that follow the type with a compact size unsigned integer representing the length of the string identifer, followed by the string identifier, then a subtype, and finally any key data.
 
 The identifier can be any variable length string that software can use to identify whether the particular data in the proprietary type can be used by it.
-It can also be the empty string and just be a single <tt>0x00</tt> byte although this is not recommended.
+It can also be the empty string although this is not recommended.
 
 The subtype is defined by the proprietary type user and can mean whatever they want it to mean.
 The subtype must also be a compact size unsigned integer in the same form as the normal types.


### PR DESCRIPTION
"Variable length string identifier" is not defined anywhere, and the suggestion
to use "0x00" is also deeply unclear.  I assumed it meant a nul-terminated
string!

Be explicit: you mean it must be a compact siz1\e unsigned int length, followed
by that many identifier bytes, followed by a compact size unsigned int subtype,
followed by optional keydata.

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>