### PR TITLE
Change `witness` to signature

### DIFF
--- a/bip-0118.mediawiki
+++ b/bip-0118.mediawiki
@@ -92,7 +92,7 @@ Any participant can take a transaction and rewrite it by changing the
 hash reference to the previous output, without invalidating the
 signatures.
 This allows transactions to be bound to any output that matches the
-value committed to in the <tt>witness</tt> and whose <tt>witnessProgram</tt>,
+value committed to in the signature and whose <tt>witnessProgram</tt>,
 combined with the spending transaction's <tt>witness</tt> returns <tt>true</tt>.
 
 Previously, all information in the transaction was committed in the


### PR DESCRIPTION
As per my understanding, the value is committed in the signature(sighash msg) and is not being supplied as an additional witness