### PR TITLE
BIP-174: Removing PSBT_OUT_TAP_LEAF_SCRIPT

### DIFF
--- a/bip-0174.mediawiki
+++ b/bip-0174.mediawiki
@@ -171,17 +171,6 @@ The currently defined global types are as follows:
 | 2
 | [[bip-0370.mediawiki|370]]
 |-
-| SIGHASH_SINGLE Inputs
-| <tt>PSBT_GLOBAL_SIGHASH_SINGLE_INPUTS = 0x07</tt>
-| None
-| No key data
-| <tt><bit vector></tt>
-| A bit vector representing which input indexes use SIGHASH_SINGLE. If the bit for an index is set to 1, then the input and output pair at that index are tied together with SIGHASH_SINGLE and must be moved together.
-|
-| 0
-| 2
-| [[bip-0370.mediawiki|370]]
-|-
 | PSBT Version Number
 | <tt>PSBT_GLOBAL_VERSION = 0xFB</tt>
 | None

--- a/bip-0174.mediawiki
+++ b/bip-0174.mediawiki
@@ -599,17 +599,6 @@ determine which outputs are change outputs and verify that the change is returni
 | 0, 2
 | [[bip-0371.mediawiki|371]]
 |-
-| Taproot Leaf Script
-| <tt>PSBT_OUT_TAP_LEAF_SCRIPT = 0x06</tt>
-| <tt><control block></tt>
-| The control block for this leaf as specified in BIP 341. The control block contains the merkle tree path to this leaf.
-| <tt><script></tt>
-| The script for this leaf as would be provided in the witness stack.
-|
-|
-| 0, 2
-| [[bip-0371.mediawiki|371]]
-|-
 | Taproot Key BIP 32 Derivation Path
 | <tt>PSBT_OUT_TAP_BIP32_DERIVATION = 0x07</tt>
 | <tt><xonlypubkey></tt>


### PR DESCRIPTION
`PSBT_OUT_TAP_LEAF_SCRIPT` seemed to appear in output key sections by copy-paste from input section. First, it shares the same byte no as `PSBT_OUT_TAP_TREE`, second its description talks about "witness"