### PR TITLE
BIP329: Add optional key origin property and expand truncation note

### DIFF
--- a/bip-0329.mediawiki
+++ b/bip-0329.mediawiki
@@ -97,8 +97,8 @@ The reference is defined for each <tt>type</tt> as follows:
 | <tt>xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8Nq...</tt>
 |}
 
-If present, the optional <tt>origin</tt> property must contain key origin information as defined by BIP380<ref>[https://github.com/bitcoin/bips/blob/master/bip-0380.mediawiki BIP-0380]</ref>, without the opening or closing brackets.
-This property should be used to disambiguate labels from different wallets contained in the same export, particularly when exporting multiple accounts derived from the same seed.
+If present, the optional <tt>origin</tt> property must contain an abbreviated output descriptor (as defined by BIP380<ref>[https://github.com/bitcoin/bips/blob/master/bip-0380.mediawiki BIP-0380]</ref>) describing a BIP32 compatible originating wallet, including all key origin information but excluding any actual keys, any child path elements, or a checksum.
+This property should be used to disambiguate transaction labels from different wallets contained in the same export, particularly when exporting multiple accounts derived from the same seed.
 
 Care should be taken when exporting due to the privacy sensitive nature of the data. 
 Encryption in transit over untrusted networks is highly recommended, and encryption at rest should also be considered.
@@ -120,12 +120,13 @@ However, importing wallets complying to this specification may ignore types not 
 
 The following fragment represents a wallet label export:
 <pre>
-{ "type": "tx", "ref": "f91d0a8a78462bc59398f2c5d7a84fcff491c26ba54c4833478b202796c8aafd", "label": "Transaction", "origin": "d34db33f/84'/0'/0'" }
+{ "type": "tx", "ref": "f91d0a8a78462bc59398f2c5d7a84fcff491c26ba54c4833478b202796c8aafd", "label": "Transaction", "origin": "wpkh([d34db33f/84'/0'/0'])" }
 { "type": "addr", "ref": "bc1q34aq5drpuwy3wgl9lhup9892qp6svr8ldzyy7c", "label": "Address" }
 { "type": "pubkey", "ref": "0283409659355b6d1cc3c32decd5d561abaac86c37a353b52895a5e6c196d6f448", "label": "Public Key" }
 { "type": "input", "ref": "f91d0a8a78462bc59398f2c5d7a84fcff491c26ba54c4833478b202796c8aafd:0", "label": "Input" }
 { "type": "output", "ref": "f91d0a8a78462bc59398f2c5d7a84fcff491c26ba54c4833478b202796c8aafd:1", "label": "Output" }
 { "type": "xpub", "ref": "xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8", "label": "Extended Public Key" }
+{ "type": "tx", "ref": "f546156d9044844e02b181026a1a407abfca62e7ea1159f87bbeaa77b4286c74", "label": "Account #1 Transaction", "origin": "wpkh([d34db33f/84'/0'/1'])" }
 </pre>
 
 ==Reference Implementation==

--- a/bip-0329.mediawiki
+++ b/bip-0329.mediawiki
@@ -44,7 +44,7 @@ It is also a convenient format for command-line processing, which is often line-
 
 Further to the JSON Lines specification, an export of labels from a wallet must be a UTF-8 encoded text file, containing one record per line consisting of a valid JSON object.
 Lines are separated by <tt>\n</tt>. Multiline values are not permitted.
-Each JSON object must contain 3 key/value pairs, defined as follows:
+Each JSON object must contain 3 or 4 key/value pairs, defined as follows:
 
 {| class="wikitable" 
 |-
@@ -59,6 +59,9 @@ Each JSON object must contain 3 key/value pairs, defined as follows:
 |-
 | <tt>label</tt>
 | The label applied to the reference
+|-
+| <tt>origin</tt>
+| Optional key origin information referencing the wallet associated with the label
 |}
 
 The reference is defined for each <tt>type</tt> as follows:
@@ -94,6 +97,9 @@ The reference is defined for each <tt>type</tt> as follows:
 | <tt>xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8Nq...</tt>
 |}
 
+If present, the optional <tt>origin</tt> property must contain key origin information as defined by BIP380<ref>[https://github.com/bitcoin/bips/blob/master/bip-0380.mediawiki BIP-0380]</ref>, without the opening or closing brackets.
+This property should be used to disambiguate labels from different wallets contained in the same export, particularly when exporting multiple accounts derived from the same seed.
+
 Care should be taken when exporting due to the privacy sensitive nature of the data. 
 Encryption in transit over untrusted networks is highly recommended, and encryption at rest should also be considered.
 Unencrypted exports should be deleted as soon as possible.
@@ -101,7 +107,7 @@ For security reasons no private key types are defined.
 
 ==Importing==
 
-* An importing wallet may ignore records it does not store, and truncate labels if necessary.
+* An importing wallet may ignore records it does not store, and truncate labels if necessary. A suggested default for maximum label length is 255 characters, and an importing wallet should consider warning the user if truncation is applied.
 * Wallets importing public key records may derive addresses from them to match against known wallet addresses.
 * Wallets importing extended public keys may match them against signers, for example in a multisig setup.
 
@@ -114,7 +120,7 @@ However, importing wallets complying to this specification may ignore types not 
 
 The following fragment represents a wallet label export:
 <pre>
-{ "type": "tx", "ref": "f91d0a8a78462bc59398f2c5d7a84fcff491c26ba54c4833478b202796c8aafd", "label": "Transaction" }
+{ "type": "tx", "ref": "f91d0a8a78462bc59398f2c5d7a84fcff491c26ba54c4833478b202796c8aafd", "label": "Transaction", "origin": "d34db33f/84'/0'/0'" }
 { "type": "addr", "ref": "bc1q34aq5drpuwy3wgl9lhup9892qp6svr8ldzyy7c", "label": "Address" }
 { "type": "pubkey", "ref": "0283409659355b6d1cc3c32decd5d561abaac86c37a353b52895a5e6c196d6f448", "label": "Public Key" }
 { "type": "input", "ref": "f91d0a8a78462bc59398f2c5d7a84fcff491c26ba54c4833478b202796c8aafd:0", "label": "Input" }


### PR DESCRIPTION
Based on feedback received after BIP329 was initially published, this adds the following:
- An optional `origin` property containing key origin information which can be used to to disambiguate labels from different wallets contained in the same export
- A note on warning users if truncation is applied, along with a suggested maximum label length