### PR TITLE
BIP 0032: Keys pool size has increased to 1000

### DIFF
--- a/bip-0032.mediawiki
+++ b/bip-0032.mediawiki
@@ -311,9 +311,10 @@ These vectors test that invalid extended keys are recognized as invalid.
 
 ==Historic notes==
 
-In this BIP is stated that the Bitcoin reference client caches (by default) 100
-keys in a pool of reserve keys. As of late 2021, contemporary reference clients
-cache (by default) 1000 keys instead, courtesy of Maxwell et al., July 2017.
+It is stated in this BIP that the Bitcoin reference client caches (by default)
+100 keys in a pool of reserve keys. As of late 2021, contemporary reference
+clients cache (by default) 1000 keys instead, courtesy of
+Maxwell et al., July 2017.
 
 ==Acknowledgements==
 

--- a/bip-0032.mediawiki
+++ b/bip-0032.mediawiki
@@ -309,6 +309,12 @@ These vectors test that invalid extended keys are recognized as invalid.
 * xpub661MyMwAqRbcEYS8w7XLSVeEsBXy79zSzH1J8vCdxAZningWLdN3zgtU6Q5JXayek4PRsn35jii4veMimro1xefsM58PgBMrvdYre8QyULY (invalid pubkey 020000000000000000000000000000000000000000000000000000000000000007)
 * xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHL (invalid checksum)
 
+==Historic notes==
+
+In this BIP is stated that the Bitcoin reference client caches (by default) 100
+keys in a pool of reserve keys. As of late 2021, contemporary reference clients
+cache (by default) 1000 keys instead, courtesy of Maxwell et al., July 2017.
+
 ==Acknowledgements==
 
 * Gregory Maxwell for the original idea of type-2 deterministic wallets, and many discussions about it.


### PR DESCRIPTION
In this BIP is stated that the Bitcoin reference client caches (by default) 100
keys in a pool of reserve keys. As of late 2021, contemporary reference clients
cache (by default) 1000 keys instead, courtesy of Maxwell et al., July 2017.
