### PR TITLE
New BIP: Revocable Proof-of-Burn Transaction Template

### DIFF
--- a/bip-rpob-tx-template.mediawiki
+++ b/bip-rpob-tx-template.mediawiki
@@ -1,0 +1,284 @@
+<pre>
+  BIP: bip-rpob-tx-template
+  Layer: Applications
+  Title: Revocable Proof-of-Burn Transaction Template
+  Author: Veleslav <veleslav.bips@protonmail.com>
+  Comments-Summary: No comments yet.
+  Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-bip-rpob-tx-template
+  Status: Draft
+  Type: Standards Track
+  Created: 2022-08-18
+  License: BSD-3-Clause
+           CC0-1.0
+</pre>
+
+==Introduction==
+
+===Abstract===
+This BIP proposes an application-layer template for revocable proof-of-burn, or ''"RPoB"'', transactions.
+
+* This proposal uses a new transaction version number to allow for future extensions.
+* This proposal recommends that implementations who mine and relay transaction to update their standard transaction templates as defined by this document.
+
+This proposal aims to support decentralised systems, allowing the use ''RPoB'' assertions in a consistent, efficient, reliable, and interoperable way.
+
+''The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.''
+
+===Copyright===
+This document is dual licensed as BSD 3-clause and Creative Commons CC0 1.0 Universal.
+
+===Motivation===
+In signalling theory<ref group="Note">Evolutionary biology theory of communication, or ''"signalling theory"'', where creatures make honest signals that are hard to cheat, for mutual evolutionary advantage.</ref>, proof of burn<ref group="Note">In Bitcoin, ''proof of burn'' places bitcoin value into outputs that provably unspendable. This dose not reduce the wealthy of the network, but instead reduces the velocity of these coins to zero. Transferring the network wealth onto the remaining coins that have a non-zero velocity.</ref> is a costly signal,<ref group="Note">A ''"costly signal"'' indicates dedication, an observer expects that such a signal is not made flippantly because the high cost.</ref> allowing the network to assign a default trust.<ref group="Note">An entity is assigned a ''"default trust"'' value when they are not connected to the trust graph. Without a default source trust, growing a decentralised web-of-trust network is impossible. New users face a catch-22 problem: they are disconnected from the trust graph and don't have a possibility to prove themselves.</ref> Bitcoin naturally provides an implementation of proof of burn without feedback loops,<ref group="Note">A ''"feedback loop"'' is when a trust signal can be amplified by a privileged subset of the network by feeding the creation-cost of this signal back into the process of making the signal.</ref> allowing for default trust to be assigned fairly in decentralised networks.<ref group="Note">New users are able to use a proof-of-burn to bootstrap themselves into new trust networks. 'New-user-with-burn-proofs' can be welcomed-in with basic services and focused attention, as the network knows that it was costly to generate the burn-proof.</ref>
+
+The ability to revoke<ref group="Note">To ''"revoke", is'' publicly asserting that a previous statement should not be valued as originally intended.</ref> past assertions is important for many applications,<ref group="Note">Unexpected things happen, for example, the loss or compromise of private keys.</ref> therefore proposal couples bitcoin proof-of-burn with a revocation mechanic.
+
+In choosing to standardise via the BIP peer-reviewed process, we hope to give the community greater confidence in making use of bitcoin-based revocable proof of burn technology.
+
+====Notes:====
+<references group="Note" />
+
+==Design==
+
+===Conceptual===
+''"Proof-of-Burn"'' transactions have long exited in Bitcoin, ''"OP_RETURN"'' transactions, (named after the op-code ''"return"'', that causes the public key script to return in failure, hence making the output unspendable and "burning" any value allocated to that output), these transactions have been actively mined since the release of Bitcoin-Core 0.9.
+
+Since OP_RETURN doesn't allow the public key script to be spent (as is it's design), there hasn't been any built-in solution addressing the requirements a application-useable proof-of-burn transaction, in particular:
+
+*A standard association with a public key in for transaction.
+*A standard protocol to publicly revoke a proof-of-burn transaction.
+
+In this proposal we satisfy these requirements by specifying a taproot public key in the op_return payload and an another output for revocation.
+
+===Other Requirements===
+Operation under <abbr title="Simple Payment Verification">SPV</abbr> assumptions:
+*Transactions are small: ''RPoB transactions (non-witness-part) are fixed to two possible sizes, depending if there is a change output, or not.''
+*Revocations are quickly and cheaply indexed: ''RPoB revocations only require obtaining the preimage to a double-sha256 hash. This is easily indexed and propagated in a gossip network.''
+
+Ease of implementation:
+*Use of only Taproot and Schnorr: ''To reduce the scope of the transaction, we use only Taproot for inputs and Outputs, and Schnorr for the signature that covers the funding outpoint.''
+
+Transaction funded by 3rd party:
+* It should be secure for an untrusted 3rd party fund the proof-of-burn transaction. ''Allowing for services to fund these transactions and be compensated with some sort of off-chain payment.''
+
+Future extendability:
+*Making use of the transaction version feature of bitcoin. ''This allows for easier indexing strategies in the future, (with a simple consensus change: to include in the coinbase the number of the transactions in the block by their transaction version).''
+* Including a byte for 8 version flag bits. ''This allows for a reliable way to upgrade in the future in a forward-comparable way.''
+
+===Transaction Design Overview:===
+[[File:bip-rpob-tx-template/rpob-template-summary-table.svg]]
+
+==Specification==
+This section specifies our RPoB transaction template.
+
+===Transaction===
+General form:
+<pre>
+version:      0x3
+marker:       0x0
+flag:         0x1
+txin_count:   0x1
+txout_count:  0x2 (without change) or 0x3 (with change)
+lock_time:    (any)
+</pre>
+
+*RPoB transactions MUST use the transaction version (nVersion) 0x03.
+
+*RPoB transactions MUST have only one input and either two or three outputs.
+
+===Input 1: Funding===
+General form:
+<pre>
+signature_script:  (empty)
+witness_script:    <taproot_witness>
+</pre>
+
+*The RPoB transaction input MUST be P2TR (Pay to Tap Root).
+
+===Output 1: Burn and Data===
+General form:
+
+<pre>
+value:              (any)
+public_key_script:  RETURN < 1-byte-rpob_version_flag>
+                           <32-byte-rpob_secp256k1_public_key>
+                           <64-byte-rpob_schnorr_signature>
+</pre>
+
+The public key script fields are:
+
+<pre>
+rpob_version_flag:           1-byte , 0x00 (initial version).
+rpob_secp256k1_public_key:  32-bytes, SECP256K1 compact public key.
+rpob_schnorr_signature:     64-bytes, bip-340 Schnorr Signature.
+</pre>
+
+*The first RPoB transaction contains the burn value, that is made unspendable by the 'OP_RETURN' in the public key script.
+
+===Output 2: Revocation Puzzle===
+General form:
+
+<pre>
+value:              0
+public_key_script:  SIZE 32 EQUALVERIFY HASH256
+                    <32-byte-rpob_revocation_puzzle>
+                    EQUAL
+</pre>
+
+*The Value of the Revocation Puzzle Output MUST be zero.
+
+<code>HASH256</code> is defined by ''double sha256'':
+
+<pre>
+rpob_revocation_puzzle:    32-bytes, public, SHA256(SHA256(
+                                     <32-byte-rpob_revocation_solution>
+                                     ))
+
+rpob_revocation_solution:  32-bytes, secret, publicly reveal this value to revoke the proof-of-burn.
+</pre>
+
+*It is RECOMMENDED that implementations use a value for the <code>rpob_revocation_solution</code> that is derived from the secret key used to generate the  <code>rpob_secp256k1_public_key</code> .
+
+===Output 3, Optional: Change===
+<pre>
+value:              (any)
+public_key_script:  1 <32-byte-taproot_witness_program>
+</pre>
+
+*This output MAY have any value.
+*The public key MUST be a standard P2TW output.
+
+===Signature: Included in Output 1===
+<pre>
+rpob_schnorr_signature:       64-bytes, bip-340, signature (
+                                        <32-byte-rpob_signature_message_hash>,
+                                        <32-byte-secp256k1_private_key>
+                                        )
+
+rpob_signature_message_hash:  32-bytes, bip-340, sha256_taged_hash (
+                                        <77-byte-rpob_signature_message>,
+                                        <16-byte-rpob_hash_tag>
+                                        )
+
+rpob_hash_tag:                16-bytes, utf-8-hash_tag ("rpob/BTC/MAINNET")
+                                    or, utf-8-hash_tag ("rpob/BTC/TESTNET")
+
+rpob_signature_message:       77-bytes, < 1-byte-version_flags>
+                                        <32-byte-input_txid_hash>
+                                        < 4-byte-input_index>
+                                        < 8-byte-burn_output_value>
+                                        <32-byte-rpob_revocation_puzzle>
+</pre>
+
+*The <code>rpob_schnorr_signature</code> uses the [https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki BIP-340] algorithm.
+
+==Deployment==
+
+While the ''IsStandard'' rules are quite restricting, it is quite possible to submit transactions directly to miners, or co-operate with miners who would enjoy to have some addition fee-revenue. So the initial process of testing on the main-network should be possible.
+
+If this standard gains significant attention, we are happy to write a supplementary BIP to define a new service bit to allow nodes to signal that this new type of standard transaction is accepted.
+
+==Rationale==
+===Why require RPoB transactions to use a new transaction version?===
+
+This allows for future indexing and enforcement strategies at the consensus layer.
+
+===Why use a hash puzzle for the revocation?===
+
+The hash-puzzle allows for easy indexing of the revocation, in the format:
+
+<code><32-byte-revocation-puzzle> (if revoked: <32-byte-revocation-puzzle-preimage>)</code>
+
+*Since the digest algorithm is double sha256, even for a very large number of revocation, this index would be very cheap to verify.
+
+*We envision nodes keeping track of all the revocation-puzzles listed in the blockchain, as 32-byte each, a million RPoB is only 32mb. This can be further optimised.
+
+Additionally, we do not want to confuse a public key, (that can sign), and a revocation-puzzle (that may only revoke).
+
+===Why must the revocation output be of zero value?===
+
+Revocation can be spent by anyone once the revocation pre-image has been published.
+
+===Why does a RPoB need a signature at all?===
+
+The primary purpose of the signature is to stop replay-attacks. (Somebody takes your public-key and makes transaction where you don't control the revocation).
+
+The secondary purpose is to allow for untrusted parties to create transactions on your behalf. i.e. a 'RPoB' transaction creation service.
+===Why waste precious block space?===
+
+Consuming block-space is a of secondary proof-of-burn that this proposal takes advantage of, as itself is limited and contested for (blocks are almost full on average). There is an opportunity cost of the next best transaction when a miner chooses to include a RPoB transaction their block.
+
+Additionally, transaction fees are important for the long-term health of the bitcoin-network, this proposal increases the demand for the blockchain.
+
+===What do you want to make these RPoB transactions if there is insufficient block-space?===
+
+This isn't our problem. Those who have the economic purpose and resources to make RPoB transactions will outcompete those who do not.
+
+==Backwards Compatibility==
+
+As this is an application layer structure without any preexisting deployment, we foresee no compatibility issues.
+
+==Reference Implementation==
+
+To be made.
+
+==Acknowledgements==
+
+While we have somewhat independently come up with the concept of RPoB, the idea of having a public record of public key enrolments has been around for a long time. None of the ideas in this BIP are new.
+
+We would like to thank Jonas Schnelli, 'M', and 'P', for their past contributions.
+
+==Appendixes==
+
+===Appendix 1: Some alternatives to blockchain-based proof-of-burn:===
+Blockchains provide the our first opportunity to have deterministic and decentralised trust networks. Before blockchains we had proof-of-work and proof-of-payments as the two main gate-keepers for boot-scraping new members into a exclusive group:
+
+==== Proof-of-Work: ====
+For example,
+
+* In games it could be to grind your character up to a certain level.
+* Or it could be to make and present hand-drawn artworks.
+* Or it could be to solve a CAPTCHA.
+
+With proof-of-work blockchains provides a way to quantises an abstract an amount of work into a value. Providing a solution "how much dose this work cost?" problem: your work can be traded for bitcoin, and the bitcoin value is set efficiently in the market.
+
+==== Proof-of-Payment: ====
+For example,
+
+* Buying an expensive uniform item required for the clan.
+* Paying membership dues.
+* Proving a donation to a charity.
+
+With proof-of-payment the problem is the feedback loops, who gets the payment is placed into a privileged position of responsibly. The blockchain solves this with proof-of-burn outputs, the 'payment' goes back to the network, distributed indirectly and proportionally the holders of bitcoin.
+
+==== None: ====
+For example,
+
+* Pretty-Good-Privacy (PGP).
+
+PGP provided the basic cryptographic infrastructure for secure communication, including a basic web-of-trust where users can cross-sign each others keys, to make man-in-the-middle attacks harder to carry out. The primary problem with PGP is that any infrastructure that uses it is open to denial-of-service attack, as making new pgp-key identities is extremely cheap.
+
+The trust network also is open to sybil attack, as huge numbers of keys can all cross-trust each other making it appear that they belong to a large-genuine trust network.
+
+==== Other: ====
+
+* Blockchain Timestamping, i.e. Open-Timestamps.
+
+One of the most simple ways of assiging value to something is to prove that it is old. Timestamping with a blockchain allows users to assert that they didn't just create this account just now. -  However the problem is that timestamps are cheap to make, and if the need for timestamps is predictable, then adversaries can pre-generate many to misuse and attack a network at a later date.
+
+* Blockchain space Use.
+
+Simply putting a statement into a blockchain itself, if there is any free-pressure is indirect form of burn by via the miner.  By out-competing the next-best-transaction set, this has burnt the value in the difference between the fees of the two set.
+
+Thus, it can be shown that if the blocks are full, a RPoB transaction with zero-burn-amount is still a proof-of-bun transaction!
+
+=== Appendix 2: Some notes on blockchain-based proof-of-burn and decentralised networks: ===
+Using a blockchain the relative value of a proof-of-burn is deterministically calculable:
+
+* Trust calculations transferring a proof-of-burn into a "default trust" value are possible. Leading to the creation of trust graphs that can operate reliably without human intervention.
+* Networks using such default trust calculations become inherently resistant to distributed denial of service attacks.
+
+All this cannot easily be achieved without leveraging the functionally of a blockchain such as Bitcoin.
+
+==Footnotes==
+
+<references />

--- a/bip-rpob-tx-template.mediawiki
+++ b/bip-rpob-tx-template.mediawiki
@@ -28,7 +28,7 @@ This proposal aims to support decentralised systems, allowing the use ''RPoB'' a
 This document is dual licensed as BSD 3-clause and Creative Commons CC0 1.0 Universal.
 
 ===Motivation===
-In signalling theory<ref group="Note">Evolutionary biology theory of communication, or ''"signalling theory"'', where creatures make honest signals that are hard to cheat, for mutual evolutionary advantage.</ref>, proof of burn<ref group="Note">In Bitcoin, ''proof of burn'' places bitcoin value into outputs that provably unspendable. This dose not reduce the wealthy of the network, but instead reduces the velocity of these coins to zero. Transferring the network wealth onto the remaining coins that have a non-zero velocity.</ref> is a costly signal,<ref group="Note">A ''"costly signal"'' indicates dedication, an observer expects that such a signal is not made flippantly because the high cost.</ref> allowing the network to assign a default trust.<ref group="Note">An entity is assigned a ''"default trust"'' value when they are not connected to the trust graph. Without a default source trust, growing a decentralised web-of-trust network is impossible. New users face a catch-22 problem: they are disconnected from the trust graph and don't have a possibility to prove themselves.</ref> Bitcoin naturally provides an implementation of proof of burn without feedback loops,<ref group="Note">A ''"feedback loop"'' is when a trust signal can be amplified by a privileged subset of the network by feeding the creation-cost of this signal back into the process of making the signal.</ref> allowing for default trust to be assigned fairly in decentralised networks.<ref group="Note">New users are able to use a proof-of-burn to bootstrap themselves into new trust networks. 'New-user-with-burn-proofs' can be welcomed-in with basic services and focused attention, as the network knows that it was costly to generate the burn-proof.</ref>
+In signalling theory<ref group="Note">Evolutionary biology theory of communication, or ''"signalling theory"'', where creatures make honest signals that are hard to cheat, for mutual evolutionary advantage.</ref>, proof of burn<ref group="Note">In Bitcoin, ''proof of burn'' places bitcoin value into outputs that provably unspendable. This dose not reduce the wealthy of the network, but instead reduces the velocity of these coins to zero. Transferring the network wealth onto the remaining coins that have a non-zero velocity.</ref> is a costly signal,<ref group="Note">A ''"costly signal"'' indicates dedication, an observer expects that such a signal is not made flippantly because the high cost.</ref> allowing the network to assign a default trust.<ref group="Note">An entity is assigned a ''"default trust"'' value when they are not connected to the trust graph. Without a default source trust, growing a decentralised web-of-trust network is impossible. New users face a catch-22 problem: they are disconnected from the trust graph and don't have a possibility to prove themselves.</ref> Bitcoin naturally provides an implementation of proof of burn without trust feedback loops,<ref group="Note">A ''"trust feedback loop"'' is when a trust signal can be amplified by a privileged subset of the network by feeding the creation-cost of this signal back into the process of making the signal.</ref> allowing for default trust to be assigned fairly in decentralised networks.<ref group="Note">New users are able to use a proof-of-burn to bootstrap themselves into new trust networks. 'New-user-with-burn-proofs' can be welcomed-in with basic services and focused attention, as the network knows that it was costly to generate the burn-proof.</ref>
 
 The ability to revoke<ref group="Note">To ''"revoke", is'' publicly asserting that a previous statement should not be valued as originally intended.</ref> past assertions is important for many applications,<ref group="Note">Unexpected things happen, for example, the loss or compromise of private keys.</ref> therefore proposal couples bitcoin proof-of-burn with a revocation mechanic.
 
@@ -45,20 +45,21 @@ In choosing to standardise via the BIP peer-reviewed process, we hope to give th
 Since OP_RETURN doesn't allow the public key script to be spent (as is it's design), there hasn't been any built-in solution addressing the requirements a application-useable proof-of-burn transaction, in particular:
 
 *A standard association with a public key in for transaction.
