### PR TITLE
[BIP 157] Add missing words to sentence

### DIFF
--- a/bip-0157.mediawiki
+++ b/bip-0157.mediawiki
@@ -431,9 +431,9 @@ document proposes a solution purely at the P2P layer.
 
 The constant interval of 1,000 blocks between checkpoints was chosen so that,
 given the current chain height and rate of growth, the size of a
-<code>cfcheckpt</code> message is not drastically from a
-<code>cfheaders</code> between two checkpoints. Also, 1,000 is a nice round
-number, at least to those of us who think in decimal.
+<code>cfcheckpt</code> message is not drastically different from a
+<code>cfheaders</code> message between two checkpoints. Also, 1,000 is a nice
+round number, at least to those of us who think in decimal.
 
 == Compatibility ==
 


### PR DESCRIPTION
This sentence does not quite make sense

... the size of a `cfcheckpt` message is not drastically from a `cfheaders` between two checkpoints. ...

Change it to be:

... the size of a `cfcheckpt` message is not drastically different from a `cfheaders` message between two checkpoints. ...