### PR TITLE
BIP 325: Clarify that scriptWitness is a stack, not a byte string

### DIFF
--- a/bip-0325.mediawiki
+++ b/bip-0325.mediawiki
@@ -21,7 +21,6 @@ Testnet is a great place to try out new things without risking real money, but i
 
 A new type of test network would be more suitable for integration testing by organizations such as exchanges, or testing of next generation Layer-2 protocols like Eltoo or sidechain pegs. The goal is not to be perfectly reliable but rather to have a predictable amount of unreliability. You want a test network to behave like mainnet (i.e. no thousands of block reorgs) while also making it easier to trigger expected but rare events like a 6-block reorg. Regtest is not suitable for longer-term scenarios involving multiple independent parties because creating blocks costs nothing, so any party can completely control the test network.
 
-
 == Specification ==
 
 A new type of network ("signet"), which takes an additional consensus parameter called the challenge (scriptPubKey). The challenge can be a simple pubkey (P2PKH style), or a k-of-n multisig, or any other script you would want.
@@ -33,7 +32,7 @@ The witness commitment of the coinbase transaction is extended to include a seco
     x bytes - scriptSig
     y bytes - scriptWitness
 
-The scriptSig is serialized by first encoding its length as CompactSize. If the scriptWitness is empty, it is encoded as 0 bytes, otherwise it is encoded in the usual way (see BIP 141 "witness" encoding).
+The scriptSig is serialized by first encoding its length as CompactSize. The scriptWitness stack is serialized as described in BIP 141.
 
 Any push operations that do not start with the 4 byte Signet header are ignored. Multiple push operations with the 4 byte Signet header are ignored except for the first instance of the header.
 


### PR DESCRIPTION
Strictly speaking the bip isn't wrong. It just happens that an empty byte vector is serialized identical to an empty vector of any other type, but it takes the reader an extra step. Thus, the minor fixup suggestion.