### PR TITLE
BIP 341: add missing conversions between bytes and int

### DIFF
--- a/bip-0341.mediawiki
+++ b/bip-0341.mediawiki
@@ -186,12 +186,13 @@ def taproot_tweak_pubkey(pubkey, h):
     return 0 if has_even_y(Q) else 1, bytes_from_int(x(Q))
 
 def taproot_tweak_seckey(seckey0, h):
-    P = point_mul(G, int_from_bytes(seckey0))
+    seckey0 = int_from_bytes(seckey0)
+    P = point_mul(G, seckey0)
     seckey = seckey0 if has_even_y(P) else SECP256K1_ORDER - seckey0
     t = int_from_bytes(tagged_hash("TapTweak", bytes_from_int(x(P)) + h))
     if t >= SECP256K1_ORDER:
         raise ValueError
-    return (seckey + t) % SECP256K1_ORDER
+    return bytes_from_int((seckey + t) % SECP256K1_ORDER)
 </source>
 
 The following function, <code>taproot_output_script</code>, returns a byte array with the scriptPubKey (see [[bip-0141.mediawiki|BIP141]]).
@@ -350,6 +351,6 @@ Depending on the implementation non-upgraded wallets may be able to send to Segw
 
 == Acknowledgements ==
 
-This document is the result of discussions around script and signature improvements with many people, and had direct contributions from Greg Maxwell and others. It further builds on top of earlier published proposals such as Taproot by Greg Maxwell, and Merkle branch constructions by Russell O'Connor, Johnson Lau, and Mark Friedenbach. 
+This document is the result of discussions around script and signature improvements with many people, and had direct contributions from Greg Maxwell and others. It further builds on top of earlier published proposals such as Taproot by Greg Maxwell, and Merkle branch constructions by Russell O'Connor, Johnson Lau, and Mark Friedenbach.
 
 The authors wish the thank Arik Sosman for suggesting to sort Merkle node children before hashes, removing the need to transfer the position in the tree, as well as all those who provided valuable feedback and reviews, including the participants of the [https://github.com/ajtowns/taproot-review structured reviews].


### PR DESCRIPTION
It seems like there are some missing type conversions in the example python code for `taproot_tweak_seckey`.

Changes made:
- Convert seckey0 to bytes at the start of the function. 
- Return the output as bytes for consistency with the rest of the code.