### PR TITLE
List implementation PRs for BIP-0157

### DIFF
--- a/bip-0157.mediawiki
+++ b/bip-0157.mediawiki
@@ -462,6 +462,36 @@ Full-node indexing: https://github.com/Roasbeef/btcd/tree/segwit-cbf
 
 Golomb-Rice Coded sets: https://github.com/Roasbeef/btcutil/tree/gcs/gcs
 
+== Bitcoin Core Implementation ==
+
+{|
+! Functionality
+! Pull request
+! Merge date
+|-
+| Serve cfcheckpt requests
+| [https://github.com/bitcoin/bitcoin/pull/18877 #18877]
+| 2020-05-12
+|-
+| Cache cfcheckpt headers
+| [https://github.com/bitcoin/bitcoin/pull/18960 #18960]
+| 2020-05-21
+|-
+| Serve cfheaders requests
+| [https://github.com/bitcoin/bitcoin/pull/19010 #19010]
+| 2020-05-26
+|-
+| Serve cfilters requests
+| [https://github.com/bitcoin/bitcoin/pull/19044 #19044]
+| 2020-05-31
+|-
+| Signal NODE_COMPACT_FILTERS support
+| [https://github.com/bitcoin/bitcoin/pull/19070 #19070]
+| 2020-08-13
+|}
+
+The merged commits are part of Bitcoin Core version 0.21.0 and later.
+
 == References ==
 
 <references/>


### PR DESCRIPTION
Almost all BIPs that have an implementation in Bitcoin Core, also have a link to their implementation. BIP-0157 was merged into Core, but its implementation is not linked from the BIP, yet. I submit this PR to add these links to the BIP document.

This table was stolen and adapted from https://github.com/bitcoin/bitcoin/pull/18876 .

It was authored by John Newbery (@jnewbery). I would appreciate if John would tell me if it is OK that I stole it.

This BIP was authored by Laolu (@roasbeef). Laolu, you have to ack this for it to get merged. I would appreciate it.