### PR TITLE
BIP341: speedy trial activation parameters

### DIFF
--- a/bip-0341.mediawiki
+++ b/bip-0341.mediawiki
@@ -298,7 +298,29 @@ This BIP is deployed concurrently with [[bip-0342.mediawiki|BIP342]].
 
 For Bitcoin signet, these BIPs are always active.
 
-For Bitcoin mainnet, these BIPs will be deployed by "version bits" with the name "taproot" and bit 2, using BIP9 modified to use a lower threshold, and with an additional ''min_activation_height'' parameter and changing the state transition logic for LOCKED_IN to the following:
+For Bitcoin mainnet, these BIPs will be deployed by "version bits" with the name "taproot" and bit 2, using [[bip-0009.mediawiki|BIP9]] modified to use a lower threshold, with an additional ''min_activation_height'' parameter and replacing the state transition logic for the DEFINED, STARTED and LOCKED_IN states as follows:
+
+    case DEFINED:
+        if (GetMedianTimePast(block.parent) >= starttime) {
+            return STARTED;
+        }
+        return DEFINED;
+
+    case STARTED:
+        int count = 0;
+        walk = block;
+        for (i = 0; i < 2016; i++) {
+            walk = walk.parent;
+            if (walk.nVersion & 0xE0000000 == 0x20000000 && (walk.nVersion >> bit) & 1 == 1) {
+                count++;
+            }
+        }
+        if (count >= threshold) {
+            return LOCKED_IN;
+        } else if (GetMedianTimePast(block.parent) >= timeout) {
+            return FAILED;
+        }
+        return STARTED;
 
     case LOCKED_IN:
         if (block.nHeight < min_activation_height) {
@@ -306,7 +328,7 @@ For Bitcoin mainnet, these BIPs will be deployed by "version bits" with the name
         }
         return ACTIVE;
 
-For Bitcoin mainnet, the BIP9 starttime is epoch timestamp 1619222400 (midnight 24 April 2021 UTC), BIP9 timeout is epoch timestamp 1628640000 (midnight 11 August 2021 UTC), the threshold is 1815 blocks (90%) instead of 1916 blocks (95%), and the min_activation_height is block 709632 (expected approximately 12 November 2021).
+For Bitcoin mainnet, the starttime is epoch timestamp 1619222400 (midnight 24 April 2021 UTC), timeout is epoch timestamp 1628640000 (midnight 11 August 2021 UTC), the threshold is 1815 blocks (90%) instead of 1916 blocks (95%), and the min_activation_height is block 709632 (expected approximately 12 November 2021).
 
 == Backwards compatibility ==
 As a soft fork, older software will continue to operate without modification.

--- a/bip-0341.mediawiki
+++ b/bip-0341.mediawiki
@@ -298,6 +298,16 @@ This BIP is deployed concurrently with [[bip-0342.mediawiki|BIP342]].
 
 For Bitcoin signet, these BIPs are always active.
 
+For Bitcoin mainnet, these BIPs will be deployed by "version bits" with the name "taproot" and bit 2, using BIP9 modified to use a lower threshold, and with an additional ''min_activation_height'' parameter and changing the state transition logic for LOCKED_IN to the following:
+
+    case LOCKED_IN:
+        if (block.nHeight < min_activation_height) {
+            return LOCKED_IN;
+        }
+        return ACTIVE;
+
+For Bitcoin mainnet, the BIP9 starttime is epoch timestamp 1619222400 (midnight 24 April 2021 UTC), BIP9 timeout is epoch timestamp 1628640000 (midnight 11 August 2021 UTC), the threshold is 1815 blocks (90%) instead of 1916 blocks (95%), and the min_activation_height is block 709632 (expected approximately 12 November 2021).
+
 == Backwards compatibility ==
 As a soft fork, older software will continue to operate without modification.
 Non-upgraded nodes, however, will consider all SegWit version 1 witness programs as anyone-can-spend scripts.

--- a/bip-0341.mediawiki
+++ b/bip-0341.mediawiki
@@ -294,7 +294,9 @@ Examples of preimage for sighashing for each of the sighash modes.
 
 == Deployment ==
 
