### PR TITLE
Reject 116 (expired)

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -560,13 +560,13 @@ Those proposing changes should consider that ultimately consent may rest with th
 | Luke Dashjr
 | Standard
 | Rejected
-|-
+|- style="background-color: #ffcfcf"
 | [[bip-0116.mediawiki|116]]
 | Consensus (soft fork)
 | MERKLEBRANCHVERIFY
 | Mark Friedenbach, Kalle Alm, BtcDrak
 | Standard
-| Draft
+| Rejected
 |-
 | [[bip-0117.mediawiki|117]]
 | Consensus (soft fork)

--- a/bip-0116.mediawiki
+++ b/bip-0116.mediawiki
@@ -7,7 +7,7 @@
           BtcDrak <btcdrak@gmail.com>
   Comments-Summary: No comments yet.
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0116
-  Status: Draft
+  Status: Rejected
   Type: Standards Track
   Created: 2017-08-25
   License: CC-BY-SA-4.0


### PR DESCRIPTION
Expired and superseded by Taproot. @kallewoof @btcdrak @maaku 