### PR TITLE
BIP 370: Use PSBT_GLOBAL_FALLBACK_LOCKTIME in text

### DIFF
--- a/bip-0370.mediawiki
+++ b/bip-0370.mediawiki
@@ -209,9 +209,9 @@ The new per-output types for PSBT Version 2 are defined as follows:
 
 ===Determining Lock Time===
 
-The nLockTime field of a transaction is determined by inspecting the PSBT_GLOBAL_PREFERRED_LOCKTIME and each input's PSBT_IN_REQUIRED_TIME_LOCKTIME and PSBT_IN_REQUIRED_HEIGHT_LOCKTIME fields.
-If none of the inputs have a PSBT_IN_REQUIRED_TIME_LOCKTIME and PSBT_IN_REQUIRED_HEIGHT_LOCKTIME, then PSBT_GLOBAL_PREFERRED_LOCKTIME must be used.
-If PSBT_GLOBAL_PREFERRED_LOCKTIME is not provided, then it is assumed to be 0.
+The nLockTime field of a transaction is determined by inspecting the PSBT_GLOBAL_FALLBACK_LOCKTIME and each input's PSBT_IN_REQUIRED_TIME_LOCKTIME and PSBT_IN_REQUIRED_HEIGHT_LOCKTIME fields.
+If none of the inputs have a PSBT_IN_REQUIRED_TIME_LOCKTIME and PSBT_IN_REQUIRED_HEIGHT_LOCKTIME, then PSBT_GLOBAL_FALLBACK_LOCKTIME must be used.
+If PSBT_GLOBAL_FALLBACK_LOCKTIME is not provided, then it is assumed to be 0.
 
 If one or more inuts have a PSBT_IN_REQUIRED_TIME_LOCKTIME or PSBT_IN_REQUIRED_HEIGHT_LOCKTIME, then the field chosen is the one which is supported by all of the inputs.
 This can be determined by looking at all of the inputs which specify a locktime in either of those fields, and choosing the field which is present in all of those inputs.
@@ -232,7 +232,7 @@ PSBTv2 introduces new roles and modifies some existing roles.
 
 In PSBTv2, the Creator initializes the PSBT with 0 inputs and 0 outputs.
 The PSBT version number is set to 2. The transaction version number must be set to at least 2. <ref>'''Why does the transaction version number need to be at least 2?''' The transaction version number is part of the validation rules for some features such as OP_CHECKSEQUENCEVERIFY. Since it is backwards compatible, and there are other ways to disable those features (e.g. through sequence numbers), it is easier to require transactions be able to support these features than to try to negotiate the transaction version number.</ref>
-The Creator should also set PSBT_GLOBAL_PREFERRED_LOCKTIME.
+The Creator should also set PSBT_GLOBAL_FALLBACK_LOCKTIME.
 If the Creator is not also a Constructor and will be giving the PSBT to others to add inputs and outputs, the PSBT_GLOBAL_TX_MODIFIABLE field must be present and and the Inputs Modifiable and Outputs Modifiable flags set appropriately.
 If the Creator is a Constructor and no inputs and outputs will be added by other entities, PSBT_GLOBAL_TX_MODIFIABLE may be omitted.
 


### PR DESCRIPTION
Replacing occurences of PSBT_GLOBAL_PREFERRED_LOCKTIME with PSBT_GLOBAL_FALLBACK_LOCKTIME to match the name in the global map table.