### PR TITLE
Update bip-0341.mediawiki

### DIFF
--- a/bip-0341.mediawiki
+++ b/bip-0341.mediawiki
@@ -199,6 +199,8 @@ The following function, <code>taproot_output_script</code>, returns a byte array
 
 <source lang="python">
 def taproot_tree_helper(script_tree):
+    if len(scripts) == 0:
+        return ([], bytes())
     if isinstance(script_tree, tuple):
         leaf_version, script = script_tree
         h = tagged_hash("TapLeaf", bytes([leaf_version]) + ser_script(script))
@@ -245,7 +247,7 @@ TapTweak = tagged_hash("TapTweak", p + ABCDE)
 
 <source lang="python">
 def taproot_sign_key(script_tree, internal_seckey, hash_type):
-    _, h = taproot_tweak_pubkey(script_tree)
+    _, h = taproot_tree_helper(script_tree)
     output_seckey = taproot_tweak_seckey(internal_seckey, h)
     sig = schnorr_sign(sighash(hash_type), output_seckey)
     if hash_type != 0:

--- a/bip-0341.mediawiki
+++ b/bip-0341.mediawiki
@@ -245,7 +245,7 @@ TapTweak = tagged_hash("TapTweak", p + ABCDE)
 
 <source lang="python">
 def taproot_sign_key(script_tree, internal_seckey, hash_type):
-    _, h = taproot_tree_helper(script_tree)
+    _, h = taproot_tweak_pubkey(script_tree)
     output_seckey = taproot_tweak_seckey(internal_seckey, h)
     sig = schnorr_sign(sighash(hash_type), output_seckey)
     if hash_type != 0:


### PR DESCRIPTION
 "If the spending conditions do not require a script path, the output key should commit to an unspendable script path instead of having no script path. This can be achieved by computing the output key point as Q = P + int(hash_TapTweak(bytes(P)))G"

Calling 'taproot_tree_helper' calls 'hash_TapLeaf' instead of 'hash_TapTweak'.