### PR TITLE
Define BIP-119 CheckDefaultCheckTemplateVerifyHash

### DIFF
--- a/bip-0119.mediawiki
+++ b/bip-0119.mediawiki
@@ -159,6 +159,12 @@ specification for the semantics of OP_CHECKTEMPLATEVERIFY.
     }
     break;
 
+Where
+
+    bool CheckDefaultCheckTemplateVerifyHash(uint256 hash) {
+        return GetDefaultCheckTemplateVerifyHash(current_tx, current_input_index) == hash;
+    }
+
 The hash is computed as follows:
 
     uint256 GetDefaultCheckTemplateVerifyHash(const CTransaction& tx, uint32_t input_index) {

--- a/bip-0119.mediawiki
+++ b/bip-0119.mediawiki
@@ -145,7 +145,7 @@ specification for the semantics of OP_CHECKTEMPLATEVERIFY.
         // If the argument was not 32 bytes, treat as OP_NOP4:
         switch (stack.back().size()) {
             case 32:
-                if (!checker.CheckDefaultCheckTemplateVerifyHash(uint256(stack.back()))) {
+                if (!checker.CheckDefaultCheckTemplateVerifyHash(stack.back())) {
                     return set_error(serror, SCRIPT_ERR_TEMPLATE_MISMATCH);
                 }
                 break;
@@ -161,8 +161,8 @@ specification for the semantics of OP_CHECKTEMPLATEVERIFY.
 
 Where
 
-    bool CheckDefaultCheckTemplateVerifyHash(uint256 hash) {
-        return GetDefaultCheckTemplateVerifyHash(current_tx, current_input_index) == hash;
+    bool CheckDefaultCheckTemplateVerifyHash(const std::vector<unsigned char>& hash) {
+        return GetDefaultCheckTemplateVerifyHash(current_tx, current_input_index) == uint256(hash);
     }
 
 The hash is computed as follows:

--- a/bip-0119.mediawiki
+++ b/bip-0119.mediawiki
@@ -145,7 +145,7 @@ specification for the semantics of OP_CHECKTEMPLATEVERIFY.
         // If the argument was not 32 bytes, treat as OP_NOP4:
         switch (stack.back().size()) {
             case 32:
-                if (!checker.CheckDefaultCheckTemplateVerifyHash(stack.back())) {
+                if (!checker.CheckDefaultCheckTemplateVerifyHash(u256(stack.back()))) {
                     return set_error(serror, SCRIPT_ERR_TEMPLATE_MISMATCH);
                 }
                 break;

--- a/bip-0119.mediawiki
+++ b/bip-0119.mediawiki
@@ -145,7 +145,7 @@ specification for the semantics of OP_CHECKTEMPLATEVERIFY.
         // If the argument was not 32 bytes, treat as OP_NOP4:
         switch (stack.back().size()) {
             case 32:
-                if (!checker.CheckDefaultCheckTemplateVerifyHash(u256(stack.back()))) {
+                if (!checker.CheckDefaultCheckTemplateVerifyHash(uint256(stack.back()))) {
                     return set_error(serror, SCRIPT_ERR_TEMPLATE_MISMATCH);
                 }
                 break;


### PR DESCRIPTION
Adds pseudocode definition of `CheckDefaultCheckTemplateVerifyHash()` to BIP-119 specification in the obvious way. Even though it is trivial, it should be included to dissolve any doubts.