### PR TITLE
Fixing Simple Signer Algorithm

### DIFF
--- a/bip-0174.mediawiki
+++ b/bip-0174.mediawiki
@@ -494,9 +494,9 @@ for input,i in enumerate(psbt.inputs):
         assert(sha256d(non_witness_utxo) == psbt.tx.input[i].prevout.hash)
         if redeemScript.exists:
             assert(non_witness_utxo.vout[psbt.tx.input[i].prevout.n].scriptPubKey == P2SH(redeemScript))
-            sign_non_witness(redeemScript)
+            sign_non_witness(redeemScript, i)
         else:
-            sign_non_witness(non_witness_utxo.vout[psbt.tx.input[i].prevout.n].scriptPubKey)
+            sign_non_witness(non_witness_utxo.vout[psbt.tx.input[i].prevout.n].scriptPubKey, i)
     else if witness_utxo.exists:
         if redeemScript.exists:
             assert(witness_utxo.scriptPubKey == P2SH(redeemScript))
@@ -504,10 +504,10 @@ for input,i in enumerate(psbt.inputs):
         else:
             script = witness_utxo.scriptPubKey
         if IsP2WPKH(script):
-            sign_witness(P2PKH(script[2:22]))
+            sign_witness(P2PKH(script[2:22]), i)
         else if IsP2WSH(script):
             assert(script == P2WSH(witnessScript))
-            sign_witness(witnessScript)
+            sign_witness(witnessScript, i)
     else:
         assert False
 </pre>


### PR DESCRIPTION
Simple Signer Algorithm was lacking an index argument (last one) on all function calls