### PR TITLE
bip-0032: remove the 'Implementations' section

### DIFF
--- a/bip-0032.mediawiki
+++ b/bip-0032.mediawiki
@@ -272,31 +272,6 @@ Seed (hex): 4b381541583be4423346c643850da4b320e46a87ae3d2a4e6da11eba819cd4acba45
 ** ext pub: xpub68NZiKmJWnxxS6aaHmn81bvJeTESw724CRDs6HbuccFQN9Ku14VQrADWgqbhhTHBaohPX4CjNLf9fq9MYo6oDaPPLPxSb7gwQN3ih19Zm4Y
 ** ext prv: xprv9uPDJpEQgRQfDcW7BkF7eTya6RPxXeJCqCJGHuCJ4GiRVLzkTXBAJMu2qaMWPrS7AANYqdq6vcBcBUdJCVVFceUvJFjaPdGZ2y9WACViL4L
 
-==Implementations==
-
-Two Python implementations exist:
-
-PyCoin (https://github.com/richardkiss/pycoin) is a suite of utilities for dealing with Bitcoin that includes BIP0032 wallet features.  BIP32Utils (https://pypi.org/project/bip32utils/) is a library and command line interface specifically focused on BIP0032 wallets and scripting.
-
-2 Java implementations exist: https://github.com/bitsofproof/supernode/blob/1.1/api/src/main/java/com/bitsofproof/supernode/api/ExtendedKey.java and https://github.com/bushidowallet/bushido-java-core/tree/master/src/main/java/com/bushidowallet/core/bitcoin/bip32
-
-A C++ implementation is available at https://github.com/ciphrex/mSIGNA/blob/master/deps/CoinCore/src/hdkeys.h
-
-An Objective-C implementation is available at https://github.com/oleganza/CoreBitcoin/blob/master/CoreBitcoin/BTCKeychain.h
-
-A Ruby implementation is available at https://github.com/GemHQ/money-tree
-
-Two Go implementations exist:
-
-hdkeychain (https://github.com/conformal/btcutil/tree/master/hdkeychain) provides an API for bitcoin hierarchical deterministic extended keys (BIP0032).  Go HD Wallet (https://github.com/WeMeetAgain/go-hdwallet).
-
-Two JavaScript implementations exist: available at https://github.com/sarchar/brainwallet.github.com/tree/bip32 and https://github.com/bitpay/bitcore
-
-A PHP implementation is available at https://github.com/Bit-Wasp/bitcoin-lib-php
-
-A C# implementation is available at https://github.com/MetacoSA/NBitcoin (ExtKey, ExtPubKey)
-
-A Haskell implementation is available at https://github.com/haskoin/haskoin together with a CLI interface at https://github.com/np/hx
 
 ==Acknowledgements==
 


### PR DESCRIPTION
~~This links to a (basic) Python3 implementation which passes all the bip's test vectors.~~

~~There are already two links to Python implementations but both are using Python2,
which was EOL at the begining of the year.~~
https://github.com/bitcoin/bips/pull/962#issuecomment-668274236