+*A standard way to privately lock a OP_RETURN transaction to a particular purpose.
 *A standard protocol to publicly revoke a proof-of-burn transaction.
 
-In this proposal we satisfy these requirements by specifying a taproot public key in the op_return payload and an another output for revocation.
+In this proposal we satisfy these requirements by specifying an optionally tweaked taproot public key in the op_return payload and an another output for revocation.
 
 ===Other Requirements===
-Operation under <abbr title="Simple Payment Verification">SPV</abbr> assumptions:
-*Transactions are small: ''RPoB transactions (non-witness-part) are fixed to two possible sizes, depending if there is a change output, or not.''
-*Revocations are quickly and cheaply indexed: ''RPoB revocations only require obtaining the preimage to a double-sha256 hash. This is easily indexed and propagated in a gossip network.''
+Optimized operation under <abbr title="Simple Payment Verification">SPV</abbr> assumptions:
+*Transactions are tiny and simple: ''The RPoB transactions template constrains the rules of the transaction to the minimum. Both size are complexity limitations are used: Single Input, used to limit the size of the RPoB transactions; Single Optional Change Output, used to limit the size of the RPoB transactions; and Exclusive use of Taproot, used to limit the complexity of the RPoB transactions.''
+*Revocations are both cheaply indexed and uncensorable: ''Receiving the pre-image to the RPoB revocation signals it's revocation. This is easily indexed and propagated in a gossip network, however gossip networks are relatively  censorable. Using the same pre-image, anyone is able to spend the revocation output, rendering this revocation uncensorable.''
 
 Ease of implementation:
 *Use of only Taproot and Schnorr: ''To reduce the scope of the transaction, we use only Taproot for inputs and Outputs, and Schnorr for the signature that covers the funding outpoint.''
 
 Transaction funded by 3rd party:
