### PR TITLE
bip-0141: clarify the sigop count calculation for CHECKMULTISIG

### DIFF
--- a/bip-0141.mediawiki
+++ b/bip-0141.mediawiki
@@ -127,7 +127,7 @@ Sigops per block is currently limited to 20,000. We change this restriction as f
 Sigops in the current pubkey script, signature script, and P2SH check script are counted at 4 times their previous value.
 The sigop limit is likewise quadrupled to ≤ 80,000.
 
-Each P2WPKH input is counted as 1 sigop. In addition, opcodes within a P2WSH <code>witnessScript</code> are counted identically as previously within the P2SH <code>redeemScript</code>. That is, CHECKSIG is counted as only 1 sigop, and CHECKMULTISIG is counted as 1 to 20 sigops according to the arguments. This rule applies to both native witness program and P2SH witness program.
+Each P2WPKH input is counted as 1 sigop. In addition, opcodes within a P2WSH <code>witnessScript</code> are counted identically as previously within the P2SH <code>redeemScript</code>. That is, CHECKSIG is counted as only 1 sigop. When preceded by OP_1 to OP_16 CHECKMULTISIG is counted as 1 to 16 sigops respectively, otherwise it is counted as 20 sigops. This rule applies to both native witness program and P2SH witness program.
 
 === Additional definitions ===
 


### PR DESCRIPTION
This makes the behaviour of the reference implementation clear for this computation, which was implied by the previous sentence but not explicited in the next one.