### PR TITLE
BIP 341/342: Add link to Bitcoin Core test vectors

### DIFF
--- a/bip-0341.mediawiki
+++ b/bip-0341.mediawiki
@@ -284,9 +284,7 @@ The reason for this is to increase leaf entropy and prevent an observer from lea
 
 == Test vectors ==
 
-Examples with creation transaction and spending transaction pairs, valid and invalid.
-
-Examples of preimage for sighashing for each of the sighash modes.
+The test vectors used in the [https://github.com/bitcoin/bitcoin/blob/3820090bd619ac85ab35eff376c03136fe4a9f04/src/test/script_tests.cpp#L1718 Bitcoin Core unit test framework] can be found [https://github.com/bitcoin-core/qa-assets/blob/main/unit_test_data/script_assets_test.json?raw=true here].
 
 == Rationale ==
 

--- a/bip-0342.mediawiki
+++ b/bip-0342.mediawiki
@@ -135,6 +135,8 @@ In addition to changing the semantics of a number of opcodes, there are also som
 
 ==Examples==
 
+The Taproot ([[bip-0341.mediawiki|BIP341]]) test vectors also contain examples for Tapscript execution.
+
 ==Acknowledgements==
 
 This document is the result of many discussions and contains contributions by a number of people. The authors wish to thank all those who provided valuable feedback and reviews, including the participants of the [https://github.com/ajtowns/taproot-review structured reviews].


### PR DESCRIPTION
Also remove mention of non-existing examples.

Test vectors and examples could get more love, but at least this points implementers to the existing test vectors.

CC @sipa @ajtowns