### PR TITLE
BIP174: add `_IN_` to names of new hash preimage fields

### DIFF
--- a/bip-0174.mediawiki
+++ b/bip-0174.mediawiki
@@ -200,25 +200,25 @@ The currently defined per-input types are defined as follows:
 ** Value: The UTF-8 encoded commitment message string for the proof-of-reserves.  See [[bip-0127.mediawiki|BIP 127]] for more information.
 *** <tt>{porCommitment}</tt>
 
-* Type: RIPEMD160 preimage <tt>PSBT_RIPEMD160 = 0x0a</tt>
+* Type: RIPEMD160 preimage <tt>PSBT_IN_RIPEMD160 = 0x0a</tt>
 ** Key: The resulting hash of the preimage
 *** <tt>{0x0a}|{20-byte hash}</tt>
 ** Value: The hash preimage, encoded as a byte vector, which must equal the key when run through the `RIPEMD160` algorithm
 *** <tt>{preimage}</tt>
 
-* Type: SHA256 preimage <tt>PSBT_SHA256 = 0x0b</tt>
+* Type: SHA256 preimage <tt>PSBT_IN_SHA256 = 0x0b</tt>
 ** Key: The resulting hash of the preimage
 *** <tt>{0x0b}|{32-byte hash}</tt>
 ** Value: The hash preimage, encoded as a byte vector, which must equal the key when run through the `SHA256` algorithm
 *** <tt>{preimage}</tt>
 
-* Type: HASH160 preimage <tt>PSBT_HASH160 = 0x0c</tt>
+* Type: HASH160 preimage <tt>PSBT_IN_HASH160 = 0x0c</tt>
 ** Key: The resulting hash of the preimage
 *** <tt>{0x0c}|{20-byte hash}</tt>
 ** Value: The hash preimage, encoded as a byte vector, which must equal the key when run through the `SHA256` algorithm followed by the `RIPEMD160` algorithm
 *** <tt>{preimage}</tt>
 
-* Type: HASH256 preimage <tt>PSBT_HASH256 = 0x0d</tt>
+* Type: HASH256 preimage <tt>PSBT_IN_HASH256 = 0x0d</tt>
 ** Key: The resulting hash of the preimage
 *** <tt>{0x0d}|{32-byte hash}</tt>
 ** Value: The hash preimage, encoded as a byte vector, which must equal the key when run through the `SHA256` algorithm twice

--- a/bip-0174.mediawiki
+++ b/bip-0174.mediawiki
@@ -839,6 +839,26 @@ Any data types, their associated scope and BIP number must be defined here
 | [[bip-0127.mediawiki|BIP 127]]
 |-
 | Input
+| 10
+| PSBT_IN_RIPEMD160
+| BIP 174
+|-
+| Input
+| 11
+| PSBT_IN_SHA256
+| BIP 174
+|-
+| Input
+| 12
+| PSBT_IN_HASH160
+| BIP 174
+|-
+| Input
+| 13
+| PSBT_IN_HASH256
+| BIP 174
+|-
+| Input
 | 252
 | PSBT_IN_PROPRIETARY
 | BIP 174


### PR DESCRIPTION
As observed in https://github.com/bitcoin/bips/pull/955 input fields should have `_IN_` in their names.