### PR TITLE
BIP 0174: Clarify use of PSBT_IN_FINAL_* when data is empty

### DIFF
--- a/bip-0174.mediawiki
+++ b/bip-0174.mediawiki
@@ -798,6 +798,8 @@ Or, for participants performing fA(psbt) and fB(psbt): Combine(fA(psbt), fB(psbt
 
 The Input Finalizer must only accept a PSBT.
 For each input, the Input Finalizer determines if the input has enough data to pass validation. If it does, it must construct the <tt>0x07</tt> Finalized scriptSig and <tt>0x08</tt> Finalized scriptWitness and place them into the input key-value map.
+If scriptSig is empty for an input, <tt>0x07</tt> should remain unset rather than assigned an empty array.
+Likewise, if no scriptWitness exists for an input, <tt>0x08</tt> should remain unset rather than assigned an empty array.
 All other data except the UTXO and unknown fields in the input key-value map should be cleared from the PSBT. The UTXO should be kept to allow Transaction Extractors to verify the final network serialized transaction.
 
 ===Transaction Extractor===


### PR DESCRIPTION
This is a clarification on how PSBT_IN_FINAL_SCRIPTSIG and PSBT_IN_FINAL_SCRIPTWITNESS should be handled when the data is empty. Based on feedback from @achow101 on twitter https://twitter.com/kallerosenbaum/status/1443856371368271872

It seems [more people than I](https://twitter.com/benthecarman/status/1443858125971501057?s=20) had interpreted the bip like you should always set PSBT_IN_FINAL_* even if data is empty, but @achow101 says we should leave those unset.