### PR TITLE
Update bip-0001.mediawiki

### DIFF
--- a/bip-0001.mediawiki
+++ b/bip-0001.mediawiki
@@ -6,7 +6,7 @@
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0001
   Status: Replaced
   Type: Process
-  Created: 2011-08-19
+  Created: 2011-09-19
   Superseded-By: 2
 </pre>
 


### PR DESCRIPTION
It seems the date is wrong for when this BIP was created. I see here (https://sourceforge.net/p/bitcoin/mailman/message/28106734/) it looks like it was published on 9/19/11. I don't see any earlier entries on the mailing list that would suggest the 8/19 date is accurate (but could be wrong).