### PR TITLE
Fix inconsistent notations in the context

### DIFF
--- a/bip-0032.mediawiki
+++ b/bip-0032.mediawiki
@@ -71,7 +71,7 @@ Each extended key has 2<sup>31</sup> normal child keys, and 2<sup>31</sup> harde
 
 Given a parent extended key and an index i, it is possible to compute the corresponding child extended key. The algorithm to do so depends on whether the child is a hardened key or not (or, equivalently, whether i ≥ 2<sup>31</sup>), and whether we're talking about private or public keys.
 
-====Private parent key &rarr; private child key====
+====Parent private key &rarr; child private key====
 
 The function CKDpriv((k<sub>par</sub>, c<sub>par</sub>), i) &rarr; (k<sub>i</sub>, c<sub>i</sub>) computes a child extended private key from the parent extended private key:
 * Check whether i ≥ 2<sup>31</sup> (whether the child is a hardened key).
@@ -84,7 +84,7 @@ The function CKDpriv((k<sub>par</sub>, c<sub>par</sub>), i) &rarr; (k<sub>i</sub
 
 The HMAC-SHA512 function is specified in [http://tools.ietf.org/html/rfc4231 RFC 4231].
 
-====Public parent key &rarr; public child key====
+====Parent public key &rarr; child public key====
 
 The function CKDpub((K<sub>par</sub>, c<sub>par</sub>), i) &rarr; (K<sub>i</sub>, c<sub>i</sub>) computes a child extended public key from the parent extended public key. It is only defined for non-hardened child keys.
 * Check whether i ≥ 2<sup>31</sup> (whether the child is a hardened key).
@@ -95,18 +95,18 @@ The function CKDpub((K<sub>par</sub>, c<sub>par</sub>), i) &rarr; (K<sub>i</sub>
 * The returned chain code c<sub>i</sub> is I<sub>R</sub>.
 * In case parse<sub>256</sub>(I<sub>L</sub>) ≥ n or K<sub>i</sub> is the point at infinity, the resulting key is invalid, and one should proceed with the next value for i.
 
-====Private parent key &rarr; public child key====
+====Parent private key &rarr; parent public key / Child private key &rarr; child public key====
 
 The function N((k, c)) &rarr; (K, c) computes the extended public key corresponding to an extended private key (the "neutered" version, as it removes the ability to sign transactions).
 * The returned key K is point(k).
 * The returned chain code c is just the passed chain code.
 
-To compute the public child key of a parent private key:
+To compute the child public key of a parent private key:
 * N(CKDpriv((k<sub>par</sub>, c<sub>par</sub>), i)) (works always).
 * CKDpub(N(k<sub>par</sub>, c<sub>par</sub>), i) (works only for non-hardened child keys).
-The fact that they are equivalent is what makes non-hardened keys useful (one can derive child public keys of a given parent key without knowing any private key), and also what distinguishes them from hardened keys. The reason for not always using non-hardened keys (which are more useful) is security; see further for more information.
+The fact that they are equivalent is what makes non-hardened keys useful (one can derive child public keys of a given parent public key without knowing any parent private key), and also what distinguishes them from hardened keys. The reason for not always using non-hardened keys (which are more useful) is security; see further for more information.
 
-====Public parent key &rarr; private child key====
+====Parent public key &rarr; child private key====
 
 This is not possible.
 


### PR DESCRIPTION
Issue One
Inconsistent Notations: public/private parent/child key and parent/child public/private key

The above two kinds of notations are used around the BIP32 document, while I suggest it is better to uniform the whole context with the 2nd kind of notation for better clarity and reasoning. Since in a public key cryptosystem, the key pair contains a public key and a private key, and here all key pairs are associated with either parent nodes or child nodes, it makes much more sense to say parent public key than public parent key.

Thus, for example, the subsection title, "Public parent key -> public child key", should be "Parent public key -> child public key". Another subtitle title, "Public parent key -> private child key", should be "Parent public key -> child private key".

Issue Two
Improper (Incorrect) subsection title: "Private parent key -> public child key"

The function N((k,c)) -> (K,c) is simply the computation K = k * G. It computes the child public key from a child private key or the parent public key from a parent private key.

Thus, the subsection title "Private parent key -> public child key" should be changed to "Private key -> public key".