### PR TITLE
BIP 174: Fix formatting changes

### DIFF
--- a/bip-0174.mediawiki
+++ b/bip-0174.mediawiki
@@ -143,7 +143,7 @@ The currently defined per-input types are defined as follows:
 * Type: Non-Witness UTXO <tt>PSBT_IN_NON_WITNESS_UTXO = 0x00</tt>
 ** Key: None. The key must only contain the 1 byte type.
 ***<tt>{0x00}</tt>
-** Value: The transaction in network serialization format the current input spends from. This should be present for inputs that spend non-segwit outputs and can be present for inputs that spend segwit outputs. An input can have both <tt>PSBT_IN_NON_WITNESS_UTXO</tt> and <tt>PSBT_IN_WITNESS_UTXO</tt>. <ref>'''Why can both UTXO types be provided?''' Many wallets began requiring the full previous transaction (i.e. <tt>PSBT_IN_NON_WITNESS_UTXO</tt>) for segwit inputs when PSBT was already in use. In order to be compatible with software which were expecting <tt>PSBT_IN_WITNESS_UTXO<tt>, both UTXO types must be allowed.</ref>
+** Value: The transaction in network serialization format the current input spends from. This should be present for inputs that spend non-segwit outputs and can be present for inputs that spend segwit outputs. An input can have both <tt>PSBT_IN_NON_WITNESS_UTXO</tt> and <tt>PSBT_IN_WITNESS_UTXO</tt>. <ref>'''Why can both UTXO types be provided?''' Many wallets began requiring the full previous transaction (i.e. <tt>PSBT_IN_NON_WITNESS_UTXO</tt>) for segwit inputs when PSBT was already in use. In order to be compatible with software which were expecting <tt>PSBT_IN_WITNESS_UTXO</tt>, both UTXO types must be allowed.</ref>
 *** <tt>{transaction}</tt>
 
 * Type: Witness UTXO <tt>PSBT_IN_WITNESS_UTXO = 0x01</tt>


### PR DESCRIPTION
Replaced `<tt>` with `</tt>` that fixes the rendering of the current BIP174. 

Fixes all symbols `&#123;` to be displayed correctly.