### PR TITLE
Be more explicit about ext_flag values in BIP118

### DIFF
--- a/bip-0118.mediawiki
+++ b/bip-0118.mediawiki
@@ -82,7 +82,7 @@ We define the following constants using bits 6 and 7 of <code>hash_type</code>:
 * <code>SIGHASH_ANYPREVOUT = 0x40</code>
 * <code>SIGHASH_ANYPREVOUTANYSCRIPT = 0xc0</code>
 
-As per [[bip-0341.mediawiki|BIP 341]], the parameter ''ext_flag'' is an integer in the range 0-127, used for indicating that extensions are added at the end of the message. The parameter ''key_version'' is an 8-bit unsigned value (an integer in the range 0-255) used for committing to the public key version.
+As per [[bip-0341.mediawiki|BIP 341]], the parameter ''ext_flag'' is an integer in the range 0-127, used for indicating that extensions are added at the end of the message, with the value of ''0'' indicating no extension, and ''1'' indicating the presence of ''SigExt118(hash_type,key_version)''. The parameter ''key_version'' is an 8-bit unsigned value (an integer in the range 0-255) used for committing to the public key version.
 
 The following restrictions apply and cause validation failure if violated:
 * Using any undefined ''hash_type'' (not ''0x00'', ''0x01'', ''0x02'',  ''0x03'', ''0x41'', ''0x42'', ''0x43'', ''0x81'', ''0x82'', ''0x83'', ''0xc1'', ''0xc2'', or ''0xc3'').


### PR DESCRIPTION
I find it difficult to reason about as-written, even if implicitly it may be correct.

cc @ajtowns 