### PR TITLE
removed proprietary and por fields

### DIFF
--- a/bip-0174.mediawiki
+++ b/bip-0174.mediawiki
@@ -132,12 +132,6 @@ The currently defined global types are as follows:
 ** Value: The 32-bit little endian unsigned integer representing the version number of this PSBT. If ommitted, the version number is 0.
 *** <tt>{32-bit uint}</tt>
 
-* Type: Proprietary Use Type <tt>PSBT_GLOBAL_PROPRIETARY = 0xFC</tt>
-** Key: Variable length identifier prefix, followed by a subtype, followed by the key data itself.
-*** <tt>{0xFC}|<prefix>|{subtype}|{key data}</tt>
-** Value: Any value data as defined by the proprietary type user.
-*** <tt><data></tt>
-
 The currently defined per-input types are defined as follows:
 
 * Type: Non-Witness UTXO <tt>PSBT_IN_NON_WITNESS_UTXO = 0x00</tt>
@@ -194,12 +188,6 @@ The currently defined per-input types are defined as follows:
 ** Value: The Finalized scriptWitness contains a fully constructed scriptWitness with signatures and any other scripts necessary for the input to pass validation.
 *** <tt>{scriptWitness}</tt>
 
-* Type: Proof-of-reserves commitment <tt>PSBT_IN_POR_COMMITMENT = 0x09</tt>
-** Key: None. The key must only contain the 1 byte type.
-*** <tt>{0x09}</tt>
-** Value: The UTF-8 encoded commitment message string for the proof-of-reserves.  See [[bip-0127.mediawiki|BIP 127]] for more information.
-*** <tt>{porCommitment}</tt>
-
 * Type: RIPEMD160 preimage <tt>PSBT_IN_RIPEMD160 = 0x0a</tt>
 ** Key: The resulting hash of the preimage
 *** <tt>{0x0a}|{20-byte hash}</tt>
@@ -224,12 +212,6 @@ The currently defined per-input types are defined as follows:
 ** Value: The hash preimage, encoded as a byte vector, which must equal the key when run through the `SHA256` algorithm twice
 *** <tt>{preimage}</tt>
 
-* Type: Proprietary Use Type <tt>PSBT_IN_PROPRIETARY = 0xFC</tt>
-** Key: Variable length identifier prefix, followed by a subtype, followed by the key data itself.
-*** <tt>{0xFC}|<prefix>|{subtype}|{key data}</tt>
-** Value: Any value data as defined by the proprietary type user.
-*** <tt><data></tt>
-
 The currently defined per-output <ref>'''Why do we need per-output data?''' Per-output data allows signers
 to verify that the outputs are going to the intended recipient. The output data can also be use by signers to
 determine which outputs are change outputs and verify that the change is returning to the correct place.</ref> types are defined as follows:
@@ -251,12 +233,6 @@ determine which outputs are change outputs and verify that the change is returni
 *** <tt>{0x02}|{public key}</tt>
 ** Value: The master key fingerprint concatenated with the derivation path of the public key. The derivation path is represented as 32-bit little endian unsigned integer indexes concatenated with each other. Public keys are those needed to spend this output.
 *** <tt>{master key fingerprint}|{32-bit uint}|...|{32-bit uint}</tt>
-
-* Type: Proprietary Use Type <tt>PSBT_OUT_PROPRIETARY = 0xFC</tt>
-** Key: Variable length identifier prefix, followed by a subtype, followed by the key data itself.
-*** <tt>{0xFC}|<prefix>|{subtype}|{key data}</tt>
-** Value: Any value data as defined by the proprietary type user.
-*** <tt><data></tt>
 
 The transaction format is specified as follows:
 
@@ -332,23 +308,6 @@ will still need to handle events where keys are duplicated when combining transa
 whichever value it wishes.<ref>'''Why can the values be arbitrarily chosen?''' When there are duplicated keys, the values that can be chosen will either be
 valid or invalid. If the values are invalid, a signer would simply produce an invalid signature and the final transaction itself would be invalid. If the
 values are valid, then it does not matter which is chosen as either way the transaction is still valid.</ref>
-
-===Proprietary Use Type===
-
-For all global, per-input, and per-output maps, the types <tt>0xFC</tt> is reserved for proprietary use.
-The proprietary use type requires keys that follow the type with a variable length string identifer, then a subtype.
-
-The identifier can be any variable length string that software can use to identify whether the particular data in the proprietary type can be used by it.
-It can also be the empty string and just be a single <tt>0x00</tt> byte although this is not recommended.
-
-The subtype is defined by the proprietary type user and can mean whatever they want it to mean.
-The subtype must also be a compact size unsigned integer in the same form as the normal types.
-The key data and value data are defined by the proprietary type user.
-
-The proprietary use types is for private use by individuals and organizations who wish to use PSBT in their processes.
-It is useful when there are additional data that they need attached to a PSBT but such data are not useful or available for the general public.
-The proprietary use type is not to be used by any public specification and there is no expectation that any publicly available software be able to understand any specific meanings of it and the subtypes.
-This type must be used for internal processes only.
 
 ==Roles==
 
@@ -783,11 +742,6 @@ Any data types, their associated scope and BIP number must be defined here
 | PSBT_GLOBAL_VERSION
 | BIP 174
 |-
-| Global
-| 252
-| PSBT_GLOBAL_PROPRIETARY
-| BIP 174
-|-
 | Input
 | 0
 | PSBT_IN_NON_WITNESS_UTXO
@@ -834,11 +788,6 @@ Any data types, their associated scope and BIP number must be defined here
 | BIP 174
 |-
 | Input
-| 9
-| PSBT_IN_POR_COMMITMENT
-| [[bip-0127.mediawiki|BIP 127]]
-|-
-| Input
 | 10
 | PSBT_IN_RIPEMD160
 | BIP 174
@@ -858,11 +807,6 @@ Any data types, their associated scope and BIP number must be defined here
 | PSBT_IN_HASH256
 | BIP 174
 |-
-| Input
-| 252
-| PSBT_IN_PROPRIETARY
-| BIP 174
-|-
 | Output
 | 0
 | PSBT_OUT_REDEEM_SCRIPT
@@ -876,10 +820,5 @@ Any data types, their associated scope and BIP number must be defined here
 | Output
 | 2
 | PSBT_OUT_BIP32_DERIVATION
-| BIP 174
-|-
-| Output
-| 252
-| PSBT_OUT_PROPRIETARY
 | BIP 174
 |}


### PR DESCRIPTION
This removes the proprietary and por fields from the PSBT specifications.

First off, at face value they have nothing to do with the operations intrinsically required to finalize a valid transaction from PSBT manipulation.

Moreover, whatever information content they can provide for non-standard PSBT manipulation, that content could stay in the unknown field without any loss of generality. How to structure and deal with unknown data would be the responsibility of proprietary software or users wanting to provide proof-of-reserve. As long as BIP174 clearly prescribes that unknown data must be kept during PSBT manipulation, that should be enough.

Let me stress the above point: I have a project where we include proprietary information in the PSBT. Any PSBT software supporting unknown data gently keeps our proprietary information and our proprietary software retrieves that data from serialized PSBT with no problem. There is no need for a PSBT implementation to provide explicit support for proprietary and proof-of-reserves types.

My last conclusion is reinforced by the evidence of all PSBT implementations I know of, including bitcoin core and HWI, not implementing proprietary and proof-of-reserve types. There is a high probability that part of BIP174 would be just ignored.