### PR TITLE
Update PSBT_IN_TAP_BIP32_DERIVATION key desc

### DIFF
--- a/bip-0174.mediawiki
+++ b/bip-0174.mediawiki
@@ -453,7 +453,7 @@ The currently defined per-input types are defined as follows:
 | Taproot Key BIP 32 Derivation Path
 | <tt>PSBT_IN_TAP_BIP32_DERIVATION = 0x16</tt>
 | <tt><32 byte xonlypubkey></tt>
-| A 32 byte X-only public key involved in this input. It may be the internal key, or a key present in a leaf script.
+| A 32 byte X-only public key involved in this input. It may be the output key, the internal key, or a key present in a leaf script.
 | <tt><compact size uint number of hashes> <32 byte leaf hash>* <4 byte fingerprint> <32-bit little endian uint path element>*</tt>
 | A compact size unsigned integer representing the number of leaf hashes, followed by a list of leaf hashes, followed by the 4 byte master key fingerprint concatenated with the derivation path of the public key. The derivation path is represented as 32-bit little endian unsigned integer indexes concatenated with each other. Public keys are those needed to spend this output. The leaf hashes are of the leaves which involve this public key. The internal key does not have leaf hashes, so can be indicated with a <tt>hashes len</tt> of 0. Finalizers should remove this field after <tt>PSBT_IN_FINAL_SCRIPTWITNESS</tt> is constructed.
 |
@@ -591,7 +591,7 @@ determine which outputs are change outputs and verify that the change is returni
 | Taproot Key BIP 32 Derivation Path
 | <tt>PSBT_OUT_TAP_BIP32_DERIVATION = 0x07</tt>
 | <tt><32 byte xonlypubkey></tt>
-| A 32 byte X-only public key involved in this output. It may be the internal key, or a key present in a leaf script.
+| A 32 byte X-only public key involved in this output. It may be the output key, the internal key, or a key present in a leaf script.
 | <tt><compact size uint number of hashes> <32 byte leaf hash>* <4 byte fingerprint> <32-bit little endian uint path element>*</tt>
 | A compact size unsigned integer representing the number of leaf hashes, followed by a list of leaf hashes, followed by the 4 byte master key fingerprint concatenated with the derivation path of the public key. The derivation path is represented as 32-bit little endian unsigned integer indexes concatenated with each other. Public keys are those needed to spend this output. The leaf hashes are of the leaves which involve this public key. The internal key does not have leaf hashes, so can be indicated with a <tt>hashes len</tt> of 0. Finalizers should remove this field after <tt>PSBT_IN_FINAL_SCRIPTWITNESS</tt> is constructed.
 |

--- a/bip-0371.mediawiki
+++ b/bip-0371.mediawiki
@@ -78,7 +78,7 @@ The new per-input types are defined as follows:
 | Taproot Key BIP 32 Derivation Path
 | <tt>PSBT_IN_TAP_BIP32_DERIVATION = 0x16</tt>
 | <tt><32 byte xonlypubkey></tt>
-| A 32 byte X-only public key involved in this input. It may be the internal key, or a key present in a leaf script.
+| A 32 byte X-only public key involved in this input. It may be the output key, the internal key, or a key present in a leaf script.
 | <tt><compact size uint number of hashes> <32 byte leaf hash>* <4 byte fingerprint> <32-bit little endian uint path element>*</tt>
 | A compact size unsigned integer representing the number of leaf hashes, followed by a list of leaf hashes, followed by the 4 byte master key fingerprint concatenated with the derivation path of the public key. The derivation path is represented as 32-bit little endian unsigned integer indexes concatenated with each other. Public keys are those needed to spend this output. The leaf hashes are of the leaves which involve this public key. The internal key does not have leaf hashes, so can be indicated with a <tt>hashes len</tt> of 0. Finalizers should remove this field after <tt>PSBT_IN_FINAL_SCRIPTWITNESS</tt> is constructed.
 |
@@ -142,7 +142,7 @@ The new per-output types are defined as follows:
 | Taproot Key BIP 32 Derivation Path
 | <tt>PSBT_OUT_TAP_BIP32_DERIVATION = 0x07</tt>
 | <tt><32 byte xonlypubkey></tt>
-| A 32 byte X-only public key involved in this output. It may be the internal key, or a key present in a leaf script.
+| A 32 byte X-only public key involved in this output. It may be the output key, the internal key, or a key present in a leaf script.
 | <tt><compact size uint number of hashes> <32 byte leaf hash>* <4 byte fingerprint> <32-bit little endian uint path element>*</tt>
 | A compact size unsigned integer representing the number of leaf hashes, followed by a list of leaf hashes, followed by the 4 byte master key fingerprint concatenated with the derivation path of the public key. The derivation path is represented as 32-bit little endian unsigned integer indexes concatenated with each other. Public keys are those needed to spend this output. The leaf hashes are of the leaves which involve this public key. The internal key does not have leaf hashes, so can be indicated with a <tt>hashes len</tt> of 0. Finalizers should remove this field after <tt>PSBT_IN_FINAL_SCRIPTWITNESS</tt> is constructed.
 |


### PR DESCRIPTION
Clarify intended usage of PSBT_IN_TAP_BIP32_DERIVATION for key-spends.