### PR TITLE
380: Clarify optionality of descriptor checksum

### DIFF
--- a/bip-0380.mediawiki
+++ b/bip-0380.mediawiki
@@ -49,6 +49,7 @@ Lastly, the use of common terminology and existing standards allow for Output Sc
 Descriptors consist of several types of expressions.
 The top level expression is a <tt>SCRIPT</tt>.
 This expression may be followed by <tt>#CHECKSUM</tt>, where <tt>CHECKSUM</tt> is an 8 character alphanumeric descriptor checksum.
+Although the checksum is optional for parsing, applications may choose to reject descriptors that do not contain a checksum.
 
 ===Script Expressions===
 


### PR DESCRIPTION
Parsers must handle checksum optionality, but applications can choose to reject descriptors that don't have a checksum.