### PR TITLE
Reject 150 (expired)

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -770,13 +770,13 @@ Those proposing changes should consider that ultimately consent may rest with th
 | Shaolin Fry
 | Standard
 | Withdrawn
-|-
+|- style="background-color: #ffcfcf"
 | [[bip-0150.mediawiki|150]]
 | Peer Services
 | Peer Authentication
 | Jonas Schnelli
 | Standard
-| Draft
+| Rejected
 |- style="background-color: #ffcfcf"
 | [[bip-0151.mediawiki|151]]
 | Peer Services

--- a/bip-0150.mediawiki
+++ b/bip-0150.mediawiki
@@ -5,7 +5,7 @@
   Author: Jonas Schnelli <dev@jonasschnelli.ch>
   Comments-Summary: Discouraged for implementation (one person)
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0150
-  Status: Draft
+  Status: Rejected
   Type: Standards Track
   Created: 2016-03-23
   License: PD


### PR DESCRIPTION
According to expiration rules, this does not need consent, since it has expired.

See also BIP-0151, which has already [been withdrawn](https://github.com/bitcoin/bips/pull/772). In that thread, there is a link to the related https://gist.github.com/jonasschnelli/c530ea8421b8d0e80c51486325587c52, which has ongoing discussion.