### PR TITLE
PSBT: Require compressed keys for BIP32 key fields

### DIFF
--- a/bip-0174.mediawiki
+++ b/bip-0174.mediawiki
@@ -246,7 +246,7 @@ The currently defined per-input types are defined as follows:
 | Partial Signature
 | <tt>PSBT_IN_PARTIAL_SIG = 0x02</tt>
 | <tt><pubkey></tt>
-| The public key which corresponds to this signature.
+| The public key which corresponds to this signature; may be compressed or uncompressed.
 | <tt><signature></tt>
 | The signature as would be pushed to the stack from a scriptSig or witness.
 |
@@ -290,7 +290,7 @@ The currently defined per-input types are defined as follows:
 | BIP 32 Derivation Path
 | <tt>PSBT_IN_BIP32_DERIVATION = 0x06</tt>
 | <tt><pubkey></tt>
-| The public key
+| The public key, always in compressed format (BIP32 does not work with uncompressed keys)
 | <tt><32-bit uint> <32-bit uint>*</tt>
 | The master key fingerprint as defined by BIP 32 concatenated with the derivation path of the public key. The derivation path is represented as 32 bit unsigned integer indexes concatenated with each other. Public keys are those that will be needed to sign this input.
 |
@@ -482,8 +482,8 @@ determine which outputs are change outputs and verify that the change is returni
 |-
 | BIP 32 Derivation Path
 | <tt>PSBT_OUT_BIP32_DERIVATION = 0x02</tt>
-| <tt><public key></tt>
-| The public key
+| <tt><pubkey></tt>
+| The public key, always in compressed format (BIP32 does not work with uncompressed keys)
 | <tt><{32-bit uint> <32-bit uint>*</tt>
 | The master key fingerprint concatenated with the derivation path of the public key. The derivation path is represented as 32-bit little endian unsigned integer indexes concatenated with each other. Public keys are those needed to spend this output.
 |


### PR DESCRIPTION
BIP32 does not work with uncompressed public key; thus, all BIP32-related fields must explicitly require that the public key for the map key value must be serialized in compressed format