### PR TITLE
BIP174: add hash preimage fields to inputs

### DIFF
--- a/bip-0174.mediawiki
+++ b/bip-0174.mediawiki
@@ -200,6 +200,30 @@ The currently defined per-input types are defined as follows:
 ** Value: The UTF-8 encoded commitment message string for the proof-of-reserves.  See [[bip-0127.mediawiki|BIP 127]] for more information.
 *** <tt>{porCommitment}</tt>
 
+* Type: RIPEMD160 preimage <tt>PSBT_RIPEMD160 = 0x0a</tt>
+** Key: The resulting hash of the preimage
+*** <tt>{0x0a}|{20-byte hash}</tt>
+** Value: The hash preimage, encoded as a byte vector, which must equal the key when run through the `RIPEMD160` algorithm
+*** <tt>{preimage}</tt>
+
+* Type: SHA256 preimage <tt>PSBT_SHA256 = 0x0b</tt>
+** Key: The resulting hash of the preimage
+*** <tt>{0x0b}|{32-byte hash}</tt>
+** Value: The hash preimage, encoded as a byte vector, which must equal the key when run through the `SHA256` algorithm
+*** <tt>{preimage}</tt>
+
+* Type: HASH160 preimage <tt>PSBT_HASH160 = 0x0c</tt>
+** Key: The resulting hash of the preimage
+*** <tt>{0x0c}|{20-byte hash}</tt>
+** Value: The hash preimage, encoded as a byte vector, which must equal the key when run through the `SHA256` algorithm followed by the `RIPEMD160` algorithm
+*** <tt>{preimage}</tt>
+
+* Type: HASH256 preimage <tt>PSBT_HASH256 = 0x0d</tt>
+** Key: The resulting hash of the preimage
+*** <tt>{0x0d}|{32-byte hash}</tt>
+** Value: The hash preimage, encoded as a byte vector, which must equal the key when run through the `SHA256` algorithm twice
+*** <tt>{preimage}</tt>
+
 * Type: Proprietary Use Type <tt>PSBT_IN_PROPRIETARY = 0xFC</tt>
 ** Key: Variable length identifier prefix, followed by a subtype, followed by the key data itself.
 *** <tt>{0xFC}|<prefix>|{subtype}|{key data}</tt>


### PR DESCRIPTION
These fields are needed to solve miniscripts, which may have hash preimage challenges.

See https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2019-March/016720.html for some earlier (very short) discussion.