### PR TITLE
BIP155: extra-clarify the semantic of sendaddrv2

### DIFF
--- a/bip-0155.mediawiki
+++ b/bip-0155.mediawiki
@@ -131,7 +131,7 @@ See the appendices for the address encodings to be used for the various networks
 
 ==Signaling support and compatibility==
 
-Introduce a new message type <code>sendaddrv2</code>. Sending such a message indicates that a node can understand and prefers to receive <code>addrv2</code> messages instead of <code>addr</code> messages. I.e. "Send me addrv2".
+Introduce a new message type <code>sendaddrv2</code>. Sending such a message indicates that a node can understand and prefers to receive <code>addrv2</code> messages instead of <code>addr</code> messages. I.e. "Send me addrv2". Sending or not sending this message does not imply any preference with respect to receiving unrequested address messages.
 
 The <code>sendaddrv2</code> message MUST only be sent in response to the <code>version</code> message from a peer and prior to sending the <code>verack</code> message.
 


### PR DESCRIPTION
BIP155: extra-clarify the semantic of sendaddrv2.

This is also how the code works currently.

There seems to be some [misinterpretation](https://github.com/bitcoin/bitcoin/pull/22245#issuecomment-862246086) of the current wording in BIP155. Clarify that (hopefully).