### PR TITLE
Remove newline to fix list rendering

### DIFF
--- a/bip-0158.mediawiki
+++ b/bip-0158.mediawiki
@@ -273,10 +273,8 @@ This BIP defines one initial filter type:
 The basic filter is designed to contain everything that a light client needs to
 sync a regular Bitcoin wallet. A basic filter MUST contain exactly the
 following items for each transaction in a block:
-* The previous output script (the script being spent) for each input, except
-  for the coinbase transaction.
-* The scriptPubKey of each output, aside from all <code>OP_RETURN</code> output
-  scripts.
+* The previous output script (the script being spent) for each input, except for the coinbase transaction.
+* The scriptPubKey of each output, aside from all <code>OP_RETURN</code> output scripts.
 
 Any "nil" items MUST NOT be included into the final set of filter elements.
 


### PR DESCRIPTION
Currently the newline in list items in BIP-0158 is causing the text on the new line to be rendered as a code section. I am unsure why this is happening but putting all the text for each list item on a single line fixes it.