### PR TITLE
BIP370: introduce PSBT_IN_PREVIOUS_OUTPOINT

### DIFF
--- a/bip-0370.mediawiki
+++ b/bip-0370.mediawiki
@@ -123,27 +123,17 @@ The new per-input types for PSBT Version 2 are defined as follows:
 ! Versions Allowing Inclusion
 |-
 | Previous TXID
-| <tt>PSBT_IN_PREVIOUS_TXID = 0x0e</tt>
+| <tt>PSBT_IN_PREVIOUS_OUTPOINT = 0x0e</tt>
 | None
 | No key data
-| <tt><txid></tt>
-| 32 byte txid of the previous transaction whose output at PSBT_IN_OUTPUT_INDEX is being spent.
-| 2
-| 0
-| 2
-|-
-| Spent Output Index
-| <tt>PSBT_IN_OUTPUT_INDEX = 0x0f</tt>
-| None
-| No key data
-| <tt><32-bit uint></tt>
-| 32 bit little endian integer representing the index of the output being spent in the transaction with the txid of PSBT_IN_PREVIOUS_TXID.
+| <tt><txid><32-bit uint></tt>
+| 32 byte txid of the previous transaction whose output at PSBT_IN_OUTPUT_INDEX is being spent, followed by 32 bit little endian integer representing the index of the output being spent.
 | 2
 | 0
 | 2
 |-
 | Sequence Number
-| <tt>PSBT_IN_SEQUENCE = 0x10</tt>
+| <tt>PSBT_IN_SEQUENCE = 0x0f</tt>
 | None
 | No key data
 | <tt><32-bit uint></tt>
@@ -153,7 +143,7 @@ The new per-input types for PSBT Version 2 are defined as follows:
 | 2
 |-
 | Required Time-based Locktime
-| <tt>PSBT_IN_REQUIRED_TIME_LOCKTIME = 0x11</tt>
+| <tt>PSBT_IN_REQUIRED_TIME_LOCKTIME = 0x10</tt>
 | None
 | No key data
 | <tt><32-bit uint></tt>
@@ -163,7 +153,7 @@ The new per-input types for PSBT Version 2 are defined as follows:
 | 2
 |-
 | Required Height-based Locktime
-| <tt>PSBT_IN_REQUIRED_HEIGHT_LOCKTIME = 0x12</tt>
+| <tt>PSBT_IN_REQUIRED_HEIGHT_LOCKTIME = 0x11</tt>
 | None
 | No key data
 | <tt><32-bit uiht></tt>


### PR DESCRIPTION
There is no single case I am aware of when `PSBT_IN_PREVIOUS_TXID` and `PSBT_IN_OUTPUT_INDEX` are used separately. Thus, I propose to keep all data about the spent output in the input map as a single data structure/key. This helps implementation and simplifies error handling: the situation where just `txid` or `vout` with the second part of the data missed for the spent outpoint are present now will be impossible.

CC @achow101 