### PR TITLE
Correct format of PSBT_GLOBAL_TX_MODIFIABLE

### DIFF
--- a/bip-0174.mediawiki
+++ b/bip-0174.mediawiki
@@ -164,8 +164,8 @@ The currently defined global types are as follows:
 | <tt>PSBT_GLOBAL_TX_MODIFIABLE = 0x06</tt>
 | None
 | No key data
-| <tt><single byte boolean> <single byte boolean> <bitvector></tt>
-| A single byte boolean (0 for False, 1 for True) representing whether inputs can be modified, followed by a single byte boolean representing whether outputs can be modified.
+| <tt><8-bit uint></tt>
+| An 8 bit little endian unsigned integer as a bitfield for various transaction modification flags. Bit 0 is the Inputs Modifiable Flag and indicates whether inputs can be modified. Bit 1 is the Outputs Modifiable Flag and indicates whether outputs can be modified. Bit 2 is the Has SIGHASH_SINGLE flag and indicates whether the transaction has a SIGHASH_SINGLE signature who's input and output pairing must be preserved. Bit 2 essentially indicates that the Constructor must iterate the inputs to determine whether and how to add an input.
 |
 | 0
 | 2


### PR DESCRIPTION
The descriptions for this field differ between bip370 and bip174. I suppose the correct format of PSBT_GLOBAL_TX_MODIFIABLE is the one in BIP370.