### PR TITLE
Clearer language in BIP38

### DIFF
--- a/bip-0038.mediawiki
+++ b/bip-0038.mediawiki
@@ -66,7 +66,7 @@ To keep the size of the encrypted key down, no initialization vectors (IVs) are 
 * Count of payload bytes (beyond prefix): 37
 ** 1 byte (''flagbyte''): 
 *** the most significant two bits are set as follows to preserve the visibility of the compression flag in the prefix, as well as to keep the payload within the range of allowable values that keep the "6P" prefix intact.  For non-EC-multiplied keys, the bits are 11.  For EC-multiplied keys, the bits are 00.
-*** the bit with value 0x20 when set indicates the key should be converted to a bitcoin address using the compressed public key format.
+*** the bit with value 0x20 when set indicates the key should be converted to a base58check encoded P2PKH bitcoin address using the DER compressed public key format. When not set, it should be a base58check encoded P2PKH bitcoin address using the DER uncompressed public key format.
 *** the bits with values 0x10 and 0x08 are reserved for a future specification that contemplates using multisig as a way to combine the factors such that parties in possession of the separate factors can independently sign a proposed transaction without requiring that any party possess both factors.  These bits must be 0 to comply with this version of the specification.
 *** the bit with value 0x04 indicates whether a lot and sequence number are encoded into the first factor, and activates special behavior for including them in the decryption process.  This applies to EC-multiplied keys only.  Must be 0 for non-EC-multiplied keys.
 *** remaining bits are reserved for future use and must all be 0 to comply with this version of the specification.


### PR DESCRIPTION
This does not change the content of the BIP, but makes things clearer to people reading the BIP in today's context (where there are multiple "bitcoin address" types that use compressed DER public keys, and taproot introduces another compressed format (x-only public keys))

These additions to the language are implied given the late-2013 early-2014 context of this BIP. This fix will make them explicit.