### PR TITLE
bip-0011/12 - fixed broken implementation url

### DIFF
--- a/bip-0011.mediawiki
+++ b/bip-0011.mediawiki
@@ -54,7 +54,7 @@ A weaker argument is OP_CHECKMULTISIG should not be used because it pops one too
 
 OP_CHECKMULTISIG is already supported by old clients and miners as a non-standard transaction type.
 
-https://github.com/gavinandresen/bitcoin-git/tree/op_eval
+https://github.com/gavinandresen/bitcoin-git/tree/e679ec969c8b22c676ebb10bea1038f6c8f13b33
 
 == Post History ==
 

--- a/bip-0011.mediawiki
+++ b/bip-0011.mediawiki
@@ -54,7 +54,7 @@ A weaker argument is OP_CHECKMULTISIG should not be used because it pops one too
 
 OP_CHECKMULTISIG is already supported by old clients and miners as a non-standard transaction type.
 
-https://github.com/gavinandresen/bitcoin-git/tree/e679ec969c8b22c676ebb10bea1038f6c8f13b33
+https://github.com/gavinandresen/bitcoin-git/tree/77f21f1583deb89bf3fffe80fe9b181fedb1dd60
 
 == Post History ==
 

--- a/bip-0012.mediawiki
+++ b/bip-0012.mediawiki
@@ -75,7 +75,7 @@ Example of a transaction that must fail for both old and new miners/clients:
 
 ==Reference Implementation==
 
-https://github.com/gavinandresen/bitcoin-git/tree/e679ec969c8b22c676ebb10bea1038f6c8f13b33
+https://github.com/gavinandresen/bitcoin-git/tree/77f21f1583deb89bf3fffe80fe9b181fedb1dd60
 
 ==See Also==
 

--- a/bip-0012.mediawiki
+++ b/bip-0012.mediawiki
@@ -75,7 +75,7 @@ Example of a transaction that must fail for both old and new miners/clients:
 
 ==Reference Implementation==
 
-https://github.com/gavinandresen/bitcoin-git/tree/op_eval
+https://github.com/gavinandresen/bitcoin-git/tree/e679ec969c8b22c676ebb10bea1038f6c8f13b33
 
 ==See Also==
 


### PR DESCRIPTION
Replaced the current implementation URL which gives an error 404. The new link is to the equivalent branch since the original named branch has been removed.