### PR TITLE
bip-0350: fix links for reference implementations

### DIFF
--- a/bip-0350.mediawiki
+++ b/bip-0350.mediawiki
@@ -138,14 +138,14 @@ On the other hand, the Bech32m proposal breaks forward-compatibility for sending
 ==Reference implementations==
 
 * Reference encoder and decoder:
-** [https://github.com/sipa/bech32/tree/bech32m/ref/python Reference Python implementation]
-** [https://github.com/sipa/bech32/tree/bech32m/ref/c Reference C implementation]
-** [https://github.com/sipa/bech32/tree/bech32m/ref/c++ Reference C++ implementation]
+** [https://github.com/sipa/bech32/blob/master/ref/python Reference Python implementation]
+** [https://github.com/sipa/bech32/blob/master/ref/c Reference C implementation]
+** [https://github.com/sipa/bech32/blob/master/ref/c++ Reference C++ implementation]
 ** [https://github.com/bitcoin/bitcoin/pull/20861 Bitcoin Core C++ implementation]
-** [https://github.com/sipa/bech32/tree/bech32m/ref/javascript Reference Javascript implementation]
+** [https://github.com/sipa/bech32/blob/master/ref/javascript Reference Javascript implementation]
 
 * Fancy decoder that localizes errors:
-** [https://github.com/sipa/bech32/tree/bech32m/ecc/javascript For JavaScript] ([http://bitcoin.sipa.be/bech32/demo/demo.html demo website])
+** [https://github.com/sipa/bech32/blob/master/ecc/javascript For JavaScript] ([http://bitcoin.sipa.be/bech32/demo/demo.html demo website])
 
 ==Test vectors==
 


### PR DESCRIPTION
This just updates broken URLs.

@sipa