### PR TITLE
BIP-48: Trivial errant apostrophe fix

### DIFF
--- a/bip-0048.mediawiki
+++ b/bip-0048.mediawiki
@@ -42,7 +42,7 @@ This paper was inspired from BIP44.
 Currently a number of wallets utilize the ‎<code>m/48'</code> derivation scheme for HD multi-sig accounts.
 This BIP is intended to maintain the *existing* real world use of the ‎<code>m/48'</code> derivation.
 No breaking changes are made so as to avoid "loss of funds" to existing users.
-Wallet's which currently support the ‎<code>m/48'</code> derivation will not need to make any changes
+Wallets which currently support the ‎<code>m/48'</code> derivation will not need to make any changes
 to comply with this BIP.
 
 ==Specification==


### PR DESCRIPTION
Plural "wallets", not possessive "wallet's".