### PR TITLE
BIP-85: Added Ian Coleman's Mnemonic Code Converter

### DIFF
--- a/bip-0085.mediawiki
+++ b/bip-0085.mediawiki
@@ -102,6 +102,8 @@ OUTPUT
 
 * Coldcard Firmware: [https://github.com/Coldcard/firmware/pull/39]
 
+* Ian Coleman's Mnemonic Code Converter: [https://github.com/iancoleman/bip39] and [https://iancoleman.io/bip39/]
+
 ==Applications==
 
 The Application number defines how entropy will be used post processing. Some basic examples follow:


### PR DESCRIPTION
- Added Ian Coleman's Mnemonic Code Converter to the "Other Implementations" section
- https://iancoleman.io/bip39/ is a nice tool to play around with and to derive test data for BIP-85

PS: Sorry that I did not include this in the previous PR #1083. I just found this this very moment, but I think it is worth while to include because it gives the user/reader an instant tool to play with and to see results of BIP-85.