### PR TITLE
BIP341: fix int conversion in taproot_tweak_pubkey

### DIFF
--- a/bip-0341.mediawiki
+++ b/bip-0341.mediawiki
@@ -182,7 +182,7 @@ def taproot_tweak_pubkey(pubkey, h):
     t = int_from_bytes(tagged_hash("TapTweak", pubkey + h))
     if t >= SECP256K1_ORDER:
         raise ValueError
-    Q = point_add(lift_x(int(pubkey)), point_mul(G, t))
+    Q = point_add(lift_x(int_from_bytes(pubkey)), point_mul(G, t))
     return 0 if has_even_y(Q) else 1, bytes_from_int(x(Q))
 
 def taproot_tweak_seckey(seckey0, h):


### PR DESCRIPTION
- fix the int conversion to use `int_from_bytes()` rather than `int()`