### PR TITLE
Bip339: small corrections and update spec to match implementation

### DIFF
--- a/bip-0339.mediawiki
+++ b/bip-0339.mediawiki
@@ -18,7 +18,7 @@ based on the BIP 141 wtxid of a transaction, rather than its txid.
 
 ==Motivation==
 
-Historically, the INV messages sent on the Bitcoin peer-to-peer network to
+Historically, the inv messages sent on the Bitcoin peer-to-peer network to
 announce transactions refer to transactions by their txid, which is a hash of
 the transaction that does not include the witness (see BIP 141). This has been
 the case even since Segregated Witness (BIP 141/143/144) has been adopted by
@@ -41,9 +41,9 @@ announcing and fetching transactions.
 
 # A new wtxidrelay message is added, which is defined as an empty message where pchCommand == "wtxidrelay".
 # The protocol version of nodes implementing this BIP must be set to 70016 or higher.
-# The wtxidrelay message must be sent in response to a VERSION message from a peer whose protocol version is >= 70016, and prior to sending a VERACK.
-# A new inv type MSG_WTX (0x00000005) is added, for use in both INV messages and GETDATA requests, indicating that the hash being referenced is a transaction's wtxid. In the case of GETDATA requests, MSG_WTX implies that the transaction being requested should be serialized with witness as well, as described in BIP 144.
-# After a node has sent and received a "wtxidrelay" message to/from a given peer, the node is required to use the MSG_WTX inv-type when announcing transactions to that peer, or requesting announced transactions from that peer.
+# The wtxidrelay message must be sent in response to a version message from a peer whose protocol version is >= 70016, and prior to sending a verack.
+# A new inv type MSG_WTX (0x00000005) is added, for use in both inv messages and getdata requests, indicating that the hash being referenced is a transaction's wtxid. In the case of getdata requests, MSG_WTX implies that the transaction being requested should be serialized with witness as well, as described in BIP 144.
+# After a node has sent and received a wtxidrelay message to/from a given peer, the node is required to use the MSG_WTX inv-type when announcing transactions to that peer, or requesting announced transactions from that peer.
 
 ==Backward compatibility==
 

--- a/bip-0339.mediawiki
+++ b/bip-0339.mediawiki
@@ -41,7 +41,7 @@ announcing and fetching transactions.
 
 # A new wtxidrelay message is added, which is defined as an empty message where pchCommand == "wtxidrelay".
 # The protocol version of nodes implementing this BIP must be set to 70016 or higher.
-# The wtxidrelay message must be sent in response to a version message from a peer whose protocol version is >= 70016, and prior to sending a verack.
+# The wtxidrelay message MUST be sent in response to a version message from a peer whose protocol version is >= 70016 and prior to sending a verack. A wtxidrelay message received after a verack message MUST be ignored or treated as invalid.
 # A new inv type MSG_WTX (0x00000005) is added, for use in both inv messages and getdata requests, indicating that the hash being referenced is a transaction's wtxid. In the case of getdata requests, MSG_WTX implies that the transaction being requested should be serialized with witness as well, as described in BIP 144.
 # After a node has sent and received a wtxidrelay message to/from a given peer, the node is required to use the MSG_WTX inv-type when announcing transactions to that peer, or requesting announced transactions from that peer.
 

--- a/bip-0339.mediawiki
+++ b/bip-0339.mediawiki
@@ -43,7 +43,8 @@ announcing and fetching transactions.
 # The protocol version of nodes implementing this BIP must be set to 70016 or higher.
 # The wtxidrelay message MUST be sent in response to a version message from a peer whose protocol version is >= 70016 and prior to sending a verack. A wtxidrelay message received after a verack message MUST be ignored or treated as invalid.
 # A new inv type MSG_WTX (0x00000005) is added, for use in both inv messages and getdata requests, indicating that the hash being referenced is a transaction's wtxid. In the case of getdata requests, MSG_WTX implies that the transaction being requested should be serialized with witness as well, as described in BIP 144.
-# After a node has sent and received a wtxidrelay message to/from a given peer, the node is required to use the MSG_WTX inv-type when announcing transactions to that peer, or requesting announced transactions from that peer.
+# After a node has received a wtxidrelay message from a peer, the node MUST use the MSG_WTX inv type when announcing transactions to that peer.
+# After receiving an inv message containing a MSG_WTX object, a node SHOULD use a MSG_WTX getdata message to request any announced transactions. A node MAY still request transactions from that peer using MSG_TX getdata messages, such as for transactions not recently announced by that peer (like the parents of recently announced transactions).
 
 ==Backward compatibility==
 


### PR DESCRIPTION
Updates text to match implementation, specifically that it's always permitted to request a transaction using the txid. Also includes some minor tidy-ups.