### PR TITLE
Reject 114 (expired)

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -546,13 +546,13 @@ Those proposing changes should consider that ultimately consent may rest with th
 | Thomas Kerin, Mark Friedenbach
 | Standard
 | Final
-|-
+|- style="background-color: #ffcfcf"
 | [[bip-0114.mediawiki|114]]
 | Consensus (soft fork)
 | Merkelized Abstract Syntax Tree
 | Johnson Lau
 | Standard
-| Draft
+| Rejected
 |- style="background-color: #ffcfcf"
 | [[bip-0115.mediawiki|115]]
 | Consensus (soft fork)

--- a/bip-0114.mediawiki
+++ b/bip-0114.mediawiki
@@ -5,7 +5,7 @@
   Author: Johnson Lau <jl2012@xbt.hk>
   Comments-Summary: No comments yet.
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0114
-  Status: Draft
+  Status: Rejected
   Type: Standards Track
   Created: 2016-04-02
   License: PD


### PR DESCRIPTION
This BIP by @jl2012 has been superseded by Taproot, I believe. I am not affiliated with this BIP, but I can request its rejection per BIP-0002 rules, since three years have passed since the last progress.