### PR TITLE
Removed link and reference to SLIP-0173

### DIFF
--- a/bip-0173.mediawiki
+++ b/bip-0173.mediawiki
@@ -262,12 +262,6 @@ P2PKH addresses can be used.
 * Fancy decoder that localizes errors:
 ** [https://github.com/sipa/bech32/tree/master/ecc/javascript For JavaScript] ([http://bitcoin.sipa.be/bech32/demo/demo.html demo website])
 
-==Registered Human-readable Prefixes==
-
-SatoshiLabs maintains a full list of registered human-readable parts for other cryptocurrencies:
-
-[https://github.com/satoshilabs/slips/blob/master/slip-0173.md SLIP-0173 : Registered human-readable parts for BIP-0173]
-
 ==Appendices==
 
 ===Test vectors===


### PR DESCRIPTION
SLIP-0173 is not relevant to BIP173 due to not containing any additional information about bitcoin.