### PR TITLE
Add James O'Beirne to 119 Author List

### DIFF
--- a/bip-0119.mediawiki
+++ b/bip-0119.mediawiki
@@ -3,6 +3,7 @@
   Layer: Consensus (soft fork)
   Title: CHECKTEMPLATEVERIFY
   Author: Jeremy Rubin <j@rubin.io>
+          James O'Beirne <vaults@au92.org>
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0119
   Status: Draft
   Type: Standards Track


### PR DESCRIPTION
I'd like to propose that James O'Beirne be added as an author to BIP-119. James has done extensive research on covenants, including 119, and is actively involved in Bitcoin Development. Since I am no longer actively involved in Development, adding James as an author will give the the BIP an active steward for any changes required going forward.