### PR TITLE
Mark Taproot BIPs as Final

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1028,21 +1028,21 @@ Those proposing changes should consider that ultimately consent may rest with th
 | Schnorr Signatures for secp256k1
 | Pieter Wuille, Jonas Nick, Tim Ruffing
 | Standard
-| Draft
+| Final
 |-
 | [[bip-0341.mediawiki|341]]
 | Consensus (soft fork)
 | Taproot: SegWit version 1 spending rules
 | Pieter Wuille, Jonas Nick, Anthony Towns
 | Standard
-| Draft
+| Final
 |-
 | [[bip-0342.mediawiki|342]]
 | Consensus (soft fork)
 | Validation of Taproot Scripts
 | Pieter Wuille, Jonas Nick, Anthony Towns
 | Standard
-| Draft
+| Final
 |- style="background-color: #ffffcf"
 | [[bip-0343.mediawiki|343]]
 | Consensus (soft fork)

--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1049,7 +1049,7 @@ Those proposing changes should consider that ultimately consent may rest with th
 | Mandatory activation of taproot deployment
 | Shinobius, Michael Folkson
 | Standard
-| Proposed
+| Final
 |-
 | [[bip-0350.mediawiki|350]]
 | Applications

--- a/bip-0340.mediawiki
+++ b/bip-0340.mediawiki
@@ -6,7 +6,7 @@
           Tim Ruffing <crypto@timruffing.de>
   Comments-Summary: No comments yet.
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0340
-  Status: Draft
+  Status: Final
   Type: Standards Track
   License: BSD-2-Clause
   Created: 2020-01-19

--- a/bip-0341.mediawiki
+++ b/bip-0341.mediawiki
@@ -7,7 +7,7 @@
           Anthony Towns <aj@erisian.com.au>
   Comments-Summary: No comments yet.
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0341
-  Status: Draft
+  Status: Final
   Type: Standards Track
   Created: 2020-01-19
   License: BSD-3-Clause

--- a/bip-0342.mediawiki
+++ b/bip-0342.mediawiki
@@ -7,7 +7,7 @@
           Anthony Towns <aj@erisian.com.au>
   Comments-Summary: No comments yet.
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0342
-  Status: Draft
+  Status: Final
   Type: Standards Track
   Created: 2020-01-19
   License: BSD-3-Clause

--- a/bip-0343.mediawiki
+++ b/bip-0343.mediawiki
@@ -6,7 +6,7 @@
           Michael Folkson <michaelfolkson@gmail.com>
   Comments-Summary: No comments yet.
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0343
-  Status: Proposed
+  Status: Final
   Type: Standards Track
   Created: 2021-04-25
   License: BSD-3-Clause


### PR DESCRIPTION
Taproot is supported by Bitcoin Core and adopted by a majority of the network, so it should be marked as Final. The progression from Draft to Proposed and from Proposed to Final was likely forgotten.