### PR TITLE
BIP 340 & 341: use consistent definition of lift_x

### DIFF
--- a/bip-0340.mediawiki
+++ b/bip-0340.mediawiki
@@ -243,6 +243,12 @@ Blind Schnorr signatures could for example be used in [https://github.com/Elemen
 For development and testing purposes, we provide a [[bip-0340/test-vectors.csv|collection of test vectors in CSV format]] and a naive, highly inefficient, and non-constant time [[bip-0340/reference.py|pure Python 3.7 reference implementation of the signing and verification algorithm]].
 The reference implementation is for demonstration purposes only and not to be used in production environments.
 
+== Changelog ==
+
+To help implementors understand updates to this BIP, we keep a list of substantial changes.
+
+* 2022-08: Fix function signature of lift_x in reference code
+
 == Footnotes ==
 
 <references />

--- a/bip-0340/reference.py
+++ b/bip-0340/reference.py
@@ -68,8 +68,7 @@ def bytes_from_point(P: Point) -> bytes:
 def xor_bytes(b0: bytes, b1: bytes) -> bytes:
     return bytes(x ^ y for (x, y) in zip(b0, b1))
 
-def lift_x(b: bytes) -> Optional[Point]:
-    x = int_from_bytes(b)
+def lift_x(x: int) -> Optional[Point]:
     if x >= p:
         return None
     y_sq = (pow(x, 3, p) + 7) % p
@@ -128,7 +127,7 @@ def schnorr_verify(msg: bytes, pubkey: bytes, sig: bytes) -> bool:
         raise ValueError('The public key must be a 32-byte array.')
     if len(sig) != 64:
         raise ValueError('The signature must be a 64-byte array.')
-    P = lift_x(pubkey)
+    P = lift_x(int_from_bytes(pubkey))
     r = int_from_bytes(sig[0:32])
     s = int_from_bytes(sig[32:64])
     if (P is None) or (r >= p) or (s >= n):

--- a/bip-0341.mediawiki
+++ b/bip-0341.mediawiki
@@ -182,7 +182,7 @@ def taproot_tweak_pubkey(pubkey, h):
     t = int_from_bytes(tagged_hash("TapTweak", pubkey + h))
     if t >= SECP256K1_ORDER:
         raise ValueError
-    Q = point_add(lift_x(pubkey), point_mul(G, t))
+    Q = point_add(lift_x(int(pubkey)), point_mul(G, t))
     return 0 if has_even_y(Q) else 1, bytes_from_int(x(Q))
 
 def taproot_tweak_seckey(seckey0, h):


### PR DESCRIPTION
As pointed out by @Randy808 [here](https://github.com/bitcoin/bips/pull/1348#issuecomment-1212973614).

CC @sipa @ajtowns 