### PR TITLE
remove int_from_bytes in lift_x call since it is done internally

### DIFF
--- a/bip-0341.mediawiki
+++ b/bip-0341.mediawiki
@@ -180,7 +180,7 @@ def taproot_tweak_pubkey(pubkey, h):
     t = int_from_bytes(tagged_hash("TapTweak", pubkey + h))
     if t >= SECP256K1_ORDER:
         raise ValueError
-    Q = point_add(lift_x(int_from_bytes(pubkey)), point_mul(G, t))
+    Q = point_add(lift_x(pubkey), point_mul(G, t))
     return 0 if has_even_y(Q) else 1, bytes_from_int(x(Q))
 
 def taproot_tweak_seckey(seckey0, h):


### PR DESCRIPTION
Functions defined in the document refers to `reference.py` created in BIP340 and there the `lift_x` function accepts bytes and converts to int internally https://github.com/bitcoin/bips/blob/99701f68a88ce33b2d0838eb84e115cef505b4c2/bip-0340/reference.py#L71