### PR TITLE
BIP155: Mention SHA3-256 explicitly

### DIFF
--- a/bip-0155.mediawiki
+++ b/bip-0155.mediawiki
@@ -170,6 +170,7 @@ onion_address = base32(PUBKEY | CHECKSUM | VERSION) + ".onion"
    - VERSION is an one byte version field (default value '\x03')
    - ".onion checksum" is a constant string
    - CHECKSUM is truncated to two bytes before inserting it in onion_address
+   - H() is the SHA3-256 cryptographic hash function
 </pre>
 
 Tor v3 addresses MUST be sent with the <code>TORV3</code> network ID, with the 32-byte PUBKEY part in the address field. As VERSION will always be '\x03' in the case of v3 addresses, this is enough to reconstruct the onion address.

--- a/bip-0155.mediawiki
+++ b/bip-0155.mediawiki
@@ -152,7 +152,7 @@ The reference implementation is available at (to be done)
 
 ==Appendix A: Tor v2 address encoding==
 
-The new message introduces a separate network ID for <code>TORV2</code>. 
+The new message introduces a separate network ID for <code>TORV2</code>.
 
 Clients MUST send Tor hidden service addresses with this network ID, with the 80-bit hidden service ID in the address field. This is the same as the representation in the legacy <code>addr</code> message, minus the 6 byte prefix of the OnionCat wrapping.
 
@@ -166,8 +166,8 @@ onion_address = base32(PUBKEY | CHECKSUM | VERSION) + ".onion"
  CHECKSUM = H(".onion checksum" | PUBKEY | VERSION)[:2]
 
  where:
-   - PUBKEY is the 32 bytes ed25519 master pubkey of the hidden service.
-   - VERSION is an one byte version field (default value '\x03')
+   - PUBKEY is the 32 bytes ed25519 master pubkey of the hidden service
+   - VERSION is a one byte version field (default value '\x03')
    - ".onion checksum" is a constant string
    - CHECKSUM is truncated to two bytes before inserting it in onion_address
    - H() is the SHA3-256 cryptographic hash function


### PR DESCRIPTION
It seems better to clarify that `CHECKSUM` in Tor onion v3 address uses SHA3-256 hash function.