### PR TITLE
Replaces Bech32 by Bech32m in BIP341

### DIFF
--- a/bip-0341.mediawiki
+++ b/bip-0341.mediawiki
@@ -336,7 +336,7 @@ Non-upgraded nodes, however, will consider all SegWit version 1 witness programs
 They are strongly encouraged to upgrade in order to fully validate the new programs.
 
 Non-upgraded wallets can receive and send bitcoin from non-upgraded and upgraded wallets using SegWit version 0 programs, traditional pay-to-pubkey-hash, etc.
-Depending on the implementation non-upgraded wallets may be able to send to Segwit version 1 programs if they support sending to [[bip-0173.mediawiki|BIP173]] Bech32 addresses.
+Depending on the implementation non-upgraded wallets may be able to send to Segwit version 1 programs if they support sending to [[bip-0350.mediawiki|BIP350]] Bech32m addresses.
 
 == Acknowledgements ==
 


### PR DESCRIPTION
Segwit version 1 is encoded by Bech32m given by BIP350