### PR TITLE
[BIP174] Fix broken link to psbt2

### DIFF
--- a/bip-0174.mediawiki
+++ b/bip-0174.mediawiki
@@ -125,7 +125,7 @@ The currently defined global types are as follows:
 | 2
 | 0
 | 2
-| [[bip-psb2.mediawiki|psbt2]]
+| [[bip-0370.mediawiki|370]]
 |-
 | Fallback Locktime
 | <tt>PSBT_GLOBAL_FALLBACK_LOCKTIME = 0x03</tt>
@@ -136,7 +136,7 @@ The currently defined global types are as follows:
 |
 | 0
 | 2
-| [[bip-psb2.mediawiki|psbt2]]
+| [[bip-0370.mediawiki|370]]
 |-
 | Input Count
 | <tt>PSBT_GLOBAL_INPUT_COUNT = 0x04</tt>
@@ -147,7 +147,7 @@ The currently defined global types are as follows:
 | 2
 | 0
 | 2
-| [[bip-psb2.mediawiki|psbt2]]
+| [[bip-0370.mediawiki|370]]
 |-
 | Output Count
 | <tt>PSBT_GLOBAL_OUTPUT_COUNT = 0x05</tt>
@@ -158,7 +158,7 @@ The currently defined global types are as follows:
 | 2
 | 0
 | 2
-| [[bip-psb2.mediawiki|psbt2]]
+| [[bip-0370.mediawiki|370]]
 |-
 | Transaction Modifiable Flags
 | <tt>PSBT_GLOBAL_TX_MODIFIABLE = 0x06</tt>
@@ -169,7 +169,7 @@ The currently defined global types are as follows:
 |
 | 0
 | 2
-| [[bip-psb2.mediawiki|psbt2]]
+| [[bip-0370.mediawiki|370]]
 |-
 | SIGHASH_SINGLE Inputs
 | <tt>PSBT_GLOBAL_SIGHASH_SINGLE_INPUTS = 0x07</tt>
@@ -180,7 +180,7 @@ The currently defined global types are as follows:
 |
 | 0
 | 2
-| [[bip-psb2.mediawiki|psbt2]]
+| [[bip-0370.mediawiki|370]]
 |-
 | PSBT Version Number
 | <tt>PSBT_GLOBAL_VERSION = 0xFB</tt>
@@ -382,7 +382,7 @@ The currently defined per-input types are defined as follows:
 | 2
 | 0
 | 2
-| [[bip-psb2.mediawiki|psbt2]]
+| [[bip-0370.mediawiki|370]]
 |-
 | Spent Output Index
 | <tt>PSBT_IN_OUTPUT_INDEX = 0x0f</tt>
@@ -393,7 +393,7 @@ The currently defined per-input types are defined as follows:
 | 2
 | 0
 | 2
-| [[bip-psb2.mediawiki|psbt2]]
+| [[bip-0370.mediawiki|370]]
 |-
 | Sequence Number
 | <tt>PSBT_IN_SEQUENCE = 0x10</tt>
@@ -404,7 +404,7 @@ The currently defined per-input types are defined as follows:
 |
 | 0
 | 2
-| [[bip-psb2.mediawiki|psbt2]]
+| [[bip-0370.mediawiki|370]]
 |-
 | Required Time-based Locktime
 | <tt>PSBT_IN_REQUIRED_TIME_LOCKTIME = 0x11</tt>
@@ -415,7 +415,7 @@ The currently defined per-input types are defined as follows:
 |
 | 0
 | 2
-| [[bip-psb2.mediawiki|psbt2]]
+| [[bip-0370.mediawiki|370]]
 |-
 | Required Height-based Locktime
 | <tt>PSBT_IN_REQUIRED_HEIGHT_LOCKTIME = 0x12</tt>
@@ -426,7 +426,7 @@ The currently defined per-input types are defined as follows:
 |
 | 0
 | 2
-| [[bip-psb2.mediawiki|psbt2]]
+| [[bip-0370.mediawiki|370]]
 |-
 | Taproot Key Spend Signature
 | <tt>PSBT_IN_TAP_KEY_SIG = 0x13</tt>
@@ -564,7 +564,7 @@ determine which outputs are change outputs and verify that the change is returni
 | 2
 | 0
 | 2
-| [[bip-psb2.mediawiki|psbt2]]
+| [[bip-0370.mediawiki|370]]
 |-
 | Output Script
 | <tt>PSBT_OUT_SCRIPT = 0x04</tt>
@@ -575,7 +575,7 @@ determine which outputs are change outputs and verify that the change is returni
 | 2
 | 0
 | 2
-| [[bip-psb2.mediawiki|psbt2]]
+| [[bip-0370.mediawiki|370]]
 |-
 | Taproot Internal Key
 | <tt>PSBT_OUT_TAP_INTERNAL_KEY = 0x05</tt>


### PR DESCRIPTION
The link to PSBT2, which was broken before the BIP number was assigned, is now linked to BIP370.