### PR TITLE
[BIP-174] Clarify that partial_sig should be a valid.

### DIFF
--- a/bip-0174.mediawiki
+++ b/bip-0174.mediawiki
@@ -235,7 +235,7 @@ The currently defined per-input types are defined as follows:
 | <tt><pubkey></tt>
 | The public key which corresponds to this signature.
 | <tt><signature></tt>
-| The signature as would be pushed to the stack from a scriptSig or witness.
+| The signature as would be pushed to the stack from a scriptSig or witness. The signature should be a valid ECDSA signature corresponding to the pubkey that would return true when verified and not a value that would return false or be invalid otherwise (such as a NULLDUMMY).
 |
 |
 | 0, 2


### PR DESCRIPTION
In discussing https://github.com/rust-bitcoin/rust-bitcoin/pull/669?notification_referrer_id=NT_kwDOAA2G-7EyNDgwMTU5NzIxOjg4NjUyMw#event-5861680619 it's clear that the PSBT spec is ambiguous with respect to what values should be parseable for PSBTs, this patch clears up the ambiguity.

------------
Personally, I feel that the better path is to allow NULLDUMMY here, as there could be some situations whereby satisfaction is NP-hard without some indicator of use a signature or not:

e.g., a contrived example (not saying you should do this) is
```
<0> toaltstack
<pk0> Checksig OP_IF FROMALTSTACK <V0> OP_ADD TOALTSTACK OP_ENDIF
<pk1> Checksig OP_IF FROMALTSTACK <V1> OP_ADD TOALTSTACK OP_ENDIF
...
<pkN> Checksig OP_IF FROMALTSTACK <VN> OP_ADD OP_ENDIF
<T> OP_EQUAL
```

where to satisfy requires solving a subset-sum, so just collecting all valid signatures does not allow a polynomial time finalizer to solve by inference in many cases even if all signers add their signature.

Of course, this isn't the best example, but it is an example nonetheless.
