### PR TITLE
BIP 341: Fix taproot_tweak_pubkey

### DIFF
--- a/bip-0341.mediawiki
+++ b/bip-0341.mediawiki
@@ -182,7 +182,10 @@ def taproot_tweak_pubkey(pubkey, h):
     t = int_from_bytes(tagged_hash("TapTweak", pubkey + h))
     if t >= SECP256K1_ORDER:
         raise ValueError
-    Q = point_add(lift_x(int(pubkey)), point_mul(G, t))
+    P = lift_x(int_from_bytes(pubkey))
+    if P is None:
+        raise ValueError
+    Q = point_add(P, point_mul(G, t))
     return 0 if has_even_y(Q) else 1, bytes_from_int(x(Q))
 
 def taproot_tweak_seckey(seckey0, h):


### PR DESCRIPTION
`lift_x` returns `None` if the input integer is not an X coordinate on the curve to indicate failure. `point_add`, on the other hand, interprets `None` as the point at infinity. Therefore, without this commit, if the internal `pubkey` is not a valid X coordinate, the function will not fail, which contradicts the specification in the "Script validation rules section". Instead, it sets `Q` to `t*G`.

A test vector is being added here: https://github.com/bitcoin-core/qa-assets/pull/98

CC @sipa @ajtowns 