### PR TITLE
bip-0325: clarify the OP_TRUE challenge special case

### DIFF
--- a/bip-0325.mediawiki
+++ b/bip-0325.mediawiki
@@ -65,9 +65,11 @@ The "to_sign" transaction is:
 
 The scriptSig and/or scriptWitness for <code>vin[0]</code> are filled in from the Signet header push above.
 
-To simplify block generation (mining), the signature also does not commit to the the block nonce value, so that rolling the nonce to generate proof-of-work does not also require regenerating signatures. When grinding proof of work, the extended nonce cannot be used as it would invalidate the signature. Instead, simply resigning the same (or an updated) block will give a new search space.
+To simplify block generation (mining), the signature also does not commit to the block nonce value, so that rolling the nonce to generate proof-of-work does not also require regenerating signatures. When grinding proof of work, the extended nonce cannot be used as it would invalidate the signature. Instead, simply resigning the same (or an updated) block will give a new search space.
 
 A block is considered fully validated only if the to_sign transaction is a valid spend of the to_spend transaction. It is recommended that this verification is done directly before or after the witness commitment verification, as the data required to do both is approximately the same.
+
+There is one other acceptable special case: if a block's challenge is e.g. `OP_TRUE` (`0x51`), where an empty solution would result in success, the block is also considered valid if the signet commitment is absent.
 
 == Genesis Block and Message Start ==
 


### PR DESCRIPTION
While `OP_TRUE` challenges have been implicitly accepted until now, it was never defined exactly how these should be solved. This adds an exception for the case where the challenge is `OP_TRUE`, that the solution must be *absent*. I.e. not even an empty signet commitment may be present, or the block should be considered invalid.

Pros: this means a signet node with challenge `OP_TRUE` works *exactly the same* as testnet/mainnet, in terms of block generation (i.e. `generate*` RPC functions in Bitcoin Core can be used out of the box).
