### PR TITLE
BIP 0001: Absolute path for figure.

### DIFF
--- a/bip-0001.mediawiki
+++ b/bip-0001.mediawiki
@@ -58,7 +58,9 @@ BIPs can also be superseded by a different BIP, rendering the original obsolete.
 
 The possible paths of the status of BIPs are as follows:
 
-<img src=bip-0001/process.png></img>
+[https://raw.githubusercontent.com/bitcoin/bips/master/bip-0001/process.png Figure 1]
+
+<img src="https://raw.githubusercontent.com/bitcoin/bips/master/bip-0001/process.png"></img>
 
 Some Informational and Process BIPs may also have a status of "Active" if they are never meant to be completed. E.g. BIP 1 (this BIP).
 


### PR DESCRIPTION
Using an absolute path for the figure, instead of a relative path,
could help figure presentation on [the bitcoin.it wiki][0], while not
affecting presentation on GitHub.

[0]: https://en.bitcoin.it/wiki/BIP_0001