### PR TITLE
Add note for repository to add new wordlists

### DIFF
--- a/bip-0039/bip-0039-wordlists.md
+++ b/bip-0039/bip-0039-wordlists.md
@@ -1,3 +1,7 @@
+# Important Note
+
+For now, [the author(s) of BIP 39 have decided not to accept any further word lists into BIP 39 itself, and encourage adding new ones to the WLIPs repo](https://github.com/bitcoin/bips/pull/1129#issuecomment-873258377) here: https://github.com/p2w34/wlips
+
 # Wordlists
 
 * [English](english.txt)


### PR DESCRIPTION
Many wordlists were proposed here, but they were closed with the following note:

> For now, [the author(s) of BIP 39 have decided not to accept any further word lists into BIP 39 itself, and encourage adding new ones to the WLIPs repo](https://github.com/bitcoin/bips/pull/1129#issuecomment-873258377) here: https://github.com/p2w34/wlips

I have added the note to the BIP's wiki so that people will know where to open these PRs going forward.