-TODO
+This BIP is deployed concurrently with [[bip-0342.mediawiki|BIP342]].
+
+For Bitcoin signet, these BIPs are always active.
 
 == Backwards compatibility ==
 As a soft fork, older software will continue to operate without modification.

--- a/bip-0341.mediawiki
+++ b/bip-0341.mediawiki
@@ -298,7 +298,7 @@ This BIP is deployed concurrently with [[bip-0342.mediawiki|BIP342]].
 
 For Bitcoin signet, these BIPs are always active.
 
-For Bitcoin mainnet, these BIPs will be deployed by "version bits" with the name "taproot" and bit 2, using [[bip-0009.mediawiki|BIP9]] modified to use a lower threshold, with an additional ''min_activation_height'' parameter and replacing the state transition logic for the DEFINED, STARTED and LOCKED_IN states as follows:
+For Bitcoin mainnet and testnet3, these BIPs will be deployed by "version bits" with the name "taproot" and bit 2, using [[bip-0009.mediawiki|BIP9]] modified to use a lower threshold, with an additional ''min_activation_height'' parameter and replacing the state transition logic for the DEFINED, STARTED and LOCKED_IN states as follows:
 
     case DEFINED:
         if (GetMedianTimePast(block.parent) >= starttime) {
@@ -329,6 +329,8 @@ For Bitcoin mainnet, these BIPs will be deployed by "version bits" with the name
         return ACTIVE;
 
 For Bitcoin mainnet, the starttime is epoch timestamp 1619222400 (midnight 24 April 2021 UTC), timeout is epoch timestamp 1628640000 (midnight 11 August 2021 UTC), the threshold is 1815 blocks (90%) instead of 1916 blocks (95%), and the min_activation_height is block 709632 (expected approximately 12 November 2021).
+
+For Bitcoin testnet3, the starttime is epoch timestamp 1619222400 (midnight 24 April 2021 UTC), timeout is epoch timestamp 1628640000 (midnight 11 August 2021 UTC), the threshold is 1512 blocks (75%), and the min_activation_height is block 0.
 
 == Backwards compatibility ==
 As a soft fork, older software will continue to operate without modification.

--- a/bip-0341.mediawiki
+++ b/bip-0341.mediawiki
@@ -311,7 +311,7 @@ For Bitcoin mainnet and testnet3, these BIPs will be deployed by "version bits" 
         walk = block;
         for (i = 0; i < 2016; i++) {
             walk = walk.parent;
-            if (walk.nVersion & 0xE0000000 == 0x20000000 && (walk.nVersion >> bit) & 1 == 1) {
+            if ((walk.nVersion & 0xE0000000) == 0x20000000 && ((walk.nVersion >> bit) & 1) == 1) {
                 count++;
             }
         }

--- a/bip-0342.mediawiki
+++ b/bip-0342.mediawiki
@@ -133,6 +133,10 @@ In addition to changing the semantics of a number of opcodes, there are also som
 
 <references />
 
+==Deployment==
+
+This proposal is deployed identically to Taproot ([[bip-0341.mediawiki|BIP341]]).
+
 ==Examples==
 
 ==Acknowledgements==


### PR DESCRIPTION
Adds mainnet and testnet3 activation parameters. This uses the "speedy trial" approach [0]  with some refinements to the exact mechanism [1], as implemented in bitcoin/bitcoin#21377 . Parameters are selected based on previous discussions [2] [3] [4]. The parameters are:

* starttime = 2021-04-24 00:00 UTC
* timeout = 2021-08-11 00:00 UTC
* min_activation_height = 709632 (est mid November 2021, mainnet only)
* threshold = 1815 / 2016 blocks (90%, mainnet only)

In terms of block heights, that will likely mean the first signalling period for mainnet should start at height 681408, approximately April 29th UTC, and will likely mean signalling will continue for 8 retarget periods until height 697536 (which if blocks arrived at 10 minute intervals, would be due around 2021-08-20).

[0] https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2021-March/018583.html
[1] https://github.com/bitcoin/bitcoin/pull/21377#issuecomment-814494847
[2] (90%) https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2021-February/018425.html
[3] (May/August/Nov) https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2021-March/018715.html
[4] (specific parameters) https://github.com/bitcoin/bips/pull/1081