### PR TITLE
Fix incorrect signature test vectors in BIP322

### DIFF
--- a/bip-0322.mediawiki
+++ b/bip-0322.mediawiki
@@ -176,5 +176,17 @@ Given below parameters:
 
 Produce signatures:
 
-* Message = "" (empty string): <code>AkcwRAIgFuS8y5m0ym9Gj2odoVB5NIL+cPYkeEj8LL1N/6P58X8CIA6jJ9QH2iYKRXVfmhsDzHq1bMS4Adj0nb8DDSdN/SpBASECx/EgAxlkQpQ9hYjgGu6EBCPMVPwVIVJqO4XCsMvViHI=</code>
-* Message = "Hello World": <code>AkcwRAIgG3PASL/vRTgAqogWT6S8rUOQXNnfRzX6JncmbFlHc1ACIGQdsW+rnVmsQzyAYRQisHKFMigDmKiL7LUw4x17Fw5tASECx/EgAxlkQpQ9hYjgGu6EBCPMVPwVIVJqO4XCsMvViHI=</code>
+* Message = "" (empty string): <code>AkcwRAIgM2gBAQqvZX15ZiysmKmQpDrG83avLIT492QBzLnQIxYCIBaTpOaD20qRlEylyxFSeEA2ba9YOixpX8z46TSDtS40ASECx/EgAxlkQpQ9hYjgGu6EBCPMVPwVIVJqO4XCsMvViHI=</code>
+* Message = "Hello World": <code>AkcwRAIgZRfIY3p7/DoVTty6YZbWS71bc5Vct9p9Fia83eRmw2QCICK/ENGfwLtptFluMGs2KsqoNSk89pO7F29zJLUx9a/sASECx/EgAxlkQpQ9hYjgGu6EBCPMVPwVIVJqO4XCsMvViHI=</code>
+
+=== Transaction Hashes ===
+
+to_spend:
+
+* Message = "" (empty string): <code>c5680aa69bb8d860bf82d4e9cd3504b55dde018de765a91bb566283c545a99a7</code>
+* Message = "Hello World": <code>b79d196740ad5217771c1098fc4a4b51e0535c32236c71f1ea4d61a2d603352b</code>
+
+to_sign:
+
+* Message = "" (empty string): <code>1e9654e951a5ba44c8604c4de6c67fd78a27e81dcadcfe1edf638ba3aaebaed6</code>
+* Message = "Hello World": <code>88737ae86f2077145f93cc4b153ae9a1cb8d56afa511988c149c5c8c9d93bddf</code>


### PR DESCRIPTION
While attempting to implement bip322 I was unable to generate the same signature as the ones provided. Furthermore, I was unable to verify these signatures in my implementation. After some digging, I noticed the test vectors in the bip322 PR to Bitcoin Core uses different values.

See util_tests.cpp in https://github.com/bitcoin/bitcoin/pull/24058

This P.R. replaces the current test vectors with the ones from the P.R.

It also adds additional test vectors for the transaction hashes of the to_spend and to_sign transactions. Having these would have speeded up my debugging process significantly.