### PR TITLE
Reject 98 (expired)

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -448,13 +448,13 @@ Those proposing changes should consider that ultimately consent may rest with th
 | James Hilliard
 | Standard
 | Final
-|-
+|- style="background-color: #ffcfcf"
 | [[bip-0098.mediawiki|98]]
 | Consensus (soft fork)
 | Fast Merkle Trees
 | Mark Friedenbach, Kalle Alm, BtcDrak
 | Standard
-| Draft
+| Rejected
 |- style="background-color: #ffcfcf"
 | [[bip-0099.mediawiki|99]]
 |

--- a/bip-0098.mediawiki
+++ b/bip-0098.mediawiki
@@ -7,7 +7,7 @@
           BtcDrak <btcdrak@gmail.com>
   Comments-Summary: No comments yet.
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0098
-  Status: Draft
+  Status: Rejected
   Type: Standards Track
   Created: 2017-08-24
   License: CC-BY-SA-4.0


### PR DESCRIPTION
This has expired according to BIP-0002 expiration rules, and I believe it has also been superseded by Taproot.