### PR TITLE
bip322: (another) significant overhaul

### DIFF
--- a/bip-0322.mediawiki
+++ b/bip-0322.mediawiki
@@ -17,11 +17,11 @@ A standard for interoperable signed messages based on the Bitcoin Script format,
 
 == Motivation ==
 
-The current message signing standard only works for P2PKH (1...) invoice addresses. We propose to extend and generalize the standard by using a Bitcoin Script based approach. This approach minimizes the burden for implementers as message signing can be expected to be part of a library or project that includes Bitcoin Script interpreters already.
+The current message signing standard only works for P2PKH (1...) invoice addresses. We propose to extend and generalize the standard by using a Bitcoin Script based approach. This ensures that any coins, no matter what script they are controlled by, can in-principle be signed for. For easy interoperability with existing signing hardware, we also define a signature message format which resembles a Bitcoin transaction (except that it contains an invalid input, so it cannot be spent on any real network).
 
-Additionally, the current message signing only proves that the message has been committed to by the recipient of a given invoice address.
-It does not prove anything about the invoice address itself, nor that the signer has access to the private keys used to implement this invoice.
-More importantly, it does not prove ownership nor access to any funds, even if the same private key would be a valid signer for spending them - and this is a commonly desired use case.
+Additionally, the current message signature format uses ECDSA signatures which do not commit to the public key, meaning that they do not actually prove knowledge of any secret keys. (Indeed, valid signatures can be tweaked by 3rd parties to become valid signatures on certain related keys.)
+
+Ultimately no message signing protocol can actually prove control of funds, both because a signature is obsolete as soon as it is created, and because the possessor of a secret key may be willing to sign messages on others' behalf even if it would not sign actual transactions. No signmessage protocol can fix these limitations.
 
 == Specification ==
 
@@ -121,7 +121,7 @@ TODO
 
 == Acknowledgements ==
 
-Thanks to David Harding, Jim Posen, Kalle Rosenbaum, Pieter Wuille, and many others for their feedback on the specification.
+Thanks to David Harding, Jim Posen, Kalle Rosenbaum, Pieter Wuille, Andrew Poelstra, and many others for their feedback on the specification.
 
 == References ==
 

--- a/bip-0322.mediawiki
+++ b/bip-0322.mediawiki
@@ -74,7 +74,7 @@ The <code>to_sign</code> transaction is:
     vout[0].nValue = 0
     vout[0].scriptPubKey = OP_RETURN
 
-A full signature consists of the base64-encoding of the <code>to_spend</code> and <code>to_sign</code> transactions concatenated in standard network serialisation.
+A full signature consists of the base64-encoding of the <code>to_sign</code> transaction in standard network serialisation.
 
 === Full (Proof of Funds) ===
 
