### PR TITLE
Reject BIP175

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -854,13 +854,13 @@ Those proposing changes should consider that ultimately consent may rest with th
 | Andrew Chow
 | Standard
 | Proposed
-|-
+|- style="background-color: #ffcfcf"
 | [[bip-0175.mediawiki|175]]
 | Applications
 | Pay to Contract Protocol
 | Omar Shibli, Nicholas Gregory
 | Informational
-| Draft
+| Rejected
 |-
 | [[bip-0176.mediawiki|176]]
 |

--- a/bip-0175.mediawiki
+++ b/bip-0175.mediawiki
@@ -6,7 +6,7 @@
           Nicholas Gregory <nicholas@commerceblock.com>
   Comments-Summary: No comments yet.
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0175
-  Status: Draft
+  Status: Rejected
   Type: Informational
   Created: 2017-07-17
   License: BSD-2-Clause


### PR DESCRIPTION
Following @ysangkok proposal a few months back here https://github.com/bitcoin/bips/pull/960

I propose to reject this BIP due to lack of meeting the BIP process requirements.

Main point that has not been addressed as part of this protocol is the data management aspect, Greg pointed this point in the bitcoin mailing list.. I highly recommend refraining from using this protocol, I would suggest to migrate to other protocols that handle this aspect.

Regards,
Omar 