### PR TITLE
bip-326: avoid errors from scripts/buildtable.pl

### DIFF
--- a/bip-0326.mediawiki
+++ b/bip-0326.mediawiki
@@ -5,8 +5,10 @@
   Author: Chris Belcher <belcher at riseup dot net>
   Status: Draft
   Type: Informational
+  Comments-Summary: No comments yet.
+  Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0326
   Created: 2021-06-10
-  License: CC-0
+  License: CC0-1.0
   Post-History: 2021-6-10: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2021-June/019048.html
 </pre>
 

--- a/scripts/buildtable.pl
+++ b/scripts/buildtable.pl
@@ -89,7 +89,7 @@ my %DefinedLicenses = (
 );
 my %GrandfatheredPD = map { $_ => undef } qw(9 36 37 38 42 49 50 60 65 67 69 74 80 81 83 90 99 105 107 109 111 112 113 114 122 124 125 126 130 131 132 133 140 141 142 143 144 146 147 150 151 152);
 my %TolerateMissingLicense = map { $_ => undef } qw(1 10 11 12 13 14 15 16 21 31 33 34 35 39 43 44 45 47 61 64 68 70 71 72 73 101 102 106 120 121);
-my %TolerateTitleTooLong = map { $_ => undef } qw(39 44 45 47 49 60 67 68 69 73 74 75 80 81 99 105 106 109 113 122 126 131 143 145 147 173);
+my %TolerateTitleTooLong = map { $_ => undef } qw(39 44 45 47 49 60 67 68 69 73 74 75 80 81 99 105 106 109 113 122 126 131 143 145 147 173 326);
 
 my %emails;
 
@@ -127,7 +127,10 @@ while (++$bipnum <= $topbip) {
 			my $title_len = length($title);
 			die "$fn has too-long TItle ($title_len > 44 char max)" if $title_len > 44 and not exists $TolerateTitleTooLong{$bipnum};
 		} elsif ($field eq 'Author') {
-			$val =~ m/^(\S[^<@>]*\S) \<([^@>]*\@[\w.]+\.\w+)\>$/ or die "Malformed Author line in $fn";
+			my $deantispam = $val;
+			$deantispam =~ s/ at /@/;
+			$deantispam =~ s/ dot /./g;
+			$deantispam =~ m/^(\S[^<@>]*\S) \<([^@>]*\@[\w.]+\.\w+)\>$/ or die "Malformed Author line in $fn";
 			my ($authorname, $authoremail) = ($1, $2);
 			$authoremail =~ s/(?<=\D)$bipnum(?=\D)/<BIPNUM>/g;
 			$emails{$authorname}->{$authoremail} = undef;


### PR DESCRIPTION
Merge of #1269 triggered CI errors due to `script/buildtable.pl`, in particular:

 * the Author: field is not a valid email address (" at " and " dot " rather than "@" and ".")
 * missing Comments-URI
 * License code is wrong (should be "CC0-1.0" rather than "CC-0")
 * the Title field is longer than the 44 char minimum (could perhaps be "Anti-fee-sniping in taproot transactions", dropping the how and why)
 
This makes the trivial changes to the BIP to add the Comments field and fix the License code, and updates buildtable.pl to avoid complaining about the email address and title.