### PR TITLE
PSBTv0: Update Simple Signer Algorithm for SegWitv0 inputs

### DIFF
--- a/bip-0174.mediawiki
+++ b/bip-0174.mediawiki
@@ -718,15 +718,8 @@ sign_non_witness(script_code, i):
         if IsMine(key) and IsAcceptable(sighash_type):
             sign(non_witness_sighash(script_code, i, input))
 
-for input,i in enumerate(psbt.inputs):
-    if non_witness_utxo.exists:
-        assert(sha256d(non_witness_utxo) == psbt.tx.input[i].prevout.hash)
-        if redeemScript.exists:
-            assert(non_witness_utxo.vout[psbt.tx.input[i].prevout.n].scriptPubKey == P2SH(redeemScript))
-            sign_non_witness(redeemScript, i)
-        else:
-            sign_non_witness(non_witness_utxo.vout[psbt.tx.input[i].prevout.n].scriptPubKey, i)
-    else if witness_utxo.exists:
+for input, i in enumerate(psbt.inputs):
+    if witness_utxo.exists:
         if redeemScript.exists:
             assert(witness_utxo.scriptPubKey == P2SH(redeemScript))
             script = redeemScript
@@ -737,6 +730,13 @@ for input,i in enumerate(psbt.inputs):
         else if IsP2WSH(script):
             assert(script == P2WSH(witnessScript))
             sign_witness(witnessScript, i)
+    else if non_witness_utxo.exists:
+        assert(sha256d(non_witness_utxo) == psbt.tx.input[i].prevout.hash)
+        if redeemScript.exists:
+            assert(non_witness_utxo.vout[psbt.tx.input[i].prevout.n].scriptPubKey == P2SH(redeemScript))
+            sign_non_witness(redeemScript, i)
+        else:
+            sign_non_witness(non_witness_utxo.vout[psbt.tx.input[i].prevout.n].scriptPubKey, i)
     else:
         assert False
 </pre>


### PR DESCRIPTION
The Simple Signer Algorithm is not updated to the fact that SegWitv0 inputs are now typically expected to have both the non-witness-utxo and the witness-utxo field (instead of the ealier requirement of omitting the non-witness-utxo).

By reverting the order of the checks, it is at least semantically correct.

Possible TODOs for followups:

- Update for segwitv1 signing
- Recommend checking the non-witness-utxo for segwitv0 inputs.