### PR TITLE
bip-0324: remove `initiating` parameter from `ellswift_create` calls

### DIFF
--- a/bip-0324.mediawiki
+++ b/bip-0324.mediawiki
@@ -181,11 +181,11 @@ As explained before, these messages are sent to set up the connection:
  ----------------------------------------------------------------------------------------------------
  | Initiator                         Responder                                                      |
  |                                                                                                  |
- | x, ellswift_X = ellswift_create(initiating=True)                                                 |
+ | x, ellswift_X = ellswift_create()                                                                |
  |                                                                                                  |
  |           --- ellswift_X + initiator_garbage (initiator_garbage_len bytes; max 4095) --->        |
  |                                                                                                  |
- |                                   y, ellswift_Y = ellswift_create(initiating=False)              |
+ |                                   y, ellswift_Y = ellswift_create()                              |
  |                                   ecdh_secret = v2_ecdh(                                         |
  |                                                     y, ellswift_X, ellswift_Y, initiating=False) |
  |                                   v2_initialize(initiator, ecdh_secret, initiating=False)        |
@@ -333,7 +333,7 @@ To establish a v2 encrypted connection, the initiator generates an ephemeral sec
 
 <pre>
 def initiate_v2_handshake(peer, garbage_len):
-    peer.privkey_ours, peer.ellswift_ours = ellswift_create(initiating=True)
+    peer.privkey_ours, peer.ellswift_ours = ellswift_create()
     peer.sent_garbage = rand_bytes(garbage_len)
     send(peer, peer.ellswift_ours + peer.sent_garbage)
 </pre>
@@ -350,7 +350,7 @@ def respond_v2_handshake(peer, garbage_len):
     while len(peer.received_prefix) < 12:
         peer.received_prefix += receive(peer, 1)
         if peer.received_prefix[-1] != V1_PREFIX[len(peer.received_prefix) - 1]:
-            peer.privkey_ours, peer.ellswift_ours = ellswift_create(initiating=False)
+            peer.privkey_ours, peer.ellswift_ours = ellswift_create()
             peer.sent_garbage = rand_bytes(garbage_len)
             send(peer, ellswift_Y + peer.sent_garbage)
             return


### PR DESCRIPTION
The keypair generating pseudocode function `ellswift_create` doesn't take a `initiating` (or any other) parameter, i.e. it should be removed from the call-sites (one could think that keypairs are in some generated differently depending on initiator/responder role, which isn't the case).

