### PR TITLE
BIP32: Modified test vectors for hardened derivation with leading zeros

### DIFF
--- a/bip-0032.mediawiki
+++ b/bip-0032.mediawiki
@@ -4,6 +4,7 @@ RECENT CHANGES:
 * (25 May 2013) Added test vectors
 * (15 Jan 2014) Rename keys with index ≥ 0x80000000 to hardened keys, and add explicit conversion functions.
 * (24 Feb 2017) Added test vectors for hardened derivation with leading zeros
+* (4 Nov 2020) Added new test vectors for hardened derivation with leading zeros
 
 <pre>
   BIP: 32
@@ -271,6 +272,21 @@ Seed (hex): 4b381541583be4423346c643850da4b320e46a87ae3d2a4e6da11eba819cd4acba45
 * Chain m/0<sub>H</sub>
 ** ext pub: xpub68NZiKmJWnxxS6aaHmn81bvJeTESw724CRDs6HbuccFQN9Ku14VQrADWgqbhhTHBaohPX4CjNLf9fq9MYo6oDaPPLPxSb7gwQN3ih19Zm4Y
 ** ext prv: xprv9uPDJpEQgRQfDcW7BkF7eTya6RPxXeJCqCJGHuCJ4GiRVLzkTXBAJMu2qaMWPrS7AANYqdq6vcBcBUdJCVVFceUvJFjaPdGZ2y9WACViL4L
+
+===Test vector 4===
+
+These vectors test for the retention of leading zeros. See [https://github.com/btcsuite/btcutil/issues/172 btcsuite/btcutil#172] for more information.
+
+Seed (hex): 3ddd5602285899a946114506157c7997e5444528f3003f6134712147db19b678
+* Chain m
+** ext pub: xpub661MyMwAqRbcGczjuMoRm6dXaLDEhW1u34gKenbeYqAix21mdUKJyuyu5F1rzYGVxyL6tmgBUAEPrEz92mBXjByMRiJdba9wpnN37RLLAXa
+** ext prv: xprv9s21ZrQH143K48vGoLGRPxgo2JNkJ3J3fqkirQC2zVdk5Dgd5w14S7fRDyHH4dWNHUgkvsvNDCkvAwcSHNAQwhwgNMgZhLtQC63zxwhQmRv
+* Chain m/0<sub>H</sub>
+** ext pub: xpub69AUMk3qDBi3uW1sXgjCmVjJ2G6WQoYSnNHyzkmdCHEhSZ4tBok37xfFEqHd2AddP56Tqp4o56AePAgCjYdvpW2PU2jbUPFKsav5ut6Ch1m
+** ext prv: xprv9vB7xEWwNp9kh1wQRfCCQMnZUEG21LpbR9NPCNN1dwhiZkjjeGRnaALmPXCX7SgjFTiCTT6bXes17boXtjq3xLpcDjzEuGLQBM5ohqkao9G
+* Chain m/0<sub>H</sub>/1<sub>H</sub>
+** ext pub: xpub6BJA1jSqiukeaesWfxe6sNK9CCGaujFFSJLomWHprUL9DePQ4JDkM5d88n49sMGJxrhpjazuXYWdMf17C9T5XnxkopaeS7jGk1GyyVziaMt
+** ext prv: xprv9xJocDuwtYCMNAo3Zw76WENQeAS6WGXQ55RCy7tDJ8oALr4FWkuVoHJeHVAcAqiZLE7Je3vZJHxspZdFHfnBEjHqU5hG1Jaj32dVoS6XLT1
 
 
 ==Acknowledgements==


### PR DESCRIPTION
As mentioned in https://github.com/bitpay/bitcore-lib/issues/47, https://github.com/iancoleman/bip39/issues/58 and https://github.com/btcsuite/btcutil/issues/172, the private key with leading zeros(i.e. less than 32 bytes) should be padded to 32 bytes when we derive a hardened child private key from a private key.

Unfortunately, the original test vector 3 is not suitable for this case since both keys are 32 bytes.

In the new test vectors, the key m/0<sub>H</sub> is 31 bytes.

[btcsuite/btcutil](https://github.com/btcsuite/btcutil) just fix the bug. See https://github.com/btcsuite/btcutil/pull/182.