@@ -102,11 +102,9 @@ A validator is given as input an address ''A'' (which may be omitted in a proof-
 Validation consists of the following steps:
 
 # Basic validation
-## Decode ''s'' as the transactions <code>to_sign</code> and <code>to_spend</code>
-## Confirm that <code>message_hash</code> is the correct hash of ''m''
-## Confirm that <code>message_challenge</code> is the scriptPubKey corresponding to ''A'' if ''A'' is present, and otherwise must be <code>OP_TRUE</code>
-## Confirm that all other fields are set as specified above; in particular that
-##* <code>to_spend</code> has exactly one input and one output
+## Compute the transaction <code>to_spend</code> from ''m'' and ''A''
+## Decode ''s'' as the transaction <code>to_sign</code>
+## If ''s'' was a full transaction, confirm all fields are set as specified above; in particular that
 ##* <code>to_sign</code> has at least one input and its first input spends the output of </code>to_spend</code>
 ##* <code>to_sign</code> has exactly one output, as specified above
 ## Confirm that the two transactions together satisfy all consensus rules, except for <code>to_spend</code>'s missing input, and except that ''nSequence'' of <code>to_sign</code>'s first input and ''nLockTime'' of <code>to_sign</code> are not checked.
@@ -120,6 +118,7 @@ Validation consists of the following steps:
 ## <code>MINIMALIF</code>: the argument of <code>IF</code>/<code>NOTIF</code> must be exactly 0x01 or empty push
 ## If any of the above steps failed, the validator should stop and output the ''invalid'' state.
 # Check the **upgradeable rules**
+## The version of <code>to_sign</code> must be 0 or 2.
 ## The use of NOPs reserved for upgrades is forbidden.
 ## The use of segwit versions greater than 0 are forbidden.
 ## If any of the above steps failed, the validator should stop and output the ''inconclusive'' state.
@@ -137,7 +136,7 @@ Signers who control an address ''A'' who wish to sign a message ''m'' act as fol
 They then encode their signature, choosing either ''simple'' or ''full'' as follows:
 
 * If they added no inputs to <code>to_sign</code>, left nSequence and nLockTime at 0, and ''A'' is a Segwit address (either pure or P2SH-wrapped), then they may base64-encode <code>message_signature</code>
-* Otherwise they must base64-encode the concatenation of <code>to_spend</code> followed by <code>to_sign</code>.
+* Otherwise they must base64-encode <code>to_sign</code>.
 
 == Compatibility ==
 

--- a/bip-0322.mediawiki
+++ b/bip-0322.mediawiki
@@ -49,7 +49,7 @@ Full signatures follow an analogous specification to the BIP-325 challenges and 
 
 Let there be two virtual transactions <code>to_spend</code> and <code>to_sign</code>.
 
-The "to_spend" transaction is:
+The <code>to_spend</code> transaction is:
 
     nVersion = 0
     nLockTime = 0
@@ -61,10 +61,9 @@ The "to_spend" transaction is:
     vout[0].nValue = 0
     vout[0].scriptPubKey = message_challenge
 
-where message_hash is a BIP340-tagged hash of the message, i.e. sha256_tag(m), where tag = "BIP0322-signed-message", and message_challenge is the to be proven (public) key script.
-For proving funds, message_challenge shall be simply OP_TRUE.
+where <code>message_hash</code> is a BIP340-tagged hash of the message, i.e. sha256_tag(m), where tag = <code>BIP0322-signed-message</code>, and <code>message_challenge</code> is the to be proven (public) key script.
 
-The "to_sign" transaction is:
+The <code>to_sign</code> transaction is:
 
     nVersion = 0 or as appropriate (e.g. 2, for time locks)
     nLockTime = 0 or as appropriate (for time locks)
@@ -75,13 +74,7 @@ The "to_sign" transaction is:
     vout[0].nValue = 0
     vout[0].scriptPubKey = OP_RETURN
 
-When a proof of funds is being created, additional inputs should be included for virtually spending transaction outputs of desired value.
-
-* All signatures must use the SIGHASH_ALL flag.
-* The proof is considered valid, inconclusive, or invalid based on whether the to_sign transaction is a valid spend of the to_spend transaction or not, according to the rules specified in the "Consensus and standard flags" section below.
-* Proofs of funds may be encumbered with the in_future flag, according to the rules specified in the "Locktime and Sequence" section below, in which case we refer to the result in text form as "valid_in_future", "inconclusive_in_future", etc.
-
-Proofs of funds are the base64-encoding of the to_spend and to_sign transactions concatenated in standard network serialisation, and proofs without additional inputs or time locks (simple proofs) are the base64-encoding of the to_sign script witness.
+A full signature consists of the base64-encoding of the <code>to_spend</code> and <code>to_sign</code> transactions concatenated in standard network serialisation.
 
 === Full (Proof of Funds) ===
 
@@ -93,47 +86,58 @@ A signer may construct a proof of funds, demonstrating control of a set of UTXOs
 
 Unlike an ordinary signature, validators of a proof of funds need access to the current UTXO set, to learn that the claimed inputs exist on the blockchain, and to learn their scriptPubKeys.
 
-A validator must verify it is valid and meets the description of virtual transactions as specified above. See "Validation" below.
+== Detailed Specification ==
 
-=== Validation ===
+For all signature types, except legacy, the <code>to_spend</code> and <code>to_sign</code> transactions must be valid transactions which pass all consensus checks, except of course that the output with prevout <code>000...000:FFFFFFFF</code> does not exist.
 
-To validate a simple proof, the following steps must be taken:
+=== Verification ===
 
-# construct the to_spend and to_sign transactions, based on the specification above
-# check the signature using consensus rules, then upgradable rules
+A validator is given as input an address ''A'' (which may be omitted in a proof-of-funds), signature ''s'' and message ''m'', and outputs one of three states
+* ''valid at time T and age S'' indicates that the signature has set timelocks but is otherwise valid
+* ''inconclusive'' means the validator was unable to check the scripts
+* ''invalid'' means that some check failed
 
-To validate a proof of funds, the following steps must be taken:
+==== Verification Process ====
 
-# deserialize the to_spend and to_sign transactions from the proof, and fail if the proof contains extraneous bytes
-# verify that the to_sign transaction uses all inputs covered by the proof of funds, exactly once
-# reconstruct the to_spend' and to_sign' transactions, based on the specification above, copying the version, lock time, and sequence values
-# verify that to_spend = to_spend', that to_sign has at least 1 input, has exactly 1 output, and that to_sign.vin[0] = to_sign'.vin[0]
-# set the "in_future" flag if the transaction's lock time is in the future according to consensus rules
-# establish a "coins map", a mapping of outpoints (hash, vout) to coins (scriptPubKey, amount), initialized to coins_map(to_spend.txid, 0) = (to_spend.vout[0], 0)
-# for each proof of fund input, set the corresponding values in the coins map; abort if the input cannot be found
-# check the signature of each input using consensus rules, then upgradable rules
+Validation consists of the following steps:
+
+# Basic validation
+## Decode ''s'' as the transactions <code>to_sign</code> and <code>to_spend</code>
+## Confirm that <code>message_hash</code> is the correct hash of ''m''
+## Confirm that <code>message_challenge</code> is the scriptPubKey corresponding to ''A'' if ''A'' is present, and otherwise must be <code>OP_TRUE</code>
+## Confirm that all other fields are set as specified above; in particular that
+##* <code>to_spend</code> has exactly one input and one output
+##* <code>to_sign</code> has at least one input and its first input spends the output of </code>to_spend</code>
+##* <code>to_sign</code> has exactly one output, as specified above
+## Confirm that the two transactions together satisfy all consensus rules, except for <code>to_spend</code>'s missing input, and except that ''nSequence'' of <code>to_sign</code>'s first input and ''nLockTime'' of <code>to_sign</code> are not checked.
+# (Optional) If the validator does not have a full script interpreter, it should check that it understands all scripts being satisfied. If not, it should stop here and output ''inconclusive''.
+# Check the **required rules**:
+## All signatures must use the SIGHASH_ALL flag.
+## The use of <code>CODESEPARATOR</code> or <code>FindAndDelete</code> is forbidden.
+## <code>LOW_S</code>, <code>STRICTENC</code> and <code>NULLFAIL</code>: valid ECDSA signatures must be strictly DER-encoded and have a low-S value; invalid ECDSA signature must be the empty push
+## <code>MINIMALDATA</code>: all pushes must be minimally encoded
+## <code>CLEANSTACK</code>: require that only a single stack element remains after evaluation
+## <code>MINIMALIF</code>: the argument of <code>IF</code>/<code>NOTIF</code> must be exactly 0x01 or empty push
+## If any of the above steps failed, the validator should stop and output the ''invalid'' state.
+# Check the **upgradeable rules**
+## The use of NOPs reserved for upgrades is forbidden.
+## The use of segwit versions greater than 0 are forbidden.
+## If any of the above steps failed, the validator should stop and output the ''inconclusive'' state.
+# Let ''T'' by the nLockTime of <code>to_sign</code> and ''S'' be the nSequence of the first input of <code>to_sign</code>. Output the state ''valid at time T and age S''.
 
 === Signing ===
 
-Given the P2PKH invoice address <code>a</code> and the message <code>m</code>, and the pubkey-hash function <code>pkh(P) = ripemd160(sha256(P))</code>:
+Signers who control an address ''A'' who wish to sign a message ''m'' act as follows:
 
-# let <code>p</code> be the pubkey-hash <code>pkh(P)</code> for the pubkey <code>P</code>, contained in <code>a</code>
-# let <code>x</code> be the private key associated with <code>P</code> so that <code>pkh(xG) = p</code>
-# let <code>digest</code> be <code>SHA56d(0x18||"Bitcoin Signed Message:\n"||compactint(len(m))||m)</code>
-# create a compact signature <code>sig</code> (aka "recoverable ECDSA signature") using <code>x</code> on <code>digest</code>
+# They construct <code>to_spend</code> and <code>to_sign</code> as specified above, using the scriptPubKey of ''A'' for <code>message_challenge</code> and tagged hash of ''m'' as <code>message_hash</code>.
+# Optionally, they may set nLockTime of <code>to_sign</code> or nSequence of its first input.
+# Optionally, they may add any additional outputs to <code>to_sign</code> that they wish to prove control of.
+# They satisfy <code>to_sign</code> as they would any other transaction.
 
-The resulting proof is <code>sig</code>, serialized using the base64 encoding.
+They then encode their signature, choosing either ''simple'' or ''full'' as follows:
 
-=== Verifying ===
-
-Given the P2PKH invoice address <code>a</code>, the message <code>m</code>, the compact signature <code>sig</code>, and the pubkey-hash function <code>pkh(P) = ripemd160(sha256(P))</code>:
-
-# let <code>p</code> be the pubkey-hash <code>pkh(P)</code> for the pubkey <code>P</code>, contained in <code>a</code>
-# let <code>digest</code> be <code>SHA56d(0x18||"Bitcoin Signed Message:\n"||compactint(len(m))||m)</code>
-# attempt pubkey recovery for <code>digest</code> using the signature <code>sig</code> and store the resulting pubkey into <code>Q</code>
-## fail verification if pubkey recovery above fails
-# let <code>q</code> be the pubkey-hash <code>pkh(Q)</code> for the pubkey <code>Q</code>
-# if <code>p == q</code>, the proof is valid, otherwise it is invalid
+* If they added no inputs to <code>to_sign</code>, left nSequence and nLockTime at 0, and ''A'' is a Segwit address (either pure or P2SH-wrapped), then they may base64-encode <code>message_signature</code>
+* Otherwise they must base64-encode the concatenation of <code>to_spend</code> followed by <code>to_sign</code>.
 
 == Compatibility ==
 
@@ -154,38 +158,6 @@ Thanks to David Harding, Jim Posen, Kalle Rosenbaum, Pieter Wuille, Andrew Poels
 == Copyright ==
 
 This document is licensed under the Creative Commons CC0 1.0 Universal license.
-
-== Consensus and standard flags ==
-
-Each flag is associated with some type of enforced rule (most often a soft fork). There are two sets of flags: consensus flags (which result in a block being rejected, if violated), and upgradable flags (which are typically policy-rejected by nodes specifically for the purpose of future network upgrades). The upgradable flags are a super-set of the consensus flags.
-
-This BIP specifies that a proof that validates for both rulesets is valid, a proof that validates for consensus rules, but not for upgradable rules, is "inconclusive", and a proof that does not validate for consensus rules is "invalid" (regardless of upgradable rule validation).
-
-The ruleset sometimes changes. This BIP does not intend to be complete, nor does it indicate enforcement of rules, it simply lists the rules as they stand at the point of writing.
-
-=== Consensus rules ===
-
-* P2SH: evaluate P2SH ([https://github.com/bitcoin/bips/blob/master/bip-0016.mediawiki BIP16]) subscripts
-* DERSIG: enforce strict DER ([https://github.com/bitcoin/bips/blob/master/bip-0066.mediawiki BIP66]) compliance
-* NULLDUMMY: enforce NULLDUMMY ([https://github.com/bitcoin/bips/blob/master/bip-0147.mediawiki BIP147])
-* CHECKLOCKTIMEVERIFY: enable CHECKLOCKTIMEVERIFY ([https://github.com/bitcoin/bips/blob/master/bip-0065.mediawiki BIP65])
-* CHECKSEQUENCEVERIFY: enable CHECKSEQUENCEVERIFY ([https://github.com/bitcoin/bips/blob/master/bip-0112.mediawiki BIP112])
-* WITNESS: enable WITNESS ([https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki BIP141])
-
-=== Upgradable rules ===
-
-All of the above, plus (subject to change):
-
-* STRICTENC: non-strict DER signature or undefined hashtype
-* MINIMALDATA: require minimal encodings for all push operations
-* DISCOURAGE_UPGRADABLE_NOPS: discourage use of NOPs reserved for upgrades
-* CLEANSTACK: require that only a single stack element remains after evaluation
-* MINIMALIF: Segwit script only: require the argument of OP_IF/NOTIF to be exactly 0x01 or empty vector
-* NULLFAIL: signature(s) must be empty vector if a CHECK(MULTI)SIG operation failed
-* LOW_S: signature with S > order/2 in a checksig operation
-* DISCOURAGE_UPGRADABLE_WITNESS_PROGRAM: v1-16 witness programs are non-standard (i.e. forbidden)
-* WITNESS_PUBKEYTYPE: public keys in segregated witness scripts must be compressed
-* CONST_SCRIPTCODE: OP_CODESEPARATOR and FindAndDelete fail any non-segwit scripts
 
 == Test vectors ==
 

--- a/bip-0322.mediawiki
+++ b/bip-0322.mediawiki
@@ -23,11 +23,31 @@ Additionally, the current message signature format uses ECDSA signatures which d
 
 Ultimately no message signing protocol can actually prove control of funds, both because a signature is obsolete as soon as it is created, and because the possessor of a secret key may be willing to sign messages on others' behalf even if it would not sign actual transactions. No signmessage protocol can fix these limitations.
 
-== Specification ==
+== Types of Signatures ==
 
-This BIP follows the specification of BIP-325 challenges and solutions (see Signet comparison below).
+This BIP specifies three formats for signing messages: ''legacy'', ''simple'' and ''full''. Additionally, a variant of the ''full'' format can be used to demonstrate control over a set of UTXOs.
 
-Let there be two virtual transactions to_spend and to_sign.
+=== Legacy ===
+
+New proofs should use the new format for all invoice address formats, including P2PKH.
+
+The legacy format MAY be used, but must be restricted to the legacy P2PKH invoice address format.
+
+=== Simple ===
+
+A ''simple'' signature consists of a witness stack, consensus encoded as a vector of vectors of bytes, and base64-encoded. Validators should construct <code>to_spend</code> and <code>to_sign</code> as defined below, with default values for all fields except that
+
+* <code>message_hash</code> is a BIP340-tagged hash of the message, as specified below
+* <code>message_challenge</code> in <code>to_spend</code> is set to the scriptPubKey being signed with
+* <code>message_signature</code> in <code>to_sign</code> is set to the provided simple signature.
+
+and then proceed as they would for a full signature.
+
+=== Full ===
+
+Full signatures follow an analogous specification to the BIP-325 challenges and solutions used by Signet.
+
+Let there be two virtual transactions <code>to_spend</code> and <code>to_sign</code>.
 
 The "to_spend" transaction is:
 
@@ -63,6 +83,16 @@ When a proof of funds is being created, additional inputs should be included for
 
 Proofs of funds are the base64-encoding of the to_spend and to_sign transactions concatenated in standard network serialisation, and proofs without additional inputs or time locks (simple proofs) are the base64-encoding of the to_sign script witness.
 
+=== Full (Proof of Funds) ===
+
+A signer may construct a proof of funds, demonstrating control of a set of UTXOs, by constructing a full signature as above, with the following modifications.
+
+* <code>message_challenge</code> is unused and shall be set to <code>OP_TRUE</code>
+* Similarly, <code>message_signature</code> is then empty.
+* All outputs that the signer wishes to demonstrate control of are included as additional inputs of <code>to_sign</code>, and their witness and scriptSig data should be set as though these outputs were actually being spent.
+
+Unlike an ordinary signature, validators of a proof of funds need access to the current UTXO set, to learn that the claimed inputs exist on the blockchain, and to learn their scriptPubKeys.
+
 A validator must verify it is valid and meets the description of virtual transactions as specified above. See "Validation" below.
 
 === Validation ===
@@ -82,12 +112,6 @@ To validate a proof of funds, the following steps must be taken:
 # establish a "coins map", a mapping of outpoints (hash, vout) to coins (scriptPubKey, amount), initialized to coins_map(to_spend.txid, 0) = (to_spend.vout[0], 0)
 # for each proof of fund input, set the corresponding values in the coins map; abort if the input cannot be found
 # check the signature of each input using consensus rules, then upgradable rules
-
-== Legacy format ==
-
-New proofs should use the new format for all invoice address formats, including P2PKH.
-
-The legacy format MAY be used, but must be restricted to the legacy P2PKH invoice address format.
 
 === Signing ===
 


### PR DESCRIPTION
Changes the validation rules to always require (script) standardness checks, except for checking NOPs and version numbers, where incorrect values result in "inconclusive" rather than "invalid". Allow validators to also return "inconclusive" when they encounter a script that they're unable to interpret.

This makes it possible to write a BIP-322 validator using Miniscript, and to write (say) a p2pkwh-only validator while remaining within spec. Both should encourage adoption.

Also removed the `to_spend` transaction from the wire serialization because it is a pure function of the address and message.

Mailing list discussion: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2020-December/thread.html