### PR TITLE
BIP155: clarify variable integer format and change time to fixed 32 bit

### DIFF
--- a/bip-0155.mediawiki
+++ b/bip-0155.mediawiki
@@ -46,7 +46,7 @@ The <code>addrv2</code> message is defined as a message where <code>pchCommand =
 It is serialized in the standard encoding for P2P messages.
 Its format is similar to the current <code>addr</code> message format
 <ref>[https://bitcoin.org/en/developer-reference#addr Bitcoin Developer Reference: addr message]</ref>, with the difference that the 
-fixed 16-byte IP address is replaced by a network ID and a variable-length address, and the time and services format has been changed to VARINT.
+fixed 16-byte IP address is replaced by a network ID and a variable-length address, and the services format has been changed to VARINT.
 
 This means that the message contains a serialized <code>std::vector</code> of the following structure:
 
@@ -55,9 +55,9 @@ This means that the message contains a serialized <code>std::vector</code> of th
 !Name
 !Description
 |-
-| <code>VARINT</code> (unsigned)
+| <code>uint32_t</code>
 | <code>time</code>
-| Time that this node was last seen as connected to the network. A time in Unix epoch time format, up to 64 bits wide.
+| Time that this node was last seen as connected to the network. A time in Unix epoch time format.
 |-
 | <code>VARINT</code> (unsigned)
 | <code>services</code>
@@ -143,8 +143,6 @@ The reference implementation is available at (to be done)
 ==Acknowledgements==
 
 - Jonas Schnelli: change <code>services</code> field to VARINT, to make the message more compact in the likely case instead of always using 8 bytes.
-
-- Luke-Jr: change <code>time</code> field to VARINT, for post-2038 compatibility.
 
 - Gregory Maxwell: various suggestions regarding extensibility
 

--- a/bip-0155.mediawiki
+++ b/bip-0155.mediawiki
@@ -46,7 +46,7 @@ The <code>addrv2</code> message is defined as a message where <code>pchCommand =
 It is serialized in the standard encoding for P2P messages.
 Its format is similar to the current <code>addr</code> message format
 <ref>[https://bitcoin.org/en/developer-reference#addr Bitcoin Developer Reference: addr message]</ref>, with the difference that the 
-fixed 16-byte IP address is replaced by a network ID and a variable-length address, and the services format has been changed to VARINT.
+fixed 16-byte IP address is replaced by a network ID and a variable-length address, and the services format has been changed to [https://en.bitcoin.it/wiki/Protocol_documentation#Variable_length_integer CompactSize].
 
 This means that the message contains a serialized <code>std::vector</code> of the following structure:
 
@@ -59,9 +59,9 @@ This means that the message contains a serialized <code>std::vector</code> of th
 | <code>time</code>
 | Time that this node was last seen as connected to the network. A time in Unix epoch time format.
 |-
-| <code>VARINT</code> (unsigned)
+| <code>CompactSize</code>
 | <code>services</code>
-| Service bits. A 64-wide bit field.
+| Service bits. A bit field that is 64 bits wide, encoded in [https://en.bitcoin.it/wiki/Protocol_documentation#Variable_length_integer CompactSize].
 |-
 | <code>uint8_t</code>
 | <code>networkID</code>
@@ -142,7 +142,7 @@ The reference implementation is available at (to be done)
 
 ==Acknowledgements==
 
-- Jonas Schnelli: change <code>services</code> field to VARINT, to make the message more compact in the likely case instead of always using 8 bytes.
+- Jonas Schnelli: change <code>services</code> field to [https://en.bitcoin.it/wiki/Protocol_documentation#Variable_length_integer CompactSize], to make the message more compact in the likely case instead of always using 8 bytes.
 
 - Gregory Maxwell: various suggestions regarding extensibility
 


### PR DESCRIPTION
* Clarify that by `VARINT` (variable integer) we mean [`CompactSize`](https://en.bitcoin.it/wiki/Protocol_documentation#Variable_length_integer), not `VARINT` (as in the source code) (huh!?). Relevant IRC discussion: http://www.erisian.com.au/bitcoin-core-dev/log-2020-07-27.html#l-94

* Change `time` to fixed 32 bits as that will work until year 2106, not just 2038 and takes 1 byte less than a variable integer format.