### PR TITLE
BIP-158: Fix description of M parameter

### DIFF
--- a/bip-0158.mediawiki
+++ b/bip-0158.mediawiki
@@ -85,7 +85,7 @@ one is able to select both Parameters independently, then more optimal values
 can be
 selected<ref>https://gist.github.com/sipa/576d5f09c3b86c3b1b75598d799fc845</ref>.
 Set membership queries against the hash outputs will have a false positive rate
-of <code>M</code>. To avoid integer overflow, the number of items <code>N</code>
+of <code>1 / M</code>. To avoid integer overflow, the number of items <code>N</code>
 MUST be <2^32 and <code>M</code> MUST be <2^32.
 
 The items are first passed through the pseudorandom function ''SipHash'', which
@@ -189,7 +189,7 @@ golomb_decode(stream, P: uint) -> uint64:
 A GCS is constructed from four parameters:
 * <code>L</code>, a vector of <code>N</code> raw items
 * <code>P</code>, the bit parameter of the Golomb-Rice coding
-* <code>M</code>, the target false positive rate
+* <code>M</code>, the inverse of the target false positive rate
 * <code>k</code>, the 128-bit key used to randomize the SipHash outputs
 
 The result is a byte vector with a minimum size of <code>N * (P + 1)</code>


### PR DESCRIPTION
The M parameter is used as the inverse of the false probability rate, so change its incorrect usage in two places.