### PR TITLE
[BIP322] Change private key format from wif to hex

### DIFF
--- a/bip-0322.mediawiki
+++ b/bip-0322.mediawiki
@@ -171,7 +171,7 @@ Message hashes are BIP340-tagged hashes of a message, i.e. sha256_tag(m), where 
 
 Given below parameters:
 
-* private key <code>L3VFeEujGtevx9w18HD1fhRbCH67Az2dpCymeRE1SoPK6XQtaN2k</code>
+* private key <code>bb051cd0dda0246f33c5a9e133ebd8e7bc02a92af6c41adc131ccd7826c5b004</code>
 * corresponding address <code>bc1q9vza2e8x573nczrlzms0wvx3gsqjx7vavgkx0l</code>
 
 Produce signatures:


### PR DESCRIPTION
The specification for deriving a bech32 address from a wif format private key does not appear to be standardized.

Some wallets, such as Electrum, [set a marker in the first byte](https://github.com/spesmilo/electrum/blob/3.0.0/RELEASE-NOTES#L42), and [BIP-0178](https://github.com/bitcoin/bips/blob/master/bip-0178.mediawiki) propose an extended WIF format.

The WIF data currently described is ambiguous as to which address is should be derived, so it would be better to describe it as a hex value.