### PR TITLE
BIP341: add aux_rand argument to taproot_sign_key

### DIFF
--- a/bip-0341.mediawiki
+++ b/bip-0341.mediawiki
@@ -245,10 +245,10 @@ TapTweak = tagged_hash("TapTweak", p + ABCDE)
 '''Spending using the key path''' A Taproot output can be spent with the secret key corresponding to the <code>internal_pubkey</code>. To do so, a witness stack consists of a single element: a [[bip-0340.mediawiki|BIP340]] signature on the signature hash as defined above, with the secret key tweaked by the same <code>h</code> as in the above snippet. See the code below:
 
 <source lang="python">
-def taproot_sign_key(script_tree, internal_seckey, hash_type):
+def taproot_sign_key(script_tree, internal_seckey, hash_type, bip340_aux_rand):
     _, h = taproot_tree_helper(script_tree)
     output_seckey = taproot_tweak_seckey(internal_seckey, h)
-    sig = schnorr_sign(sighash(hash_type), output_seckey)
+    sig = schnorr_sign(sighash(hash_type), output_seckey, bip340_aux_rand)
     if hash_type != 0:
         sig += bytes([hash_type])
     return [sig]


### PR DESCRIPTION
The `schnorr_sign` function from the [bip340 reference code](https://github.com/bitcoin/bips/blob/master/bip-0340/reference.py#L98) has a third required argument `aux_rand: bytes`.

Change:
- ~adding `aux_rand` as an optional argument that defaults to `0x0000...`~
- adding `bip340_aux_rand` as a required argument to the function `taproot_sign_key` 