### PR TITLE
BIP-0002: Update Rejection criteria to require there to be an actual …

### DIFF
--- a/bip-0002.mediawiki
+++ b/bip-0002.mediawiki
@@ -190,7 +190,7 @@ The BIP editor may also change the status to Deferred when no progress is being 
 
 A BIP may only change status from Draft (or Rejected) to Proposed, when the author deems it is complete, has a working implementation (where applicable), and has community plans to progress it to the Final status.
 
-BIPs should be changed from Draft or Proposed status, to Rejected status, upon request by any person, if they have not made progress in three years. Such a BIP may be changed to Draft status if the champion provides revisions that meaningfully address public criticism of the proposal, or to Proposed status if it meets the criteria required as described in the previous paragraph.
+BIPs in Draft or Proposed status may be changed to Rejected status upon request by any person, if there is outstanding criticism, vulnerabilities, or other concerns which have not been addressed within three years. Such a BIP may be changed to Draft status if the champion provides revisions that meaningfully address the given issues, or to Proposed status if it meets the criteria required as described in the previous paragraph.
 
 An Proposed BIP may progress to Final only when specific criteria reflecting real-world adoption has occurred. This is different for each BIP depending on the nature of its proposed changes, which will be expanded on below. Evaluation of this status change should be objectively verifiable, and/or be discussed on the development mailing list.
 


### PR DESCRIPTION
…concern

Right now, BIPs may be Rejected simply due to the passing of time. The intent was to close BIPs with outstanding issues that were not adequately addressed within a given amount of time. This changes the wording to reflect this criteria.

Ping @maaku, @harding, @michaelfolkson.

Alternative to #1012.