### PR TITLE
Make Wikitext linguist-detectable

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.mediawiki linguist-detectable


### PR DESCRIPTION
Before this change, repository gets detected as:

Python 66.4%
Go 12.9%
Perl 11.0%
TeX 8.1%
Shell 1.6%

After this change, repository gets detected as:

Wikitext 97.2%
Python 1.9%
Other 0.9%

This change was added for a cosmetic effect on GitHub, and the line
this change adds can go away in any of these cases:

* Conflict with other tool used for reading these documents.

* GitHub ceases to use the line.

* GitHub ceases to be used as a reading medium for these documents.

* GitHub ceases to exist.