### PR TITLE
Updated URL of the JavaScript reference implementation

### DIFF
--- a/bip-0039.mediawiki
+++ b/bip-0039.mediawiki
@@ -163,7 +163,7 @@ Haskell:
 * https://github.com/NicolasDorier/NBitcoin
 
 JavaScript:
-* https://github.com/bitpay/bitcore-mnemonic
+* https://github.com/bitpay/bitcore/tree/master/packages/bitcore-mnemonic
 * https://github.com/bitcoinjs/bip39 (used by [[https://github.com/blockchain/My-Wallet-V3/blob/v3.8.0/src/hd-wallet.js#L121-L146|blockchain.info]])
 
 Java:


### PR DESCRIPTION
Old repo is archived and links to the new repo are found in the old one's README file. This change updates the old repo's link to the new one.