### PR TITLE
BIP34 encoding clarification

### DIFF
--- a/bip-0034.mediawiki
+++ b/bip-0034.mediawiki
@@ -22,7 +22,7 @@ Bitcoin blocks and transactions are versioned binary structures. Both currently 
 ==Specification==
 
 # Treat transactions with a version greater than 1 as non-standard (official Satoshi client will not mine or relay them).
-# Add height as the first item in the coinbase transaction's scriptSig, and increase block version to 2. The format of the height is "serialized CScript" -- first byte is number of bytes in the number (will be 0x03 on main net for the next 150 or so years with 2<sup>23</sup>-1 blocks), following bytes are little-endian representation of the number (including a sign bit).  Height is the height of the mined block in the block chain, where the genesis block is height zero (0).
+# Add height as the first item in the coinbase transaction's scriptSig, and increase block version to 2. The format of the height is "minimally encoded serialized CScript" -- first byte is number of bytes in the number (will be 0x03 on main net for the next 150 or so years with 2<sup>23</sup>-1 blocks), following bytes are little-endian representation of the number (including a sign bit).  Height is the height of the mined block in the block chain, where the genesis block is height zero (0).
 # 75% rule: If 750 of the last 1,000 blocks are version 2 or greater, reject invalid version 2 blocks. (testnet3: 51 of last 100)
 # 95% rule ("Point of no return"): If 950 of the last 1,000 blocks are version 2 or greater, reject all version 1 blocks. (testnet3: 75 of last 100)
 


### PR DESCRIPTION
Non minimal encodings are rejected by the bitcoin-core client because it only checks against a specific encoding.
Link for reference: https://github.com/bitcoin/bitcoin/blob/master/src/validation.cpp#L3503

For example:
Height 16512 has two encodings which should be valid according to the spec. 03804000 and 028040. However, the prior would always be rejected due to the implementation of the BIP34 height check. 