### PR TITLE
update bip-0129.mediawiki

### DIFF
--- a/bip-0129.mediawiki
+++ b/bip-0129.mediawiki
@@ -47,10 +47,13 @@ Concerns #4 and #5 should be handled by Signers and are out of scope of this pro
 ==Specification==
 
 ===Prerequisites===
-This proposal assumes the parties in the multisig support [https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki BIP-0032], [https://github.com/bitcoin/bips/blob/master/bip-0322.mediawiki BIP-0322], [https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md the descriptor language] and [https://tools.ietf.org/html/rfc3686 AES encryption].
+This proposal assumes the parties in the multisig support [https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki BIP-0032], [https://github.com/bitcoin/bips/blob/master/bip-0322.mediawiki BIP-0322], [https://github.com/bitcoin/bips/blob/master/bip-0380.mediawiki BIP-0380 Output Script Descriptors] ([https://github.com/bitcoin/bips/blob/master/bip-0381.mediawiki BIP-0381],[https://github.com/bitcoin/bips/blob/master/bip-0382.mediawiki BIP-0382],[https://github.com/bitcoin/bips/blob/master/bip-0383.mediawiki BIP-0383]) and [https://tools.ietf.org/html/rfc3686 AES encryption].
 
 ===File Extensions===
 All descriptor and key records should have a <tt>.bsms</tt> file extension. Encrypted data should have a <tt>.dat</tt> extension.
+
+===Newline===
+This specification uses line feed (LF) control character <tt>\n</tt>.
 
 ===Roles===
 ====Coordinator====
@@ -141,7 +144,7 @@ Whereas:
 * Password = "No SPOF"
 * Salt = <tt>TOKEN</tt>
 * c = 2048
-* dkLen = 256
+* dkLen = 256 bits (32 bytes)
 * DKey = Derived <tt>ENCRYPTION_KEY</tt>
 
 ====Encryption Scheme====


### PR DESCRIPTION
* add more recent links to descriptor related BIPs
* explicitly specify LF as newline control character
* explicitly specify unit for `dklen` variable