### PR TITLE
BIP 341: fix tuple index in taproot_tweak_pubkey

### DIFF
--- a/bip-0341.mediawiki
+++ b/bip-0341.mediawiki
@@ -173,7 +173,7 @@ First, we define <code>taproot_tweak_pubkey</code> for 32-byte [[bip-0340.mediaw
 The function returns a bit indicating the tweaked public key's Y coordinate as well as the public key byte array.
 The parity bit will be required for spending the output with a script path.
 In order to allow spending with the key path, we define <code>taproot_tweak_seckey</code> to compute the secret key for a tweaked public key.
-For any byte string <code>h</code> it holds that <code>taproot_tweak_pubkey(pubkey_gen(seckey), h)[0] == pubkey_gen(taproot_tweak_seckey(seckey, h))</code>.
+For any byte string <code>h</code> it holds that <code>taproot_tweak_pubkey(pubkey_gen(seckey), h)[1] == pubkey_gen(taproot_tweak_seckey(seckey, h))</code>.
 
 <source lang="python">
 def taproot_tweak_pubkey(pubkey, h):
@@ -219,7 +219,7 @@ def taproot_output_script(internal_pubkey, script_tree):
         h = bytes()
     else:
         _, h = taproot_tree_helper(script_tree)
-    output_pubkey, _ = taproot_tweak_pubkey(internal_pubkey, h)
+    _, output_pubkey = taproot_tweak_pubkey(internal_pubkey, h)
     return bytes([0x51, 0x20]) + output_pubkey
 </source>
 


### PR DESCRIPTION
It is [0] but the pubkey is index [1]