### PR TITLE
BIP 0370: Signer to determine locktime

### DIFF
--- a/bip-0370.mediawiki
+++ b/bip-0370.mediawiki
@@ -272,6 +272,8 @@ For PSBTv2, an Updater can set the sequence number.
 ===Signer===
 
 For PSBTv2s, a signer must update the PSBT_GLOBAL_TX_MODIFIABLE field after signing inputs so that it accurately reflects the state of the PSBT.
+The lock time for this transaction is determined as described in the Determining Lock Time section.
+The signer must set the PSBT_GLOBAL_FALLBACK_LOCKTIME to the determined value or optionally unset it if the determined value is 0, and delete any per-input PSBT_IN_REQUIRED_TIME_LOCKTIME and PSBT_IN_REQUIRED_HEIGHT_LOCKTIME.
 If the Signer added a signature that does not use SIGHASH_ANYONECANPAY, the Input Modifiable flag must be set to False.
 If the Signer added a signature that does not use SIGHASH_NONE, the Outputs Modifiable flag must be set to False.
 If the Signer added a signature that uses SIGHASH_SINGLE, the Has SIGHASH_SINGLE flag must be set to True.
@@ -279,7 +281,7 @@ If the Signer added a signature that uses SIGHASH_SINGLE, the Has SIGHASH_SINGLE
 ===Transaction Extractor===
 
 For PSBTv2s, the transaction is constructed using the PSBTv2 fields.
-The lock time for this transaction is determined as described in the Determining Lock Time section.
+The lock time for this transaction is read from PSBT_GLOBAL_FALLBACK_LOCKTIME or 0 if unset.
 The Extractor should produce a fully valid, network serialized transaction if all inputs are complete.
 
 ==Backwards Compatibility==


### PR DESCRIPTION
Since the signer has to determine the locktime before signing, the extractor shouldn't have to redo that work. This PR suggests that the signer updates the PSBT_GLOBAL_FALLBACK_LOCKTIME, and that the extractor later uses this value.