### PR TITLE
Mention activation heights in BIP 341 🥕

### DIFF
--- a/bip-0341.mediawiki
+++ b/bip-0341.mediawiki
@@ -304,7 +304,7 @@ This BIP is deployed concurrently with [[bip-0342.mediawiki|BIP342]].
 
 For Bitcoin signet, these BIPs are always active.
 
-For Bitcoin mainnet and testnet3, these BIPs will be deployed by "version bits" with the name "taproot" and bit 2, using [[bip-0009.mediawiki|BIP9]] modified to use a lower threshold, with an additional ''min_activation_height'' parameter and replacing the state transition logic for the DEFINED, STARTED and LOCKED_IN states as follows:
+For Bitcoin mainnet and testnet3, these BIPs are deployed by "version bits" with the name "taproot" and bit 2, using [[bip-0009.mediawiki|BIP9]] modified to use a lower threshold, with an additional ''min_activation_height'' parameter and replacing the state transition logic for the DEFINED, STARTED and LOCKED_IN states as follows:
 
     case DEFINED:
         if (GetMedianTimePast(block.parent) >= starttime) {
@@ -334,9 +334,11 @@ For Bitcoin mainnet and testnet3, these BIPs will be deployed by "version bits" 
         }
         return ACTIVE;
 
-For Bitcoin mainnet, the starttime is epoch timestamp 1619222400 (midnight 24 April 2021 UTC), timeout is epoch timestamp 1628640000 (midnight 11 August 2021 UTC), the threshold is 1815 blocks (90%) instead of 1916 blocks (95%), and the min_activation_height is block 709632 (expected approximately 12 November 2021).
+For Bitcoin mainnet, the starttime is epoch timestamp 1619222400 (midnight 24 April 2021 UTC), timeout is epoch timestamp 1628640000 (midnight 11 August 2021 UTC), the threshold is 1815 blocks (90%) instead of 1916 blocks (95%), and the min_activation_height is block 709632.
+The deployment did activate at height 709632 on Bitcoin mainnet.
 
 For Bitcoin testnet3, the starttime is epoch timestamp 1619222400 (midnight 24 April 2021 UTC), timeout is epoch timestamp 1628640000 (midnight 11 August 2021 UTC), the threshold is 1512 blocks (75%), and the min_activation_height is block 0.
+The deployment did activate at height 2011968 on Bitcoin testnet3.
 
 == Backwards compatibility ==
 As a soft fork, older software will continue to operate without modification.


### PR DESCRIPTION
While this change isn't needed, I think it is nice for the reader to tell if and when the deployment activated.

ping @sipa, @jonasnick, @ajtowns for ACK or NACK