-* It should be secure for an untrusted 3rd party fund the proof-of-burn transaction. ''Allowing for services to fund these transactions and be compensated with some sort of off-chain payment.''
+*It should be secure for an untrusted 3rd party fund the proof-of-burn transaction. ''Allowing for services to fund these transactions and be compensated with some sort of off-chain payment.''
 
 Future extendability:
 *Making use of the transaction version feature of bitcoin. ''This allows for easier indexing strategies in the future, (with a simple consensus change: to include in the coinbase the number of the transactions in the block by their transaction version).''
@@ -73,7 +74,7 @@ This section specifies our RPoB transaction template.
 ===Transaction===
 General form:
 <pre>
-version:      0x3
+version:      0x5
 marker:       0x0
 flag:         0x1
 txin_count:   0x1
@@ -81,7 +82,7 @@ txout_count:  0x2 (without change) or 0x3 (with change)
 lock_time:    (any)
 </pre>
 
-*RPoB transactions MUST use the transaction version (nVersion) 0x03.
+*RPoB transactions MUST use the transaction version (nVersion) 0x05.
 
 *RPoB transactions MUST have only one input and either two or three outputs.
 
@@ -113,6 +114,7 @@ rpob_schnorr_signature:     64-bytes, bip-340 Schnorr Signature.
 </pre>
 
 *The first RPoB transaction contains the burn value, that is made unspendable by the 'OP_RETURN' in the public key script.
