### PR TITLE
[BIP78] Recommended fee rate estimation for P2TR

### DIFF
--- a/bip-0078.mediawiki
+++ b/bip-0078.mediawiki
@@ -229,6 +229,9 @@ Our recommendation for <code>maxadditionalfeecontribution=</code> is <code>origi
 |-
 |P2SH-P2WPKH
 |91
+|-
+|P2TR
+|58
 |}
 
 


### PR DESCRIPTION
Non-Witness: 

Outpoint size = 32+4
Sequence size = 4
ScriptSig VarInt Size= 1

Witness: 

WitScript VarInt Size= 1
Then script itself: 65 signature size + 1 byte of push opcode

`(32 + 4 + 4 + 1) + (65+1+1)/4=57.75`, rounded up `58`.

We assume 65 of signature size rather than 64, since we can't assume the sighash to be `Default`.