### PR TITLE
BIP330: drop redundant booleans from the sendtxrcncl message

### DIFF
--- a/bip-0330.mediawiki
+++ b/bip-0330.mediawiki
@@ -144,16 +144,13 @@ Its payload consists of:
 {|class="wikitable"
 ! Data type !! Name !! Description
 |-
-| bool || initiator || Indicates whether the sender will send "reqrecon" message
-|-
-| bool || responder || Indicates whether the sender will respond to "reqrecon" messages.
-|-
 | uint32 || version || Sender must set this to 1 currently, otherwise receiver should ignore the message. v1 is the lowest protocol version, everything below that is a protocol violation.
 |-
 | uint64 || salt || The salt used in the short transaction ID computation.
 |}
 
-"reqrecon" messages can only be sent if the inititor has sent a "sendtxrcncl" message with initiator=true, and the receiver has sent a "sendtxrcncl" message with responder=true.
+After both peers have confirmed support by sending "sendtxrcncl", the initiator of the P2P connection assumes the role of reconciliation initiator (will send "reqrecon" messages) and the other peer assumes the role of reconciliation responder (will respond to "reqrecon" messages).
+"reqrecon" messages can only be sent by the reconciliation initiator.
 
 ====reqrecon====
 The reqrecon message initiates a reconciliation round.


### PR DESCRIPTION
The reconciliation protocol assumes using one role consistently. Since it is irrelevant which one is which, we can imply that the initiator of the P2P connection will assume the role of reconciliation initiator.

This protocol simplification will seep into the implementation.