### PR TITLE
Fixing incorrect allowing of unsigned transaction

### DIFF
--- a/bip-0174.mediawiki
+++ b/bip-0174.mediawiki
@@ -101,7 +101,7 @@ The currently defined global types are as follows:
 | <tt><transaction></tt>
 | The transaction in network serialization. The scriptSigs and witnesses for each input must be empty. The transaction must be in the old serialization format (without witnesses).
 | 0
-|
+| 2
 | 0
 | 174
 |-


### PR DESCRIPTION
V2 does not allow Global Key Type of 0 (Unsigned Transaction), but not listed as excluded in the spec.