+*The 'secp256k1_public_key' may be tweaked, showing the signed tweak (and it's associated pre-image) proves the single-purpose of the RPoB transaction.
 
 ===Output 2: Revocation Puzzle===
 General form:
@@ -169,18 +171,52 @@ rpob_signature_message:       77-bytes, < 1-byte-version_flags>
                                         <32-byte-rpob_revocation_puzzle>
 </pre>
 
-*The <code>rpob_schnorr_signature</code> uses the [https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki BIP-340] algorithm.
+*The signature is included so that the RPoB transaction may be safely constructed and funded by untrusted second parties.
+
+===Optional: Fixed Purpose Encoded in the Key Tweak===
+The Tweak is applied to the public and secret keys the same as the 'TapTweak' hash in [https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki BIP-341]:
+
+<pre>
+rpob_secp256k1_public_key_tweaked:    32-bytes, bip-341, taproot_tweak_pubkey  (
+                                                <32-byte-rpob_secp256k1_public_key>,
+                                                <32-byte-rpob_tweak_hash>
+                                                )
+
+rpob_secp256k1_private_key_tweaked:   32-bytes, bip-341, taproot_tweak_seckey  (
+                                                <32-byte-secp256k1_private_key>,
+                                                <32-byte-rpob_tweak_hash>
+                                                )
+
+rpob_tweak_hash:                      32-bytes, bip-340, sha256_taged_hash (
+                                                <rpob_transaction_purpose>,
+                                                <16-byte-rpob_tweak_hash_tag>
+                                                )
+
+rpob_tweak_hash_tag:                  16-bytes, utf-8-hash_tag ("rpob/BTC/PURPOSE")
+</pre>
+
+The 'rpob_transaction_purpose', is a user defined string that locks the RPoB transaction to a particular purpose.
+
+The Taproot Tweaks should be signed and revealed according to [https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki BIP-341].
 
 ==Deployment==
 
 While the ''IsStandard'' rules are quite restricting, it is quite possible to submit transactions directly to miners, or co-operate with miners who would enjoy to have some addition fee-revenue. So the initial process of testing on the main-network should be possible.
 
-If this standard gains significant attention, we are happy to write a supplementary BIP to define a new service bit to allow nodes to signal that this new type of standard transaction is accepted.
+If this standard gains significant attention, we are happy to write a supplementary BIP to define a way for participating nodes signal to each other that they accept the relay of  RPoB transactions.
 
 ==Rationale==
 ===Why require RPoB transactions to use a new transaction version?===
 
 This allows for future indexing and enforcement strategies at the consensus layer.
+
+===Why use a Tweaked secp256k1 for the RPoB transaction purpose?===
+
+Locking a transaction to a particular purpose allows for users to prove globally that their RPoB transaction is not secretly having additional purposes.  Often when making a proof-of-burn transaction a service will want to assure that the value burnt is not being spread over multiple purposes.
+
+Tweaks provide a natural solution to this problem:
+1. It is impossible to encode multiple top-level tweaks into the a public key.  (Multiple tweaks are possible but this is not a problem as it demands using a different decoding process).
+2. Privacy is maintained. Nobody can tell if a RPoB transaction has a fixed purpose, or not, unless the tweak has been revealed.
 
 ===Why use a hash puzzle for the revocation?===
 
@@ -188,7 +224,7 @@ The hash-puzzle allows for easy indexing of the revocation, in the format:
 
 <code><32-byte-revocation-puzzle> (if revoked: <32-byte-revocation-puzzle-preimage>)</code>
 
-*Since the digest algorithm is double sha256, even for a very large number of revocation, this index would be very cheap to verify.
+*Since the digest algorithm is double sha256, even for a very large number of revocation, this index would be very cheap to verify, in contrast to asymmetrical cryptographic signatures.
 
 *We envision nodes keeping track of all the revocation-puzzles listed in the blockchain, as 32-byte each, a million RPoB is only 32mb. This can be further optimised.
 
@@ -203,11 +239,14 @@ Revocation can be spent by anyone once the revocation pre-image has been publish
 The primary purpose of the signature is to stop replay-attacks. (Somebody takes your public-key and makes transaction where you don't control the revocation).
 
 The secondary purpose is to allow for untrusted parties to create transactions on your behalf. i.e. a 'RPoB' transaction creation service.
+
 ===Why waste precious block space?===
 
-Consuming block-space is a of secondary proof-of-burn that this proposal takes advantage of, as itself is limited and contested for (blocks are almost full on average). There is an opportunity cost of the next best transaction when a miner chooses to include a RPoB transaction their block.
+The authors of this BIP do accept the premise of this question. Each block is a auction of block-space that helps rewarding the miner in their important consensus role. We are not some authority who can define 'waste' from 'economic' transaction. We take the neutral position that if a transaction is willing to pay the transaction-fee-at-auction it must have a economic purpose that supports doing so.
 
-Additionally, transaction fees are important for the long-term health of the bitcoin-network, this proposal increases the demand for the blockchain.
+Additionally, this proposal takes advantage of economic opportunity cost that the miner faces when excluding transaction when blocks are full (that they generally are). This allows for the transaction-fees-at-auction to behave as a secondary proof-of-burn.
+
+The authors are not fazed by the possibility that proposal, if gaining significant adoption, will lead to the a meaningful increase of the Bitcoin transaction fees. We regard transaction fees important for long-term health of the network and consider making statements in global consensus networks as inherently costly.
 
 ===What do you want to make these RPoB transactions if there is insufficient block-space?===
 
@@ -263,7 +302,7 @@ The trust network also is open to sybil attack, as huge numbers of keys can all 
 
 * Blockchain Timestamping, i.e. Open-Timestamps.
 
-One of the most simple ways of assiging value to something is to prove that it is old. Timestamping with a blockchain allows users to assert that they didn't just create this account just now. -  However the problem is that timestamps are cheap to make, and if the need for timestamps is predictable, then adversaries can pre-generate many to misuse and attack a network at a later date.
+One of the most simple ways of assigning value to something is to prove that it is old. Timestamping with a blockchain allows users to assert that they didn't just create this account just now. -  However the problem is that timestamps are cheap to make, and if the need for timestamps is predictable, then adversaries can pre-generate many to misuse and attack a network at a later date.
 
 * Blockchain space Use.
 
@@ -277,7 +316,7 @@ Using a blockchain the relative value of a proof-of-burn is deterministically ca
 * Trust calculations transferring a proof-of-burn into a "default trust" value are possible. Leading to the creation of trust graphs that can operate reliably without human intervention.
 * Networks using such default trust calculations become inherently resistant to distributed denial of service attacks.
 
-All this cannot easily be achieved without leveraging the functionally of a blockchain such as Bitcoin.
+All this cannot easily be achieved without leveraging the functionally of a global-consensus blockchain such as Bitcoin.
 
 ==Footnotes==
 

--- a/bip-rpob-tx-template/rpob-template-summary-table.svg
+++ b/bip-rpob-tx-template/rpob-template-summary-table.svg
@@ -1,0 +1,279 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg version='1.1'
+     viewBox='0 0 642.5 483.5'
+     xmlns='http://www.w3.org/2000/svg'>
+    <style type='text/css'>
+	.stroke_black{stroke:#000000;stroke-width:1.5;stroke-linecap:square;stroke-miterlimit:10;}
+	.fill_white{fill:#FFFFFF;}
+	.fill_dark{fill:#231F20;}
+	.fill_yellow{fill:#FEC306;}
+	.fill_orange{fill:#DF5327;}
+	.fill_opacity_light{fill-opacity:0.2}
+	.fill_opacity_medium{fill-opacity:0.35}
+	.fill_opacity_dark{fill-opacity:0.65}
+	.fill_opacity_very_dark{fill-opacity:0.8}
+	.font_family{font-family:'Liberation Serif',serif;}
+	.font_bold{font-weight: bold;}
+	.font_italic{font-style: italic;}
+	.font_big{font-size:17px;}
+	.font_medium{font-size:16px;}
+	.font_small{font-size:14px;}
+</style>
+    <defs>
+        <g id='Table'>
+            <rect class='stroke_black'
+                  x='0'
+                  y='0'
+                  width='641'
+                  height='37' />
+            <text class='fill_white font_family font_big font_bold'
+                  transform='matrix(1 0 0 1 141 24)'>Revokable Proof-of-Burn Transaction Template</text>
+            <rect class='stroke_black fill_opacity_very_dark'
+                  x='0'
+                  y='37'
+                  width='47'
+                  height='445' />
+            <text transform='matrix(0 1 -1 0 19 128)'>
+                <tspan class='fill_white font_family font_medium font_bold'
+                       x='0'
+                       y='0'>Transaction Version </tspan>
+                <tspan class='fill_white font_family font_italic font_medium'
+                       x='144'
+                       y='0'>(nVersion)</tspan>
+                <tspan class='fill_white font_family font_medium font_bold'
+                       x='212'
+                       y='0'> = 0x03</tspan>
+            </text>
+            <rect class='stroke_black fill_opacity_light'
+                  x='81'
+                  y='37'
+                  width='61'
+                  height='29' />
+            <text class='fill_dark font_family font_small font_bold'
+                  transform='matrix(1 0 0 1 94 56)'>Index</text>
+            <rect class='stroke_black fill_opacity_light'
+                  x='142'
+                  y='37'
+                  width='421'
+                  height='29' />
+            <text class='fill_dark font_family font_small font_bold'
+                  transform='matrix(1 0 0 1 299 56)'>Script Public Key</text>
+            <rect class='stroke_black fill_yellow'
+                  x='47'
+                  y='66'
+                  width='34'
+                  height='106' />
+            <text class='fill_dark font_family font_small font_bold'
+                  transform='matrix(0 1 -1 0 59 102)'>Input</text>
+            <rect class='stroke_black fill_opacity_very_dark'
+                  x='81'
+                  y='66'
+                  width='560'
+                  height='30' />
+            <text class='fill_white font_family font_small'
+                  transform='matrix(1 0 0 1 91 85)'>A Single Index Only</text>
+            <rect class='stroke_black fill_yellow fill_opacity_dark '
+                  x='81'
+                  y='95'
+                  width='61'
+                  height='30' />
+            <text class='fill_dark font_family font_small'
+                  transform='matrix(1 0 0 1 106 112)'>1.</text>
+            <rect class='stroke_black fill_yellow fill_opacity_dark '
+                  x='563'
+                  y='95'
+                  width='78'
+                  height='30' />
+            <text class='fill_dark font_family font_small'
+                  transform='matrix(1 0 0 1 587 112)'>[any]</text>
+            <rect class='stroke_black fill_yellow fill_opacity_medium '
+                  x='81'
+                  y='125'
+                  width='560'
+                  height='47' />
+            <text transform='matrix(1 0 0 1 316 145)'>
+                <tspan class='fill_dark font_family font_italic font_small'
+                       x='0'
+                       y='0'>Only a single taproot output is used to fund transaction. </tspan>
+                <tspan class='fill_dark font_family font_italic font_small'
+                       x='-29'
+                       y='16'>For simplicity and constraining non-witness transaction size.</tspan>
+            </text>
+            <rect class='stroke_black fill_orange'
+                  x='47'
+                  y='172'
+                  width='34'
+                  height='310' />
+            <text class='fill_dark font_family font_small font_bold'
+                  transform='matrix(0 1 -1 0 59 302)'>Outputs</text>
+            <rect class='stroke_black fill_opacity_very_dark'
+                  x='81'
+                  y='172'
+                  width='560'
+                  height='30' />
+            <text class='fill_white font_family font_small'
+                  transform='matrix(1 0 0 1 91 191)'>Two or Three Indexes Only</text>
+            <rect class='stroke_black fill_orange fill_opacity_dark'
+                  x='81'
+                  y='202'
+                  width='61'
+                  height='63' />
+            <text class='fill_dark font_family font_small'
+                  transform='matrix(1 0 0 1 106 218)'>1.</text>
+            <rect class='stroke_black fill_orange fill_opacity_dark'
+                  x='563'
+                  y='202'
+                  width='78'
+                  height='63' />
+            <text class='fill_dark font_family font_small'
+                  transform='matrix(1 0 0 1 584 218)'>[burn]</text>
+            <rect class='stroke_black fill_orange fill_opacity_medium'
+                  x='81'
+                  y='265'
+                  width='560'
+                  height='64' />
+            <text transform='matrix(1 0 0 1 371 285)'>
+                <tspan class='fill_dark font_family font_italic font_small'
+                       x='0'
+                       y='0'>Bitcoin made unspendable accompanied with: </tspan>
+                <tspan class='fill_dark font_family font_italic font_small'
+                       x='-267'
+                       y='16'>Version; Public Key; Signiture, covering the version, input, burn value, and revocation puzzle.</tspan>
+                <tspan class='fill_dark font_family font_italic font_small'
+                       x='38'
+                       y='33'>Burn may be any value, including zero.</tspan>
+            </text>
+            <rect class='stroke_black fill_orange fill_opacity_dark'
+                  x='81'
+                  y='328'
+                  width='61'
+                  height='47' />
+            <text class='fill_dark font_family font_small'
+                  transform='matrix(1 0 0 1 106 345)'>2.</text>
+            <rect class='stroke_black fill_orange fill_opacity_dark'
+                  x='563'
+                  y='328'
+                  width='78'
+                  height='47' />
+            <text class='fill_dark font_family font_small'
+                  transform='matrix(1 0 0 1 598 345)'>0</text>
+            <rect class='stroke_black fill_orange fill_opacity_medium'
+                  x='81'
+                  y='375'
+                  width='560'
+                  height='47' />
+            <text transform='matrix(1 0 0 1 378 395)'>
+                <tspan class='fill_dark font_family font_italic font_small'
+                       x='0'
+                       y='0'>Zero-value output with Revocation Program. </tspan>
+                <tspan class='fill_dark font_family font_italic font_small'
+                       x='56'
+                       y='16'>Signalling intent to revoke if spent.</tspan>
+            </text>
+            <rect class='stroke_black fill_orange fill_opacity_dark'
+                  x='81'
+                  y='422'
+                  width='61'
+                  height='30' />
+            <text class='fill_dark font_family font_small'
+                  transform='matrix(1 0 0 1 101 438)'>(3.)</text>
+            <rect class='stroke_black fill_orange fill_opacity_dark'
+                  x='563'
+                  y='422'
+                  width='78'
+                  height='30' />
+            <text class='fill_dark font_family font_small'
+                  transform='matrix(1 0 0 1 587 438)'>[any]</text>
+            <rect class='stroke_black fill_orange fill_opacity_medium'
+                  x='81'
+                  y='452'
+                  width='560'
+                  height='30' />
+            <text class='fill_dark font_family font_italic font_small'
+                  transform='matrix(1 0 0 1 396 471)'>An optional single taproot change output.</text>
+            <rect class='stroke_black fill_opacity_light'
+                  x='563'
+                  y='37'
+                  width='78'
+                  height='29' />
+            <text class='fill_dark font_family font_small font_bold'
+                  transform='matrix(1 0 0 1 577 56)'>Amount</text>
+            <rect class='stroke_black fill_orange fill_opacity_dark'
+                  x='142'
+                  y='202'
+                  width='421'
+                  height='63' />
+            <text transform='matrix(1 0 0 1 152 221)'>
+                <tspan class='font_family font_small font_bold'
+                       x='0'
+                       y='0'>RETURN</tspan>
+                <tspan class='font_family font_small'
+                       x='62'
+                       y='0'> &lt;1-byte-version-flag&gt;</tspan>
+                <tspan class='font_family font_small'
+                       x='0'
+                       y='16'> &lt;32-byte-secp256k1_public_key&gt;</tspan>
+                <tspan class='font_family font_small'
+                       x='0'
+                       y='33'> &lt;64-byte-schnorr_signature&gt;</tspan>
+            </text>
+            <rect class='stroke_black fill_orange fill_opacity_dark'
+                  x='142'
+                  y='328'
+                  width='421'
+                  height='47' />
+            <text transform='translate(152 348)'>
+                <tspan class='font_family font_small font_bold'
+                       x='0'
+                       y='0'>SIZE 32 EQUALVERIFY HASH256 </tspan>
+                <tspan class='font_family font_small'
+                       x='0'
+                       y='17'>&lt;32-byte-revocation_puzzle&gt; </tspan>
+                <tspan class='font_family font_small font_bold'
+                       x='170'
+                       y='17'>EQUAL</tspan>
+            </text>
+            <rect class='stroke_black fill_orange fill_opacity_dark'
+                  x='142'
+                  y='422'
+                  width='421'
+                  height='30' />
+            <text transform='translate(152 441)'>
+                <tspan class='font_family font_small font_bold'
+                       x='0'
+                       y='0'>1</tspan>
+                <tspan class='font_family font_small'
+                       x='12'
+                       y='0'> &lt;32-byte-taproot_witness_program&gt;</tspan>
+            </text>
+            <rect class='stroke_black fill_yellow fill_opacity_dark '
+                  x='142'
+                  y='95'
+                  width='421'
+                  height='30' />
+            <text transform='translate(152 115)'>
+                <tspan class='font_family font_small font_bold'
+                       x='0'
+                       y='0'>1</tspan>
+                <tspan class='font_family font_small'
+                       x='12'
+                       y='0'> &lt;32-byte-taproot_witness_program&gt;</tspan>
+            </text>
+            <rect class='stroke_black fill_white'
+                  x='47'
+                  y='37'
+                  width='34'
+                  height='29' />
+            <text class='font_family font_small font_bold'
+                  transform='translate(59 56)'>₿</text>
+        </g>
+    </defs>
+    <g id='Background'>
+        <rect class='fill_white'
+              width='642.5'
+              height='483.5' />
+    </g>
+    <use href='#Table'
+         x='0.75'
+         y='0.75' />
+</svg>

--- a/bip-rpob-tx-template/rpob-template-summary-table.svg
+++ b/bip-rpob-tx-template/rpob-template-summary-table.svg
@@ -138,7 +138,7 @@
                        y='0'>Bitcoin made unspendable accompanied with: </tspan>
                 <tspan class='fill_dark font_family font_italic font_small'
                        x='-267'
-                       y='16'>Version; Public Key; Signiture, covering the version, input, burn value, and revocation puzzle.</tspan>
+                       y='16'>Version; Public Key; Signature, covering the version, input, burn value, and revocation puzzle.</tspan>
                 <tspan class='fill_dark font_family font_italic font_small'
                        x='38'
                        y='33'>Burn may be any value, including zero.</tspan>

--- a/bip-rpob-tx-template/rpob-template-summary-table.svg
+++ b/bip-rpob-tx-template/rpob-template-summary-table.svg
@@ -42,7 +42,7 @@
                        y='0'>(nVersion)</tspan>
                 <tspan class='fill_white font_family font_medium font_bold'
                        x='212'
-                       y='0'> = 0x03</tspan>
+                       y='0'> = 0x05</tspan>
             </text>
             <rect class='stroke_black fill_opacity_light'
                   x='81'


### PR DESCRIPTION
This BIP proposes a standard way for making Bitcoin Proof-of-Burn Transactions.

There are many possible applications, such as being:
- The default trust anchor in decentralised networks.
- An effective dos-resistant signal for announcements or other low-frequency events.

Please view the proposal here:
https://github.com/veleslavs/bips/blob/bip-rpob-tx-template/bip-rpob-tx-template.mediawiki

Next steps:
- [ ] Update proposal with BIP Number.
- [ ] Collect more peer-review.
- [ ] Collect review in particular with the Taproot Tweak Parts.
- [ ] Update BIP with reference implementation and test vectors.
- [ ] Merge proposal as Draft BIP.

Upon assignment of a BIP number, I will update and convert this Draft Pull Request into a normal Pull Request.