### PR TITLE
bip39: discourage from using localized wordlists

### DIFF
--- a/bip-0039.mediawiki
+++ b/bip-0039.mediawiki
@@ -113,7 +113,14 @@ will make the desired wallet available.
 
 ==Wordlists==
 
-* [[bip-0039/bip-0039-wordlists.md|Moved to separate document]]
+Since the vast majority of BIP39 wallets supports only the English wordlist,
+it is '''strongly discouraged''' to use non-English wordlists for generating
+the mnemonic sentences.
+
+If you still feel your application really needs to use a localized wordlist,
+use one of the following instead of inventing your own.
+
+* [[bip-0039/bip-0039-wordlists.md|Wordlists]]
 
 ==Test vectors==
 


### PR DESCRIPTION
Add a paragraph which explains that using a non-English bip39 mnemonic is usually a bad idea.