### PR TITLE
bip-325: correct placement of challenge

### DIFF
--- a/bip-0325.mediawiki
+++ b/bip-0325.mediawiki
@@ -60,8 +60,10 @@ The "to_sign" transaction is:
     vin[0].prevout.hash = to_spend.txid
     vin[0].prevout.n = 0
     vin[0].nSequence = 0
+    vin[0].sigScript = [ signet_solution sigScript (x bytes), if any ]
+    vin[0].scriptWitness = [ signet_solution scriptWitness (y bytes), if any ]
     vout[0].nValue = 0
-    vout[0].scriptPubKey = signet_challenge
+    vout[0].scriptPubKey = OP_RETURN
 
 The scriptSig and/or scriptWitness for <code>vin[0]</code> are filled in from the Signet header push above.
 


### PR DESCRIPTION
In https://github.com/bitcoin/bips/pull/1003#discussion_r499466365 (where I adopt the approach here), it is pointed out that the message signature going into the scriptPubKey of the spending transaction is weird.

It should go into the scriptSig and/or scriptWitness, and the scriptPubKey for the spending tx is OP_RETURN.