### PR TITLE
Removing size param (not used anymore)

### DIFF
--- a/bip-0021.mediawiki
+++ b/bip-0021.mediawiki
@@ -58,7 +58,6 @@ The scheme component ("bitcoin:") is case-insensitive, and implementations must 
 *label: Label for that address (e.g. name of receiver)
 *address: bitcoin address
 *message: message that describes the transaction to the user ([[#Examples|see examples below]])
-*size: amount of base bitcoin units ([[#Transfer amount/size|see below]])
 *(others): optional, for future extensions
 
 ==== Transfer amount/size ====

--- a/bip-0021.mediawiki
+++ b/bip-0021.mediawiki
@@ -60,7 +60,7 @@ The scheme component ("bitcoin:") is case-insensitive, and implementations must 
 *message: message that describes the transaction to the user ([[#Examples|see examples below]])
 *(others): optional, for future extensions
 
-==== Transfer amount/size ====
+==== Transfer amount ====
 
 If an amount is provided, it MUST be specified in decimal BTC.
 All amounts MUST contain no commas and use a period (.) as the separating character to separate whole numbers and decimal fractions.


### PR DESCRIPTION
Text mentions `size` param and provides broken link to the explanation which is absent. It seems the parameter was removed after strict requirement to always use bitcoin denomination, but this line was left.