### PR TITLE
BIP173: segwit address witness version is one 5-bit char not one byte

### DIFF
--- a/bip-0173.mediawiki
+++ b/bip-0173.mediawiki
@@ -208,7 +208,7 @@ be of the same length as the mainnet counterpart (to simplify
 implementations' assumptions about lengths), but still be visually
 distinct.</ref> for testnet.
 * The data-part values:
-** 1 byte: the witness version
+** 1 character (representing 5 bits of data): the witness version
 ** A conversion of the 2-to-40-byte witness program (as defined by [https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki BIP141]) to base32:
 *** Start with the bits of the witness program, most significant bit per byte first.
 *** Re-arrange those bits into groups of 5, and pad with zeroes at the end if needed.


### PR DESCRIPTION
When describing the segwit address, `bc1q...` for example - the `q` represents witness version `0` but it is not one entire byte as the BIP currently describes it, it is one bech32 character which only represents 5 bits.

(unless the intention is to describe the byte in terms of how ASCII characters occupy one byte?)