### PR TITLE
docs: add passphrase.js to JS list

### DIFF
--- a/bip-0039.mediawiki
+++ b/bip-0039.mediawiki
@@ -165,6 +165,7 @@ Haskell:
 JavaScript:
 * https://github.com/bitpay/bitcore/tree/master/packages/bitcore-mnemonic
 * https://github.com/bitcoinjs/bip39 (used by [[https://github.com/blockchain/My-Wallet-V3/blob/v3.8.0/src/hd-wallet.js#L121-L146|blockchain.info]])
+* https://github.com/therootcompany/passphrase.js (VanillaJS + WebCrypto, Browser-compatible)
 
 Java:
 * https://github.com/bitcoinj/bitcoinj/blob/master/core/src/main/java/org/bitcoinj/crypto/MnemonicCode.java


### PR DESCRIPTION
A modern, WebCrypto-based JS implementation.

No dependencies. No webpack / browserify / etc. Just Works™.

Passes all of https://github.com/trezor/python-mnemonic/blob/master/vectors.json.

Demo at: https://therootcompany.github.io/passphrase.js/