### PR TITLE
BIP340: Make reference impl accept None for aux_rand

### DIFF
--- a/bip-0340/reference.py
+++ b/bip-0340/reference.py
@@ -96,18 +96,18 @@ def pubkey_gen(seckey: bytes) -> bytes:
     assert P is not None
     return bytes_from_point(P)
 
-def schnorr_sign(msg: bytes, seckey: bytes, aux_rand: bytes) -> bytes:
+def schnorr_sign(msg: bytes, seckey: bytes, aux_rand: Optional[bytes]) -> bytes:
     if len(msg) != 32:
         raise ValueError('The message must be a 32-byte array.')
     d0 = int_from_bytes(seckey)
     if not (1 <= d0 <= n - 1):
         raise ValueError('The secret key must be an integer in the range 1..n-1.')
-    if len(aux_rand) != 32:
+    if not aux_rand is None and len(aux_rand) != 32:
         raise ValueError('aux_rand must be 32 bytes instead of %i.' % len(aux_rand))
     P = point_mul(G, d0)
     assert P is not None
     d = d0 if has_even_y(P) else n - d0
-    t = xor_bytes(bytes_from_int(d), tagged_hash("BIP0340/aux", aux_rand))
+    t = bytes_from_int(d) if aux_rand is None else xor_bytes(bytes_from_int(d), tagged_hash("BIP0340/aux", aux_rand))
     k0 = int_from_bytes(tagged_hash("BIP0340/nonce", t + bytes_from_point(P) + msg)) % n
     if k0 == 0:
         raise RuntimeError('Failure. This happens only with negligible probability.')


### PR DESCRIPTION
Checking the libsecp256k1 implementation, it accepts a null pointer for aux_rand and uses the possibly negated private key alone without XORing with anything in that case.

This fix brings the implementation in-line with the C implementation.