### PR TITLE
BIP88: fix description of the "*h/0" example

### DIFF
--- a/bip-0088.mediawiki
+++ b/bip-0088.mediawiki
@@ -223,7 +223,7 @@ Its representation after parsing can be (using Python syntax, ignoring full/part
 Its representation after parsing can be:
     [[(0, 2), (33, 33), (123, 123)], [(0, 2147483647)]]
 
-<code>*h/0</code> specifies a partial template that matches any hardened index followed by any non-hardened index
+<code>*h/0</code> specifies a partial template that matches any hardened index followed by non-hardened index 0
 
 Its representation after parsing can be:
     [[(2147483648, 4294967295)], [(0, 0)]]


### PR DESCRIPTION
The text describing the example wrongfully stated "followed by any non-hardened index" while the second index is just 0