### PR TITLE
BIP338: Add further restrictions on disabletx

### DIFF
--- a/bip-0338.mediawiki
+++ b/bip-0338.mediawiki
@@ -71,6 +71,7 @@ in the number of block-relay-only connections that can be made on the network.
 ## getdata messages for transactions
 ## getdata messages for merkleblock (BIP 37)
 ## filteradd/filterload/filterclear (BIP 37)
+## feefilter (BIP 133)
 ## mempool (BIP 35)
 ## tx message
 # It is RECOMMENDED that a node that has sent or received a disabletx message to/from a peer not send any of these messages to the peer:

--- a/bip-0338.mediawiki
+++ b/bip-0338.mediawiki
@@ -64,8 +64,10 @@ in the number of block-relay-only connections that can be made on the network.
 # A new disabletx message is added, which is defined as an empty message with message type set to "disabletx".
 # The protocol version of nodes implementing this BIP must be set to 70017 or higher.
 # If a node sets the transaction relay field in the version message to a peer to false, then the disabletx message MAY also be sent in response to a version message from that peer if the peer's protocol version is >= 70017. If sent, the disabletx message MUST be sent prior to sending a verack.
+# A node MUST NOT send the disabletx message if the transaction relay field in the version message is omitted or set to true.
 # A node that has sent or received a disabletx message to/from a peer MUST NOT send any of these messages to the peer:
 ## inv messages for transactions
+## notfound messages for transactions
 ## getdata messages for transactions
 ## getdata messages for merkleblock (BIP 37)
 ## filteradd/filterload/filterclear (BIP 37)


### PR DESCRIPTION
Clarify that peers must set fRelay=false in order to send disabletx,
and that notfound and feefilter messages may not be sent.