### PR TITLE
BIP 371: Require Schnorr sig to be 64 bytes long

### DIFF
--- a/bip-0371.mediawiki
+++ b/bip-0371.mediawiki
@@ -50,7 +50,7 @@ The new per-input types are defined as follows:
 | None
 | No key data <ref>'''Why is there no key data for <tt>PSBT_IN_TAP_KEY_SIG</tt>'''The signature in a key path spend corresponds directly with the pubkey provided in the output script. Thus it is not necessary to provide any metadata that attaches the key path spend signature to a particular pubkey.</ref>
 | <tt><signature></tt>
-| The 64 or 65 byte Schnorr signature for key path spending a Taproot output. Finalizers should remove this field after <tt>PSBT_IN_FINAL_SCRIPTWITNESS</tt> is constructed.
+| The 64 Schnorr signature for key path spending a Taproot output. Finalizers should remove this field after <tt>PSBT_IN_FINAL_SCRIPTWITNESS</tt> is constructed.
 |
 |
 | 0, 2
@@ -60,7 +60,7 @@ The new per-input types are defined as follows:
 | <tt><xonlypubkey> <leafhash></tt>
 | A 32 byte X-only public key involved in a leaf script concatenated with the 32 byte hash of the leaf it is part of.
 | <tt><signature></tt>
-| The 64 or 65 byte Schnorr signature for this pubkey and leaf combination. Finalizers should remove this field after <tt>PSBT_IN_FINAL_SCRIPTWITNESS</tt> is constructed.
+| The 64 Schnorr signature for this pubkey and leaf combination. Finalizers should remove this field after <tt>PSBT_IN_FINAL_SCRIPTWITNESS</tt> is constructed.
 |
 |
 | 0, 2


### PR DESCRIPTION
BIP-340 does not defines 65 byte serialization for Schnorr signature. Allowing it here introduces unnecessary and non-standard complexity for implementing PSBT v2.