### PR TITLE
Update bip-0370.mediawiki

### DIFF
--- a/bip-0370.mediawiki
+++ b/bip-0370.mediawiki
@@ -288,7 +288,7 @@ The Extractor should produce a fully valid, network serialized transaction if al
 
 ==Backwards Compatibility==
 
-PSBTv2 shares the same gemeric format as PSBTv0 as defined in BIP 174. Parsers for PSBTv0 should
+PSBTv2 shares the same generic format as PSBTv0 as defined in BIP 174. Parsers for PSBTv0 should
 be able to deserialize PSBTv2 with only changes to support the new fields.
 
 However PSBTv2 is incompatible with PSBTv0, and vice versa due to the use of the PSBT_GLOBAL_VERSION.


### PR DESCRIPTION
Small typo. Changed 'gemeric' to 'generic'.