### PR TITLE
Update BIP-119 to include python reference hash / link BIP-341

### DIFF
--- a/bip-0119.mediawiki
+++ b/bip-0119.mediawiki
@@ -203,7 +203,18 @@ Where
         return GetDefaultCheckTemplateVerifyHash(current_tx, current_input_index) == uint256(hash);
     }
 
-The hash is computed as follows:
+The hash is computed as follows, where the outputs_hash and sequences_hash are computed as defined in BIP-341.
+
+    /** Compute the (single) SHA256 of the concatenation of all scriptSigs in a tx. */
+    template <class T>
+    uint256 GetScriptSigsSHA256(const T& txTo)
+    {
+        CHashWriter ss(SER_GETHASH, 0);
+        for (const auto& in : txTo.vin) {
+            ss << in.scriptSig;
+        }
+        return ss.GetSHA256();
+    }
     // not DoS safe, for reference/testing!
     uint256 GetDefaultCheckTemplateVerifyHash(const CTransaction& tx, uint32_t input_index) {
         return GetDefaultCheckTemplateVerifyHash(tx, GetOutputsSHA256(tx), GetSequenceSHA256(tx), input_index);
@@ -243,6 +254,21 @@ The hash is computed as follows:
             << input_index;
         return h.GetSHA256();
     }
+
+In python, this can be written as (but note this implementation is DoS-able).
+
+    def get_default_check_template_hash(self, nIn):
+        r = b""
+        r += struct.pack("<i", self.nVersion)
+        r += struct.pack("<I", self.nLockTime)
+        if any(inp.scriptSig for inp in self.vin):
+            r += sha256(b"".join(ser_string(inp.scriptSig) for inp in self.vin))
+        r += struct.pack("<I", len(self.vin))
+        r += sha256(b"".join(struct.pack("<I", inp.nSequence) for inp in self.vin))
+        r += struct.pack("<I", len(self.vout))
+        r += sha256(b"".join(out.serialize() for out in self.vout))
+        r += struct.pack("<I", nIn)
+        return sha256(r)
 
 A PayToBareDefaultCheckTemplateVerifyHash output matches the following template:
 


### PR DESCRIPTION
Thanks to roconnor for pointing that this was not clear from the BIP text and one had to see the reference implementation.