### PR TITLE
bip-141: improve `witness` field wording

### DIFF
--- a/bip-0141.mediawiki
+++ b/bip-0141.mediawiki
@@ -56,7 +56,7 @@ The <code>marker</code> MUST be a 1-byte zero value: <code>0x00</code>.
 
 The <code>flag</code> MUST be a 1-byte non-zero value. Currently, <code>0x01</code> MUST be used.
 
-The <code>witness</code> is a serialization of all witness data of the transaction. Each txin is associated with a witness field. A witness field starts with a <code>var_int</code> to indicate the number of stack items for the txin. It is followed by stack items, with each item starts with a <code>var_int</code> to indicate the length. Witness data is NOT script.
+The <code>witness</code> is a serialization of all witness fields of the transaction. Each txin is associated with a witness field. A witness field starts with a <code>var_int</code> to indicate the number of stack items for the txin. It is followed by stack items, with each item starts with a <code>var_int</code> to indicate the length. Witness data is NOT script.
 
 A non-witness program (defined hereinafter) txin MUST be associated with an empty witness field, represented by a <code>0x00</code>. If all txins are not witness program, a transaction's <code>wtxid</code> is equal to its <code>txid</code>.
 


### PR DESCRIPTION
When describing the `witness` field, reword "witness data" to "witness field" as "witness data" refers also to the `marker` and `flag` fields.

### The confusion

https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#transaction-size-calculations
> Base transaction size is the size of the transaction serialised with the witness data stripped. 

Here, "witness data" refers to having the `marker`, `flag` and `witness` fields stripped.

https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#transaction-id
> The `witness` is a serialization of all witness data of the transaction.

However, here "witness data" refers to just the `witness` field.