### PR TITLE
BIP8: directly support special cases

### DIFF
--- a/bip-0008.mediawiki
+++ b/bip-0008.mediawiki
@@ -90,30 +90,30 @@ For flexibility, during the LOCKED_IN phase only, this rule does NOT require the
 
 During the STARTED state if the '''lockinontimeout''' is set to true, the state will transition to LOCKED_IN when '''timeoutheight''' is reached.
 
-The genesis block has state DEFINED for each deployment, by definition.
-
-    State GetStateForBlock(block) {
-        if (block.height == 0) {
-            return DEFINED;
-        }
-
 All blocks within a retarget period have the same state. This means that if
 floor(block1.height / 2016) = floor(block2.height / 2016), they are guaranteed to have the same state for every
 deployment.
 
+    State GetStateForBlock(block) {
         if ((block.height % 2016) != 0) {
             return GetStateForBlock(block.parent);
         }
 
-Otherwise, the next state depends on the previous state:
+Otherwise, the next state depends on the previous state. For the genesis block, the previous state is DEFINED.
 
-        switch (GetStateForBlock(GetAncestorAtHeight(block, block.height - 2016))) {
+        const prev_state = block.height == 0 ? DEFINED : GetStateForBlock(GetAncestorAtHeight(block, block.height - 2016));
 
-We remain in the initial state until we reach the start block height.
+        switch (prev_state):
+
+We remain in the initial state until we reach the start height. If we reach the timeout height simultaneously, immediately transition into the appropriate final state.
 
         case DEFINED:
             if (block.height >= startheight) {
-                return STARTED;
+                if (block.height >= timeoutheight) {
+                    return (lockinontimeout ? ACTIVE : FAILED);
+                } else {
+                    return STARTED;
+                }
             }
             return DEFINED;
 


### PR DESCRIPTION
Rather than always having the genesis block be DEFINED, allow {0,0,true} to act as ALWAYS_ACTIVE and {0,0,false} to act as NEVER_ACTIVE, and {n,n,true} to act as a buried deployment.

This cleans up the implementation a bit I think, removing the need for special case handling. (Note that in the {n,n,true} case n will still be rounded up to the next retarget period however)