### PR TITLE
Reject 38 (expired)

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -195,13 +195,13 @@ Those proposing changes should consider that ultimately consent may rest with th
 | Mike Hearn, Matt Corallo
 | Standard
 | Final
-|-
+|- style="background-color: #ffcfcf"
 | [[bip-0038.mediawiki|38]]
 | Applications
 | Passphrase-protected private key
 | Mike Caldwell, Aaron Voisine
 | Standard
-| Draft
+| Rejected
 |- style="background-color: #ffffcf"
 | [[bip-0039.mediawiki|39]]
 | Applications

--- a/bip-0038.mediawiki
+++ b/bip-0038.mediawiki
@@ -6,7 +6,7 @@
           Aaron Voisine <voisine@gmail.com>
   Comments-Summary: Unanimously Discourage for implementation
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0038
-  Status: Draft (Some confusion applies: The announcements for this never made it to the list, so it hasn't had public discussion)
+  Status: Rejected
   Type: Standards Track
   Created: 2012-11-20
   License: PD


### PR DESCRIPTION
I request BIP-0038 marked as expired, since three years have passed since the last progress in this proposal. There is not consensus for its adoption, so it can be marked as rejected per BIP-0002 rules. I am not affiliated with this BIP.

paging @voisine (noted author) and @ricmoo which commented on #72. 