### PR TITLE
BIP-341: Explain the 64-byte signature format

### DIFF
--- a/bip-0341.mediawiki
+++ b/bip-0341.mediawiki
@@ -136,6 +136,9 @@ In summary, the semantics of the [[bip-0143.mediawiki|BIP143]] sighash types rem
 
 ==== Taproot key path spending signature validation ====
 
+A Taproot signature is a 64-byte Schnorr signature, as defined in [[bip-0340.mediawiki|BIP340]], with the sighash byte appended in the usual Bitcoin fashion.
+However, in the common case of <code>SIGHASH_DEFAULT</code>, encoded as ''0x00'', a space optimization can be made by ''omitting'' the sighash byte, resulting in a 64-byte signature with <code>SIGHASH_DEFAULT</code> assumed.
+
 To validate a signature ''sig'' with public key ''q'':
 * If the ''sig'' is 64 bytes long, return ''Verify(q, hash<sub>TapSighash</sub>(0x00 || SigMsg(0x00, 0)), sig)''<ref>'''Why is the input to ''hash<sub>TapSighash</sub>'' prefixed with 0x00?''' This prefix is called the sighash epoch, and allows reusing the ''hash<sub>TapSighash</sub>'' tagged hash in future signature algorithms that make invasive changes to how hashing is performed (as opposed to the ''ext_flag'' mechanism that is used for incremental extensions). An alternative is having them use a different tag, but supporting a growing number of tags may become undesirable.</ref>, where ''Verify'' is defined in [[bip-0340.mediawiki#design|BIP340]].
 * If the ''sig'' is 65 bytes long, return ''sig[64] &ne; 0x00<ref>'''Why can the <code>hash_type</code> not be <code>0x00</code> in 65-byte signatures?''' Permitting that would enable malleating (by third parties, including miners) 64-byte signatures into 65-byte ones, resulting in a different `wtxid` and a different fee rate than the creator intended.</ref> and Verify(q, hash<sub>TapSighash</sub>(0x00 || SigMsg(sig[64], 0)), sig[0:64])''.
@@ -350,6 +353,6 @@ Depending on the implementation non-upgraded wallets may be able to send to Segw
 
 == Acknowledgements ==
 
-This document is the result of discussions around script and signature improvements with many people, and had direct contributions from Greg Maxwell and others. It further builds on top of earlier published proposals such as Taproot by Greg Maxwell, and Merkle branch constructions by Russell O'Connor, Johnson Lau, and Mark Friedenbach. 
+This document is the result of discussions around script and signature improvements with many people, and had direct contributions from Greg Maxwell and others. It further builds on top of earlier published proposals such as Taproot by Greg Maxwell, and Merkle branch constructions by Russell O'Connor, Johnson Lau, and Mark Friedenbach.
 
 The authors wish the thank Arik Sosman for suggesting to sort Merkle node children before hashes, removing the need to transfer the position in the tree, as well as all those who provided valuable feedback and reviews, including the participants of the [https://github.com/ajtowns/taproot-review structured reviews].


### PR DESCRIPTION
The signature would be expected to be 65-bytes: the 64-byte Schnorr
signature plus the appended sighash byte.  But the new sighash value
`SIGHASH_DEFAULT`, encoded as `0x00`, allows the space optimization of
omitting the sighash byte, allowing for a 64-byte signature.

This is now explained explicitly in the text.