### PR TITLE
BIP 0174: Remove transparent background from figures

### DIFF
--- a/bip-0174/coinjoin-workflow.svg
+++ b/bip-0174/coinjoin-workflow.svg
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="420.819pt" height="118.266pt" viewBox="0 0 420.819 118.266" version="1.1">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="420.819pt" height="118.266pt"
+     viewBox="0 0 420.819 118.266" style="background-color:white" version="1.1">
 <defs>
 <g>
 <symbol overflow="visible" id="glyph0-0">

--- a/bip-0174/multisig-workflow.svg
+++ b/bip-0174/multisig-workflow.svg
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="375.988pt" height="411.906pt" viewBox="0 0 375.988 411.906" version="1.1">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="375.988pt" height="411.906pt"
+     viewBox="0 0 375.988 411.906" style="background-color:white" version="1.1">
 <defs>
 <g>
 <symbol overflow="visible" id="glyph0-0">


### PR DESCRIPTION
This is basically the same as https://github.com/bitcoin/bips/pull/1184
and https://github.com/bitcoin/bips/pull/1192. In 1192, node connections
are visible, but with low contrast. In 1184 and in this case, arrows are
barely visible at all.
