### PR TITLE
BIP-48 - define P2SH, P2TR derivation paths

### DIFF
--- a/bip-0048.mediawiki
+++ b/bip-0048.mediawiki
@@ -103,7 +103,10 @@ This level splits the key space into two separate <code>script_type</code>(s). T
 forward compatibility for future script types this specification can be easily extended.
 
 Currently the only script types covered by this BIP are Native Segwit (p2wsh) and
-Nested Segwit (p2sh-p2wsh).
+Nested Segwit (p2sh-p2wsh) and Script Hash (p2sh).
+
+The following path represents Script Hash (p2sh) mainnet, account 0:
+<code>0'</code>: Script Hash (p2sh) <code>m/48'/0'/0'/0'</code></br>
 
 The following path represents Nested Segwit (p2sh-p2wsh) mainnet, account 0:
 <code>1'</code>: Nested Segwit (p2sh-p2wsh) <code>m/48'/0'/0'/1'</code></br>
@@ -184,6 +187,13 @@ Public derivation is used at this level.
 |external
 |second
 |m / 48' / 0' / 1' / 2' / 0 / 1
+|-
+|testnet
+|first
+|p2sh
+|external
+|first
+|m / 48' / 1' / 0' / 0' / 0 / 0
 |-
 |testnet
 |first

--- a/bip-0048.mediawiki
+++ b/bip-0048.mediawiki
@@ -102,8 +102,8 @@ Hardened derivation is used at this level.
 This level splits the key space into two separate <code>script_type</code>(s). To provide
 forward compatibility for future script types this specification can be easily extended.
 
-Currently the only script types covered by this BIP are Native Segwit (p2wsh) and
-Nested Segwit (p2sh-p2wsh) and Script Hash (p2sh).
+Currently the script types covered by this BIP are Native Segwit (p2wsh),
+Nested Segwit (p2sh-p2wsh), Script Hash (p2sh) and Taproot (p2tr).
 
 The following path represents Script Hash (p2sh) mainnet, account 0:
 <code>0'</code>: Script Hash (p2sh) <code>m/48'/0'/0'/0'</code></br>
@@ -113,6 +113,9 @@ The following path represents Nested Segwit (p2sh-p2wsh) mainnet, account 0:
 
 The following path represents Native Segwit (p2wsh) mainnet, account 0:
 <code>2'</code>: Native Segwit (p2wsh) <code>m/48'/0'/0'/2'</code></br>
+
+The following path represents Taproot (p2tr) mainnet, account 0:
+<code>0'</code>: Taproot (p2tr) <code>m/48'/0'/0'/3'</code></br>
 
 The recommended default for wallets is pay to witness script hash <code>m/48'/0'/0'/2'</code>.
 
@@ -201,6 +204,13 @@ Public derivation is used at this level.
 |external
 |first
 |m / 48' / 1' / 0' / 1' / 0 / 0
+|-
+|testnet
+|first
+|p2tr
+|external
+|first
+|m / 48' / 1' / 0' / 3' / 0 / 0
 |-
 |testnet
 |first

--- a/bip-0048.mediawiki
+++ b/bip-0048.mediawiki
@@ -115,7 +115,7 @@ The following path represents Native Segwit (p2wsh) mainnet, account 0:
 <code>2'</code>: Native Segwit (p2wsh) <code>m/48'/0'/0'/2'</code></br>
 
 The following path represents Taproot (p2tr) mainnet, account 0:
-<code>0'</code>: Taproot (p2tr) <code>m/48'/0'/0'/3'</code></br>
+<code>3'</code>: Taproot (p2tr) <code>m/48'/0'/0'/3'</code></br>
 
 The recommended default for wallets is pay to witness script hash <code>m/48'/0'/0'/2'</code>.
 


### PR DESCRIPTION
It would be useful to add P2SH script type derivation path to BIP-48 to further extend this standard.
Since BIP-48 can be expanded to altchains following SLIP-44 coin_type, this would be very helpful standard for blockchains that do not yet support Segwit or Bitcoin wallets that want to use more adopted standard of BIP-48 rather than older disappearing BIP-45 but want to also offer older P2SH address type.