### PR TITLE
BIP118: Key version should be 0x01

### DIFF
--- a/bip-0118.mediawiki
+++ b/bip-0118.mediawiki
@@ -131,8 +131,8 @@ Note that if ''hash_type & 0x40'' is zero, ''SigMsg118(hash_type,ext_flag) == Si
 
 To verify a signature ''sig'' for a BIP 118 public key ''p'':
 
-* If the ''sig'' is 64 bytes long, return ''Verify(p, hash<sub>TapSigHash</sub>(0x00 || SigMsg118(0x00, 1) || SigExt118(0x00, 0x02), sig)'', where ''Verify'' is defined in [[bip-0340.mediawiki|BIP 340]].
-* If the ''sig'' is 65 bytes long, return ''sig[64] &ne; 0x00 and Verify(p, hash<sub>TapSighash</sub>(0x00 || SigMsg118(sig[64], 1) || SigExt118(sig[64], 0x02), sig[0:64])''.
+* If the ''sig'' is 64 bytes long, return ''Verify(p, hash<sub>TapSigHash</sub>(0x00 || SigMsg118(0x00, 1) || SigExt118(0x00, 0x01), sig)'', where ''Verify'' is defined in [[bip-0340.mediawiki|BIP 340]].
+* If the ''sig'' is 65 bytes long, return ''sig[64] &ne; 0x00 and Verify(p, hash<sub>TapSighash</sub>(0x00 || SigMsg118(sig[64], 1) || SigExt118(sig[64], 0x01), sig[0:64])''.
 * Otherwise, fail.
 
 The key differences from [[bip-0342.mediawiki|BIP 342]] signature verification are:


### PR DESCRIPTION
The key version should be 1 unless I am misunderstanding something. 