### PR TITLE
bip-324: fix FSChaCha20 type error

### DIFF
--- a/bip-0324.mediawiki
+++ b/bip-0324.mediawiki
@@ -483,7 +483,7 @@ def v2_enc_packet(peer, contents, aad=b'', ignore=False):
     header = (ignore << IGNORE_BIT_POS).to_bytes(HEADER_LEN, 'little')
     plaintext = header + contents
     aead_ciphertext = peer.send_P.encrypt(aad, plaintext)
-    enc_contents_len = peer.send_L.encrypt(len(contents).to_bytes(LENGTH_FIELD_LEN, 'little'))
+    enc_contents_len = peer.send_L.crypt(len(contents).to_bytes(LENGTH_FIELD_LEN, 'little'))
     return enc_contents_len + aead_ciphertext
 </pre>
 


### PR DESCRIPTION
The FSChaCha20 class, as written in the BIP's pseudocode, doesn't have an encrypt() method (even though the equivalent class in `bip-0324/reference.py` does), so use crypt() to be clear that we're not using FSChaCha20Poly1305 for `peer.send_L`.