### PR TITLE
BIP47: Define address types explicitly

### DIFF
--- a/bip-0047.mediawiki
+++ b/bip-0047.mediawiki
@@ -96,10 +96,8 @@ Unless otherwise specified, payment codes of different versions are interoperabl
 Currently specified versions:
 
 * Version 1
-** Address type: P2PKH
 ** Notification type: address
 * Version 2
-** Address type: P2PKH
 ** Notification type: bloom-multisig
 
 ===Recommended Versions===
@@ -118,11 +116,23 @@ A payment code contains the following elements:
 * Byte 0: version. required value: 0x01
 * Byte 1: features bit field. All bits must be zero except where specified elsewhere in this specification
 ** Bit 0: Bitmessage notification
-** Bits 1-7: reserved
+** Bits 1-3: little endian encoded integer denoting the address type the code is deriving
+** Bits 4-7: reserved
 * Byte 2: sign. required value: 0x02 or 0x03
 * Bytes 3 - 34: x value, must be a member of the secp256k1 group
 * Bytes 35 - 66: chain code
 * Bytes 67 - 79: reserved for future expansion, zero-filled unless otherwise noted
+
+====Address Type====
+
+Bits 1,2,3 of the features byte (byte 1) decode to an integer (little endian) whose value ranges from 0 to 7 inclusive. The value determines the address type the payment code is deriving. The following address types are currently defined:
+
+* 0: P2PKH (legacy pubkey hash)
+* 1: P2SH-P2WPKH (wrapped segwit)
+* 2: P2WPKH (native segwit)
+* 3: P2TR (taproot)
+
+Alice MUST NOT send to an address type that Bob is not deriving, unless Bob communicates to Alice out-of-band that this is acceptable.
 
 ====Base58 Serialization====
 


### PR DESCRIPTION
It caught my attention that the specification supports only P2PKH addresses. Meanwhile, it appears that some implementers of the standard make it possible to derive other address types (native segwit primarily) and that that information is communicated through out-of-band channels.

For instance, the biggest payment code directory (https://paynym.is) communicates that information by verbally stating "Derives native segwit addresses (p2wpkh) as well as legacy addresses".

The proposed change to the BIP would address the issue by allocating several bits to communicating the exact address type that the recipient is deriving. This removes potential confusion, funds being sent to incorrect addresses, and makes the standard more self contained. The BIP is still in a draft state so modifying this bit would benefit everyone using the standard.

Backward compatibility with the earlier iteration of the standard is locked in with the provision stating that it is acceptable to send to other address types, as long as that information is communicated elsewhere (as is currently the case with the Paynym directory).

Tagging @SamouraiDev and @justusranvier.