### PR TITLE
BIP 174: rename responsibilities->roles to match Bitcoin Core

### DIFF
--- a/bip-0174.mediawiki
+++ b/bip-0174.mediawiki
@@ -350,9 +350,9 @@ It is useful when there are additional data that they need attached to a PSBT bu
 The proprietary use type is not to be used by any public specification and there is no expectation that any publicly available software be able to understand any specific meanings of it and the subtypes.
 This type must be used for internal processes only.
 
-==Responsibilities==
+==Roles==
 
-Using the transaction format involves many different responsibilities. Multiple responsibilities can be handled by a single entity, but each responsibility is specialized in what it should be capable of doing.
+Using the transaction format involves many different roles. Multiple roles can be handled by a single entity, but each role is specialized in what it should be capable of doing.
 
 ===Creator===
 


### PR DESCRIPTION
[Bitcoin Core uses "roles" instead of "responsibilities"](https://github.com/bitcoin/bitcoin/blob/master/src/psbt.h#L559) and it makes semantical sense (plus less verbose).