### PR TITLE
BIP 325: correct byte count for compact size

### DIFF
--- a/bip-0325.mediawiki
+++ b/bip-0325.mediawiki
@@ -28,8 +28,8 @@ A new type of network ("signet"), which takes an additional consensus parameter 
 
 The witness commitment of the coinbase transaction is extended to include a secondary commitment (the signature/solution) of either:
 
-    1-4 bytes - Push the following (4 + x + y) bytes
-    4 bytes - Signet scriptSig header (0xecc7daa2)
+    1-5 bytes - Push the following (4 + x + y) bytes
+    4 bytes - Signet header (0xecc7daa2)
     x bytes - scriptSig
     y bytes - scriptWitness
 


### PR DESCRIPTION
For 4-byte-push case, the push opcode was not counted; the length element is 1-5 bytes, not 4.

Also tweaks the 'signet header' name (removing 'scriptSig').