### PR TITLE
Fix "filterLoad" missing "nFilterBytes" issue.

### DIFF
--- a/bip-0037.mediawiki
+++ b/bip-0037.mediawiki
@@ -48,6 +48,8 @@ The <code>filterload</code> command is defined as follows:
 {|class="wikitable"
 ! Field Size !! Description !! Data type !! Comments
 |-
+| 1+ || nFilterBytes || var_int || The length of filter in byte.
+|-
 | ? || filter || uint8_t[] || The filter itself is simply a bit field of arbitrary byte-aligned size. The maximum size is 36,000 bytes.
 |-
 | 4 || nHashFuncs || uint32_t || The number of hash functions to use in this filter. The maximum value allowed in this field is 50.


### PR DESCRIPTION
The "filterLoad" message misses "nFilterBytes" in the doc.