### PR TITLE
BIP158: Fix typo - changed 'outpoints spent' to 'outputs spent'.

### DIFF
--- a/bip-0158.mediawiki
+++ b/bip-0158.mediawiki
@@ -60,7 +60,7 @@ interpreted as described in RFC 2119.
 === Golomb-Coded Sets ===
 
 For each block, compact filters are derived containing sets of items associated
-with the block (eg. addresses sent to, outpoints spent, etc.). A set of such
+with the block (eg. addresses sent to, outputs spent, etc.). A set of such
 data objects is compressed into a probabilistic structure called a
 ''Golomb-coded set'' (GCS), which matches all items in the set with probability
 1, and matches other items with probability <code>1/M</code> for some


### PR DESCRIPTION
Fix a potential typo in BIP158.