### PR TITLE
Slight cleanup of signet commitment description

### DIFF
--- a/bip-0325.mediawiki
+++ b/bip-0325.mediawiki
@@ -26,12 +26,14 @@ A new type of test network would be more suitable for integration testing by org
 
 A new type of network ("signet"), which takes an additional consensus parameter called the challenge (scriptPubKey). The challenge can be a simple pubkey (P2PKH style), or a k-of-n multisig, or any other script you would want.
 
-The witness commitment of the coinbase transaction is extended to include a secondary commitment (the signature/solution) of either:
+In order to provide a non-empty solution to the block challenge the block's BIP 141 commitment's optional data must include an additional commitment of the signature/solution for the block:
 
     1-5 bytes - Push the following (4 + x + y) bytes
     4 bytes - Signet header (0xecc7daa2)
     x bytes - scriptSig
     y bytes - scriptWitness
+
+In the special case where an empty solution is valid (ie scriptSig and scriptWitness are both empty) this additional commitment can optionally be left out. This special case is to allow non-signet-aware block generation code to be used to test a custom signet chain where the challenge is trivially true.
 
 The scriptSig is serialized by first encoding its length as CompactSize. If the scriptWitness is empty, it is encoded as 0 bytes, otherwise it is encoded in the usual way (see BIP 141 "witness" encoding).
 

--- a/bip-0325.mediawiki
+++ b/bip-0325.mediawiki
@@ -26,7 +26,7 @@ A new type of test network would be more suitable for integration testing by org
 
 A new type of network ("signet"), which takes an additional consensus parameter called the challenge (scriptPubKey). The challenge can be a simple pubkey (P2PKH style), or a k-of-n multisig, or any other script you would want.
 
-In order to provide a non-empty solution to the block challenge the block's BIP 141 commitment's optional data must include an additional commitment of the signature/solution for the block:
+Signet requires all blocks to have a BIP 141 commitment in the coinbase transaction. In order to provide a non-empty solution to the block challenge the block's BIP 141 commitment's optional data must include an additional commitment of the signature/solution for the block:
 
     1-5 bytes - Push the following (4 + x + y) bytes
     4 bytes - Signet header (0xecc7daa2)


### PR DESCRIPTION
"either" and "Signet scriptSig header" seem to make no sense here, if other touchups are disagreeable I can drop them.