### PR TITLE
BIP 341: allow taproot_sign_key with no script tree

### DIFF
--- a/bip-0341.mediawiki
+++ b/bip-0341.mediawiki
@@ -249,7 +249,10 @@ TapTweak = tagged_hash("TapTweak", p + ABCDE)
 
 <source lang="python">
 def taproot_sign_key(script_tree, internal_seckey, hash_type, bip340_aux_rand):
-    _, h = taproot_tree_helper(script_tree)
+    if script_tree is None:
+        h = bytes()
+    else:
+        _, h = taproot_tree_helper(script_tree)
     output_seckey = taproot_tweak_seckey(internal_seckey, h)
     sig = schnorr_sign(sighash(hash_type), output_seckey, bip340_aux_rand)
     if hash_type != 0:


### PR DESCRIPTION
In contrast to taproot_output_script, taproot_sign_key was not able to deal with
a script_tree that is None. This commit fixes taproot_sign_key such that it can
sign for such outputs.

This commit avoids changing the behavior of the functions except
taproot_sign_key at the cost of having some code duplication. Alternatively, one
could let taproot_tree_helper deal with a None script_tree directly.

CC @sipa @ajtowns 