### PR TITLE
Define BIP Steward Process and set Temporary Editor

### DIFF
--- a/bip-0002.mediawiki
+++ b/bip-0002.mediawiki
@@ -68,6 +68,62 @@ If you are interested in assuming ownership of a BIP, send a message asking to t
 
 The current BIP editor is Jaime Caring who can be contacted at [[mailto:jaime.caring@gmail.com|jaime.caring@gmail.com]].
 
+Jaime Caring is an interim editor and will not serve beyond June 1st, 2021.
+
+===BIP Editor Replacement and Stewardship===
+
+The following 23 GitHub users have been selected based on their contributorship
+to Bitcoin Core, current standing in the community, or commitment to the
+dissemination of high quality information as Stewards of the BIP process.
+
+* @achow101 Andrew Chow
+* @ajtowns Anthony Towns
+* @dongcarl Carl Dong
+* @Empact Ben Woosley
+* @gmaxwell Gregory Maxwell
+* @harding David A. Harding
+* @hebasto Hennadii Stepanov
+* @instagibbs Gregory Sanders
+* @jnewbery John Newbery
+* @jonasschnelli Jonas Schnelli
+* @jonatack Jon Atack
+* @kallewoof kallewoof
+* @laanwj W. J. van der Laan
+* @MarcoFalke MarcoFalke
+* @morcos Alex Morcos
+* @practicalswift practicalswift (Thomas J)
+* @promag João Barbosa
+* @ryanofsky Russell Yanofsky
+* @sdaftuar Suhas Daftuar
+* @sipa Pieter Wuille
+* @Sjors Sjors Provoost
+* @TheBlueMatt Matt Corallo
+* @theuni Cory Fields
+
+By June 1st, 2021, the Stewards shall convene an open meeting to nominate and
+ratify (via 15/23 supermajority) the election of at least 3 BIP Editors to
+replace Jaime Caring. Such nominations must be accepted before being ratified.
+BIP Editors may be drawn from the Bitcoin Community at large, and may also be
+Stewards. However, Stewards must step down from the Stewardship position upon
+ratification.
+
+Stewards may be replaced by either a supermajority (above 2/3) vote or by a
+nomination from the Steward stepping down with a simple majority (above 1/2).
+
+The initial Stewards were not contacted in their selection and have played no
+role in the formation of OpenBIPs, unless Jaime Caring represents one such
+Steward. As such, Stewards may not wish to participate in this process.
+
+Should Stewards fail to acknowledge their role by May 1st, 2021, the other
+Stewards should act to replace them.
+
+Stewards may form and ratify new procedural documents for the BIP Process and
+Stewardship Governance via creating BIP-0003. Edits to BIP-0003 are exempt from
+the usual process of Editor approval, and must be approved by a super majority
+of Stewards. BIP-0004 may be created and actively maintained by the current BIP
+Editors to define their current agreed upon workflows.
+
+
 
 ===BIP Editor Responsibilities & Workflow===
 

--- a/bip-0002.mediawiki
+++ b/bip-0002.mediawiki
@@ -1,7 +1,8 @@
 <pre>
   BIP: 2
   Title: BIP process, revised
-  Author: Luke Dashjr <luke+bip@dashjr.org>
+  Author: Jaime Caring <jaime.caring@gmail.com>
+  Historical-Author: Luke Dashjr <luke+bip@dashjr.org>
   Comments-Summary: No comments yet.
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0002
   Status: Active
@@ -65,12 +66,13 @@ If you are interested in assuming ownership of a BIP, send a message asking to t
 
 ===BIP Editors===
 
-The current BIP editor is Luke Dashjr who can be contacted at [[mailto:luke_bipeditor@dashjr.org|luke_bipeditor@dashjr.org]].
+The current BIP editor is Jaime Caring who can be contacted at [[mailto:jaime.caring@gmail.com|jaime.caring@gmail.com]].
+
 
 ===BIP Editor Responsibilities & Workflow===
 
 The BIP editor subscribes to the Bitcoin development mailing list.
-Off-list BIP-related correspondence should be sent (or CC'd) to luke_bipeditor@dashjr.org.
+Off-list BIP-related correspondence should be sent (or CC'd) to jaime.caring@gmail.com.
 
 For each new BIP that comes in an editor does the following:
 
@@ -128,6 +130,7 @@ Each BIP must begin with an RFC 822 style header preamble. The headers must appe
 * Layer: <Consensus (soft fork) | Consensus (hard fork) | Peer Services | API/RPC | Applications>
   Title: <BIP title; maximum 44 characters>
   Author: <list of authors' real names and email addrs>
+* Historical-Author: <list of former authors' real names and email addrs (ownership revoked)>
 * Discussions-To: <email address>
 * Comments-Summary: <summary tone>
   Comments-URI: <links to wiki page for comments>


### PR DESCRIPTION
On https://github.com/JaimeCaring/OpenBIPs/issues/2 I received feedback that a new repo was "nuclear".

Up-streaming the OpenBIPs process here. See the linked issue for motivation.

I'm happy for a non-nym editor to replace me championing this process, but I don't think anyone deserves the political and reputational loss for this necessary action.