### PR TITLE
[BIP 158] Fix grammar - remove 'was chosen as'

### DIFF
--- a/bip-0158.mediawiki
+++ b/bip-0158.mediawiki
@@ -299,9 +299,9 @@ one is able to select <code>P</code> and <code>M</code> independently, then
 setting <code>M=1.497137 * 2^P</code> is close to optimal
 <ref>https://gist.github.com/sipa/576d5f09c3b86c3b1b75598d799fc845</ref>.
 
-Empirical analysis also shows that was chosen as these parameters minimize the
-bandwidth utilized, considering both the expected number of blocks downloaded
-due to false positives and the size of the filters themselves.
+Empirical analysis also shows that these parameters minimize the bandwidth
+utilized, considering both the expected number of blocks downloaded due to false
+positives and the size of the filters themselves.
 
 The parameter <code>k</code> MUST be set to the first 16 bytes of the hash
 (in standard little-endian representation) of the block for which the filter is


### PR DESCRIPTION
This sentence is grammatically incorrect:

    "Empirical analysis also shows that was chosen as these parameters ..."

Elect to fix the sentence to be:

    "Empirical analysis also shows that these parameters ..."