### PR TITLE
typo in bip-0078

### DIFF
--- a/bip-0078.mediawiki
+++ b/bip-0078.mediawiki
@@ -637,7 +637,7 @@ A successful exchange with:
 !maxadditionalfeecontribution
 !additionalfeeoutputindex
 |-
-|P2SH-P2WSH
+|P2SH-P2WPKH
 |2 sat/vbyte
 |0.00000182
 |0


### PR DESCRIPTION
This is a transaction with inputs of type P2SH-P2WPKH 
1. P2SH-P2WPKH is defined as a valid type for payjoins in this doc and the other type not.
2. The RedeemScript(0 c78a45725355828d5658074dd5260d5fcb698530) consists of 0 + <20 bytes> and indicates therefore P2WPKH-Type. https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#P2WPKH_nested_in_BIP16_P2SH