### PR TITLE
BIP-341: require full spent transaction for taproot inputs in PSBT

### DIFF
--- a/bip-0371.mediawiki
+++ b/bip-0371.mediawiki
@@ -154,8 +154,10 @@ The new per-output types are defined as follows:
 
 BIP 174 recommends using <tt>PSBT_IN_NON_WITNESS_UTXO</tt> for all inputs because of potential attacks involving
 an updater lying about the amounts in an output. Because a Taproot signature will commit to all of the amounts
-and output scripts spent by the inputs of the transaction, such attacks are prevented as any such lying would
-result in an invalid signature. Thus Taproot inputs can use just <tt>PSBT_IN_WITNESS_UTXO</tt>.
+and output scripts spent by the inputs of the transaction, <tt>PSBT_IN_NON_WITNESS_UTXO</tt> MUST be always set 
+for the taproot inputs which are not <tt>SIGHASH_ANYONECANPAY</tt>, and <tt>PSBT_IN_WITNESS_UTXO</tt> MAY be 
+ignored. For taproot inputs with <tt>SIGHASH_ANYONECANPAY</tt> sighash type <tt>PSBT_IN_WITNESS_UTXO</tt> SHOULD
+be used instead, and <tt>PSBT_IN_NON_WITNESS_UTXO</tt>, which MAY be omitted.
 
 ==Compatibility==
 


### PR DESCRIPTION
Since taproot signatures sign over all amounts in the spent transaction, taproot inputs must require `PSBT_IN_NON_WITNESS_UTXO` to be always present. The only exclusion is `SIGHASH_ANYONECANPAY`, where `PSBT_IN_WITNESS_UTXO` may be enough.

I also propose to consider changing names of `PSBT_IN_NON_WITNESS_UTXO` and `PSBT_IN_WITNESS_UTXO` in all three PSBT standards to `PSBT_IN_SPENT_FULL_TX` and `PSBT_IN_SPENT_UTXO` 