### PR TITLE
BIP 174: require creator to initialize empty output fields

### DIFF
--- a/bip-0174.mediawiki
+++ b/bip-0174.mediawiki
@@ -357,7 +357,7 @@ Using the transaction format involves many different responsibilities. Multiple 
 ===Creator===
 
 The Creator creates a new PSBT. It must create an unsigned transaction and place it in the PSBT.
-The Creator must create empty input fields.
+The Creator must create empty input and output fields fields.
 
 ===Updater===
 

--- a/bip-0174.mediawiki
+++ b/bip-0174.mediawiki
@@ -357,7 +357,7 @@ Using the transaction format involves many different responsibilities. Multiple 
 ===Creator===
 
 The Creator creates a new PSBT. It must create an unsigned transaction and place it in the PSBT.
-The Creator must create empty input and output fields fields.
+The Creator must create empty input and output fields.
 
 ===Updater===
 


### PR DESCRIPTION
The current version of the spec requires creator role to initialize empty input fields, but says nothing about output field initialization. At the same time, the following role, updater, "should also add redeemScripts, witnessScripts, and BIP 32 derivation paths to the input and output data if it knows them.", which does not make any sense if the fields were uninitialized. The [current Bitcoin Core implementation does this](https://github.com/bitcoin/bitcoin/blob/a24806c25d7a81a9c436de58eb5778d93abab16b/src/psbt.cpp#L12), and [other PSBT implementations, like rust-bitcoin, follow this practice](https://github.com/rust-bitcoin/rust-bitcoin/blob/master/src/util/psbt/mod.rs#L59)