### PR TITLE
BIP-0085: fix typo

### DIFF
--- a/bip-0085.mediawiki
+++ b/bip-0085.mediawiki
@@ -81,7 +81,7 @@ Coldcard Firmware: [https://github.com/Coldcard/firmware/pull/39]
 
 Application number define how entropy will be used post processing. Some basic examples follow:
 
-Derivation path uses the format <code>m/83696968/' + /app_no' + /index'</code> where ''app_no'' path for the application, and `index` in the index.
+Derivation path uses the format <code>m/83696968' + /app_no' + /index'</code> where ''app_no'' path for the application, and `index` in the index.
 
 ===BIP39===
 Application number: 39'


### PR DESCRIPTION
I've noticed a small typo in the specification of bip 85 -- hardened derivation was after the slash.
