### PR TITLE
Add link to anquii/BIP39 (Swift)

### DIFF
--- a/bip-0039.mediawiki
+++ b/bip-0039.mediawiki
@@ -190,6 +190,7 @@ Swift:
 * https://github.com/matter-labs/web3swift/blob/develop/Sources/web3swift/KeystoreManager/BIP39.swift
 * https://github.com/zcash-hackworks/MnemonicSwift
 * https://github.com/ShenghaiWang/BIP39
+* https://github.com/anquii/BIP39
 
 C++:
 * https://github.com/libbitcoin/libbitcoin-system/blob/master/include/bitcoin/system/wallet/mnemonic.hpp


### PR DESCRIPTION
Updated [bip-0039.mediawiki](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) to include a link to [anquii/BIP39](https://github.com/anquii/BIP39) in the Swift section of implementations.