### PR TITLE
BIP155: change when sendaddrv2 is to be sent

### DIFF
--- a/bip-0155.mediawiki
+++ b/bip-0155.mediawiki
@@ -134,7 +134,7 @@ See the appendices for the address encodings to be used for the various networks
 
 Introduce a new message type <code>sendaddrv2</code>. Sending such a message indicates that a node can understand and prefers to receive <code>addrv2</code> messages instead of <code>addr</code> messages. I.e. "Send me addrv2".
 
-<code>sendaddrv2</code> SHOULD be sent after receiving the <code>verack</code> message from the peer.
+The <code>sendaddrv2</code> message MUST only be sent in response to the <code>version</code> message from a peer and prior to sending the <code>verack</code> message.
 
 For older peers, that did not emit <code>sendaddrv2</code>, keep sending the legacy <code>addr</code> message, ignoring addresses with the newly introduced address types.
 


### PR DESCRIPTION
Mandate to send `sendaddrv2` to the peer before sending our `verack`
to them.

This way we know that the peer does not support `addrv2` if we did not
receive `sendaddrv2` from them before receiving their `verack`.