### PR TITLE
PSBT: Add pay-to-contract tweaks to tx inputs

### DIFF
--- a/bip-0174.mediawiki
+++ b/bip-0174.mediawiki
@@ -494,6 +494,39 @@ The currently defined per-input types are defined as follows:
 | 0, 2
 | [[bip-0371.mediawiki|371]]
 |-
+| ECDSA P2C Key Tweak
+| <tt>PSBT_IN_ECDSA_P2C_TWEAK = 0x19</tt>
+| <tt><pubkey></tt>
+| 33 bytes of compact public key serialization specifying to which of keys the ECDSA tweak must be applied (i.e. this MUST be a value of a public key before the tweak is applied)
+| <tt><tweak></tt>
+| The 32 byte value which MUST be added to a private key to produce correct ECDSA signature ("key tweak"). Signers should remove this field after <tt>PSBT_IN_PARTIAL_SIG</tt> is constructed.
+|
+|
+| 0, 2
+| 174
+|-
+| Taproot Per-key P2C Tweak
+| <tt>PSBT_IN_TAP_P2C_TWEAK = 0x1a</tt>
+| <tt><xonlypubkey></tt>
+| 32 bytes of public key specifying to which of keys tweak must be applied (i.e. this MUST be a value of a public key before the tweak is applied)
+| <tt><tweak></tt>
+| The 32 byte value which MUST be added to a private key to produce correct BIP-340 signature ("key tweak"). Signers should remove this field after <tt>PSBT_IN_PARTIAL_SIG</tt> is constructed.
+|
+|
+| 0, 2
+| 174
+|-
+| Taproot Internal P2C Tweak
+| <tt>PSBT_IN_INTERNAL_P2C_TWEAK = 0x1b</tt>
+| <tt><xonlypubkey></tt>
+| 32 bytes of the original internal taproot public key before any non-taproot tweak is applied, i.e. if <tt>Q = (P' + tweak * G) + TapTweakHash(P || m) * G</tt>, this should be a value of <tt>P</tt>
+| <tt><tweak></tt>
+| The 32 byte value which MUST be added to a private internal key to produce correct BIP-340 signature ("key tweak"). Signers should remove this field after <tt>PSBT_IN_PARTIAL_SIG</tt> is constructed.
+|
+|
+| 0, 2
+| 174
+|-
 | Proprietary Use Type
 | <tt>PSBT_IN_PROPRIETARY = 0xFC</tt>
 | <tt><identifierlen> <identifier> <subtype> <subkeydata></tt>


### PR DESCRIPTION
A number of protocols utilizes pay-to-contract and/or sign-to-contract public key tweaks. Inclusion of the tweak information into outputs (for pay-to-contract) or inputs (for sign-to-contract) as a security measure requires presence of full information from which the tweak is generated, i.e. protocol-specific and SHOULD not be a part of this standard. However, to spend already existing output containing pay-to-contract commitment a signer must apply raw tweak value to the private key. This operation is safe even if the meaning of the tweak is unknown since it does not provides any commitment to any external data. Since this operation is not protocol-specific I propose to add standard fields in order to provide signers with necessary information.

Looking for Concept ACK and I will add to the PR changes to other PSBT-related BIPS and more information on the tweaks.

CC @achow101 