### PR TITLE
BIP21: Update Address Types

### DIFF
--- a/bip-0021.mediawiki
+++ b/bip-0021.mediawiki
@@ -40,7 +40,7 @@ Elements of the query component may contain characters outside the valid range. 
 (See also [[#Simpler syntax|a simpler representation of syntax]])
 
  bitcoinurn     = "bitcoin:" bitcoinaddress [ "?" bitcoinparams ]
- bitcoinaddress = *base58
+ bitcoinaddress = *base58 / *bech32 / *bech32m
  bitcoinparams  = bitcoinparam [ "&" bitcoinparams ]
  bitcoinparam   = [ amountparam / labelparam / messageparam / otherparam / reqparam ]
  amountparam    = "amount=" *digit [ "." *digit ]


### PR DESCRIPTION
Added bech32 and bech32m address types to reflect the newer SegWit and Taproot addresses.