### PR TITLE
Obsolete 61 (feature was removed from Core)

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -280,13 +280,13 @@ Those proposing changes should consider that ultimately consent may rest with th
 | Amir Taaki
 | Standard
 | Draft
-|- style="background-color: #cfffcf"
+|- style="background-color: #ffcfcf"
 | [[bip-0061.mediawiki|61]]
 | Peer Services
 | Reject P2P message
 | Gavin Andresen
 | Standard
-| Final
+| Obsolete
 |- style="background-color: #ffcfcf"
 | [[bip-0062.mediawiki|62]]
 | Consensus (soft fork)

--- a/bip-0061.mediawiki
+++ b/bip-0061.mediawiki
@@ -5,7 +5,7 @@
   Author: Gavin Andresen <gavinandresen@gmail.com>
   Comments-Summary: Controversial; some recommendation, and some discouragement
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0061
-  Status: Final
+  Status: Obsolete
   Type: Standards Track
   Created: 2014-06-18
 </pre>


### PR DESCRIPTION
Hi @gavinandresen , how are you doing? Would you mind acking this? I would be so grateful.

The feature was deprecated in v0.18 according to [v0.19.0.1 release notes](https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-0.19.0.1.md#p2p-changes).

This feature was disabled by default in Bitcoin Core in [PR #14054](https://github.com/bitcoin/bitcoin/pull/14054) (merged in September 2018), the PR was included in v0.19.0.1, which was released in November 2019.

Support was wholly removed in [PR #15437](https://github.com/bitcoin/bitcoin/pull/15437) (merged in October 2019) and included in v0.20.0 which was released in June 2020.

These details were stolen from [bitcoin/doc/bips.md](https://github.com/bitcoin/bitcoin/blob/master/doc/bips.md).