### PR TITLE
BIP 341: Specify Speedy Trial activation parameters

### DIFF
--- a/bip-0341.mediawiki
+++ b/bip-0341.mediawiki
@@ -294,7 +294,9 @@ Examples of preimage for sighashing for each of the sighash modes.
 
 == Deployment ==
 
-TODO
+This BIP is deployed concurrently with [[bip-0342.mediawiki|BIP342]].
+
+For Bitcoin signet, these BIPs are always active.
 
 == Backwards compatibility ==
 As a soft fork, older software will continue to operate without modification.

--- a/bip-0341.mediawiki
+++ b/bip-0341.mediawiki
@@ -298,6 +298,14 @@ This BIP is deployed concurrently with [[bip-0342.mediawiki|BIP342]].
 
 For Bitcoin signet, these BIPs are always active.
 
+There may be multiple deployment attempts of these BIPs.
+
+The first deployment will use BIP 8 with the name "taproot", using bit 2, and a lockinontimeout of false.
+
+For Bitcoin mainnet, the BIP 8 startheight will be 681408 (approximately May 1st 2021), the timeoutheight will be 695520 (approximately August 6th 2021), the minimum_activation_height will be 709632 (approximately November 12th 2021), and the activation threshold will be 1815 out of 2016 blocks (90%).
+
+For Bitcoin testnet3, the BIP 8 startheight will be 1967616 (mined March 26th 2021), the timeoutheight will be 2169216 (approximately March 2022 due to testnet3's low difficulty), the minimum_activation_height will be 0, and the activation threshold will be 1512 out of 2016 blocks (75%).
+
 == Backwards compatibility ==
 As a soft fork, older software will continue to operate without modification.
 Non-upgraded nodes, however, will consider all SegWit version 1 witness programs as anyone-can-spend scripts.

--- a/bip-0342.mediawiki
+++ b/bip-0342.mediawiki
@@ -133,6 +133,10 @@ In addition to changing the semantics of a number of opcodes, there are also som
 
 <references />
 
+==Deployment==
+
+This proposal is deployed identically to Taproot ([[bip-0341.mediawiki|BIP341]]).
+
 ==Examples==
 
 ==Acknowledgements==


### PR DESCRIPTION
Specifies activation parameters for BIP 341 using the Speedy Trial activation proposal discussed [on the bitcoin-dev mailing list](https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2021-March/018594.html).

Testnet parameters were not discussed so I just chose block heights that corresponded to a start time of 2021/04/18 with 3 retarget periods of activation time and an additional 3 retarget periods for the minimum activation height.

Requires #1080 as it uses the `minimum_activation_height` specified there.