### PR TITLE
Update bip79 status

### DIFF
--- a/bip-0079.mediawiki
+++ b/bip-0079.mediawiki
@@ -5,10 +5,11 @@
   Author: Ryan Havar <rhavar@protonmail.com>
   Comments-Summary: No comments yet.
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0079
-  Status: Proposed
+  Status: Replaced
   Type: Informational
   Created: 2018-10-05
   License: CC0-1.0
+  Superseded-By: 78
 </pre>
 
 


### PR DESCRIPTION
Bip78 now replaces bip79. https://github.com/bitcoin/bips/pull/923#issuecomment-634928082

@RHavar