### PR TITLE
BIP 125: Change 'Client support' to 'Backwards compatibility'

### DIFF
--- a/bip-0125.mediawiki
+++ b/bip-0125.mediawiki
@@ -171,13 +171,9 @@ Actual replacement may be unreliable until two conditions have been satisfied:
 
 # Enough hash rate has upgraded to support replacement, allowing for reasonable probability that a replacement can be mined.
 
-==Client support==
+==Backwards compatibility==
 
-No known wallet currently creates transactions by default with
-nSequence set below (0xffffffff - 1), so no known existing wallet
-explicitly signals replaceability by default.  No known popular wallet
-spends other users' unconfirmed transactions by default, so no known
-existing wallets signals inherited replaceability.
+At the time opt-in RBF support was added/proposed, no known wallet created transactions by default with nSequence set below (0xffffffff - 1), so no known wallet explicitly signaled replaceability by default. Also no known popular wallet spent other users' unconfirmed transactions by default, so no known wallets signaled inherited replaceability.
 
 ==See also==
 


### PR DESCRIPTION
+ Change 'Client support' section to 'Backwards compatibility'
+ Reasons: avoid confusion and according to the format mentioned in the below link:
https://github.com/bitcoin/bips/blob/master/bip-0002.mediawiki#specification
+ Discussed changes in https://github.com/bitcoin/bips/pull/994