### PR TITLE
clarify message serialization and add test vectors to BIP-322

### DIFF
--- a/bip-0322.mediawiki
+++ b/bip-0322.mediawiki
@@ -65,11 +65,11 @@ where <code>message_hash</code> is a BIP340-tagged hash of the message, i.e. sha
 
 The <code>to_sign</code> transaction is:
 
-    nVersion = 0 or as appropriate (e.g. 2, for time locks)
-    nLockTime = 0 or as appropriate (for time locks)
+    nVersion = 0 or (FULL format only) as appropriate (e.g. 2, for time locks)
+    nLockTime = 0 or (FULL format only) as appropriate (for time locks)
     vin[0].prevout.hash = to_spend.txid
     vin[0].prevout.n = 0
-    vin[0].nSequence = 0 or as appropriate (for time locks)
+    vin[0].nSequence = 0 or (FULL format only) as appropriate (for time locks)
     vin[0].scriptWitness = message_signature
     vout[0].nValue = 0
     vout[0].scriptPubKey = OP_RETURN

--- a/bip-0322.mediawiki
+++ b/bip-0322.mediawiki
@@ -144,7 +144,7 @@ This specification is backwards compatible with the legacy signmessage/verifymes
 
 == Reference implementation ==
 
-TODO
+* Bitcoin Core pull request (basic support) at: https://github.com/bitcoin/bitcoin/pull/24058
 
 == Acknowledgements ==
 
@@ -160,4 +160,21 @@ This document is licensed under the Creative Commons CC0 1.0 Universal license.
 
 == Test vectors ==
 
-TODO
+=== Message hashing ===
+
+Message hashes are BIP340-tagged hashes of a message, i.e. sha256_tag(m), where tag = <code>BIP0322-signed-message</code>, and m is the message as is without length prefix or null terminator:
+
+* Message = "" (empty string): <code>c90c269c4f8fcbe6880f72a721ddfbf1914268a794cbb21cfafee13770ae19f1</code>
+* Message = "Hello World": <code>f0eb03b1a75ac6d9847f55c624a99169b5dccba2a31f5b23bea77ba270de0a7a</code>
+
+=== Message signing ===
+
+Given below parameters:
+
+* private key <code>L3VFeEujGtevx9w18HD1fhRbCH67Az2dpCymeRE1SoPK6XQtaN2k</code>
+* corresponding address <code>bc1q9vza2e8x573nczrlzms0wvx3gsqjx7vavgkx0l</code>
+
+Produce signatures:
+
+* Message = "" (empty string): <code>AkcwRAIgFuS8y5m0ym9Gj2odoVB5NIL+cPYkeEj8LL1N/6P58X8CIA6jJ9QH2iYKRXVfmhsDzHq1bMS4Adj0nb8DDSdN/SpBASECx/EgAxlkQpQ9hYjgGu6EBCPMVPwVIVJqO4XCsMvViHI=</code>
+* Message = "Hello World": <code>AkcwRAIgG3PASL/vRTgAqogWT6S8rUOQXNnfRzX6JncmbFlHc1ACIGQdsW+rnVmsQzyAYRQisHKFMigDmKiL7LUw4x17Fw5tASECx/EgAxlkQpQ9hYjgGu6EBCPMVPwVIVJqO4XCsMvViHI=</code>

--- a/bip-0322.mediawiki
+++ b/bip-0322.mediawiki
@@ -61,7 +61,7 @@ The <code>to_spend</code> transaction is:
     vout[0].nValue = 0
     vout[0].scriptPubKey = message_challenge
 
-where <code>message_hash</code> is a BIP340-tagged hash of the message, i.e. sha256_tag(m), where tag = <code>BIP0322-signed-message</code>, and <code>message_challenge</code> is the to be proven (public) key script.
+where <code>message_hash</code> is a BIP340-tagged hash of the message, i.e. sha256_tag(m), where tag = <code>BIP0322-signed-message</code> and <code>m</code> is the message as is without length prefix or null terminator, and <code>message_challenge</code> is the to be proven (public) key script.
 
 The <code>to_sign</code> transaction is:
 


### PR DESCRIPTION
This
* adds test vectors to the BIP-322 (signmessage) proposal (more needed, but better than nothing)
* clarifies how messages are serialized as this was slightly ambiguous
* clarifies that the <code>to_sign</code> transaction must have version, locktime, and sequence all set to 0 for the SIMPLE format (signature only)
