### PR TITLE
[BIP78] Fix client implementation when there is output substitution

### DIFF
--- a/bip-0078.mediawiki
+++ b/bip-0078.mediawiki
@@ -541,10 +541,16 @@ public async Task<PSBT> RequestPayjoin(
         // Verify that no keypaths is in the PSBT output
         if (proposedPSBTOutput.HDKeyPaths.Count != 0)
             throw new PayjoinSenderException("The receiver added keypaths to an output");
-        bool isOriginalOutput = originalOutputs.Count > 0 && originalOutputs.Peek().OriginalTxOut.ScriptPubKey == proposedPSBTOutput.ScriptPubKey;
-        if (isOriginalOutput)
+        if (originalOutputs.Count == 0)
+                continue;
+        var originalOutput = originalOutputs.Peek();
+        bool isOriginalOutput = originalOutput.OriginalTxOut.ScriptPubKey == proposedPSBTOutput.ScriptPubKey;
+        bool substitutedOutput = !isOriginalOutput &&
+                                allowOutputSubstitution &&
+                                originalOutput.OriginalTxOut.ScriptPubKey == paymentScriptPubKey;
+        if (isOriginalOutput || substitutedOutput)
         {
-            var originalOutput = originalOutputs.Dequeue();
+            originalOutputs.Dequeue();
             if (output.OriginalTxOut == feeOutput)
             {
                 var actualContribution = feeOutput.Value - proposedPSBTOutput.Value;


### PR DESCRIPTION
There was a bug in the payjoin client reference implementation if the receiver used output substitution, causing the payjoin to fallback to normal payment unecessarily.

Fixing bug reported by @Kixunil (https://github.com/btcpayserver/btcpayserver/issues/2677)
Fixed on the C# client (https://github.com/btcpayserver/BTCPayServer.BIP78/commit/451e1126f7b3f5c6bb9b648aa3ac6bd7485996ee) and tested by Kixunil.

The bug was best explained by @Kixunil

-------

* The code was iterating over proposed PSBT outputs and have original outputs in a queue.
* It was comparing the proposed output to the output at the front of the queue
* If there are two outputs: payee, payer_change - in this order, then if payee substituted the output, the comparison is false. Then  we did nothing with it and thus leaving the output in the queue, blocking the remaining iterations from seeing following outputs.