### PR TITLE
PSBTv2: Relax transaction version requirement

### DIFF
--- a/bip-0370.mediawiki
+++ b/bip-0370.mediawiki
@@ -235,9 +235,9 @@ PSBTv2 introduces new roles and modifies some existing roles.
 ===Creator===
 
 In PSBTv2, the Creator initializes the PSBT with 0 inputs and 0 outputs.
-The PSBT version number is set to 2. The transaction version number must be set to at least 2. <ref>'''Why does the transaction version number need to be at least 2?''' The transaction version number is part of the validation rules for some features such as OP_CHECKSEQUENCEVERIFY. Since it is backwards compatible, and there are other ways to disable those features (e.g. through sequence numbers), it is easier to require transactions be able to support these features than to try to negotiate the transaction version number.</ref>
+The PSBT version number is set to 2.
 The Creator should also set PSBT_GLOBAL_FALLBACK_LOCKTIME.
-If the Creator is not also a Constructor and will be giving the PSBT to others to add inputs and outputs, the PSBT_GLOBAL_TX_MODIFIABLE field must be present and and the Inputs Modifiable and Outputs Modifiable flags set appropriately.
+If the Creator is not also a Constructor and will be giving the PSBT to others to add inputs and outputs, the PSBT_GLOBAL_TX_MODIFIABLE field must be present and the Inputs Modifiable and Outputs Modifiable flags set appropriately; moreover, the transaction version number must be set to at least 2. <ref>'''Why does the transaction version number need to be at least 2?''' The transaction version number is part of the validation rules for some features such as OP_CHECKSEQUENCEVERIFY. Since it is backwards compatible, and there are other ways to disable those features (e.g. through sequence numbers), it is easier to require transactions be able to support these features than to try to negotiate the transaction version number.</ref>
 If the Creator is a Constructor and no inputs and outputs will be added by other entities, PSBT_GLOBAL_TX_MODIFIABLE may be omitted.
 
 ===Constructor===


### PR DESCRIPTION
PSBTs with transaction version number less than 2 are valid for PSBTv0; therefore, mandating transaction version number 2 in a PSBTv2 implementation would create the situation where some valid PSBTv0 can't be converted to PSBTv2.

By only mandating the transaction version to be at least 2 when the transaction is modifiable (that is, when Creator and Constructor roles are distinct), the issue is avoided.

(h/t to @bucko13 for spotting the issue)