### PR TITLE
Mark BIP84 as Final

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -440,7 +440,7 @@ Those proposing changes should consider that ultimately consent may rest with th
 | Derivation scheme for P2WPKH based accounts
 | Pavol Rusnak
 | Informational
-| Draft
+| Final
 |-
 | [[bip-0085.mediawiki|85]]
 | Applications

--- a/bip-0084.mediawiki
+++ b/bip-0084.mediawiki
@@ -5,7 +5,7 @@
   Author: Pavol Rusnak <stick@satoshilabs.com>
   Comments-Summary: No comments yet.
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0084
-  Status: Draft
+  Status: Final
   Type: Informational
   Created: 2017-12-28
   License: CC0-1.0


### PR DESCRIPTION
Revisiting #1053, as this is now implemented by multiple software wallets and most hardware wallets (source: https://walletsrecovery.org).

@prusnak: You mentioned you didn't want to move this to Final as you'd like to expand it with Taproot handling, but I suppose that was abandoned in favor of BIP86?