### PR TITLE
BIP 174: clarify key uniqueness

### DIFF
--- a/bip-0174.mediawiki
+++ b/bip-0174.mediawiki
@@ -65,7 +65,7 @@ be used as a separator and allow for easier unserializer implementation.</ref>.
 Where:
 
 ;<tt><keytype></tt>
-: A compact size unsigned integer representing the type. This compact size unsigned integer must be minimally encoded, i.e. if the value can be represented using one byte, it must be represented as one byte. This must be unique within a specific <tt><map></tt>.
+: A compact size unsigned integer representing the type. This compact size unsigned integer must be minimally encoded, i.e. if the value can be represented using one byte, it must be represented as one byte. There can be multiple entries with the same <tt><keytype></tt> within a specific <tt><map></tt>, but the <tt><key></tt> must be unique.
 ;<tt><keylen></tt>
 : The compact size unsigned integer containing the combined length of <tt><keytype></tt> and <tt><keydata></tt>
 ;<tt><valuelen></tt>
@@ -544,7 +544,7 @@ values are valid, then it does not matter which is chosen as either way the tran
 
 ===Proprietary Use Type===
 
-For all global, per-input, and per-output maps, the types <tt>0xFC</tt> is reserved for proprietary use.
+For all global, per-input, and per-output maps, the type <tt>0xFC</tt> is reserved for proprietary use.
 The proprietary use type requires keys that follow the type with a compact size unsigned integer representing the length of the string identifer, followed by the string identifier, then a subtype, and finally any key data.
 
 The identifier can be any variable length string that software can use to identify whether the particular data in the proprietary type can be used by it.
@@ -554,7 +554,7 @@ The subtype is defined by the proprietary type user and can mean whatever they w
 The subtype must also be a compact size unsigned integer in the same form as the normal types.
 The key data and value data are defined by the proprietary type user.
 
-The proprietary use types is for private use by individuals and organizations who wish to use PSBT in their processes.
+The proprietary use type is for private use by individuals and organizations who wish to use PSBT in their processes.
 It is useful when there are additional data that they need attached to a PSBT but such data are not useful or available for the general public.
 The proprietary use type is not to be used by any public specification and there is no expectation that any publicly available software be able to understand any specific meanings of it and the subtypes.
 This type must be used for internal processes only.
@@ -727,7 +727,7 @@ If an updater is updating a PSBT and needs to add a field that is only available
 ===Procedure For New Fields===
 
 New fields should first be proposed on the bitcoin-dev mailing list.
-If a field requires significatn description as to its usage, it should be accompanied by a separate BIP.
+If a field requires significant description as to its usage, it should be accompanied by a separate BIP.
 The field must be added to the field listing tables in the Specification section.
 
 ===Procedure For New Versions===


### PR DESCRIPTION
The description of `keytype` incorrectly said it had to be unique: it's the whole `key` that must be unique, not the `keytype` (since we can for instance have multiple `xpubs` in the global map).

@achow101 