### PR TITLE
added colon at end of if statement - bip-0119.mediawiki

### DIFF
--- a/bip-0119.mediawiki
+++ b/bip-0119.mediawiki
@@ -88,7 +88,7 @@ def execute_bip_119(self):
             self.context.precomputed_ctv_data = self.context.tx.get_default_check_template_precomputed_data()
 
         # If the hashes do not match, return error
-        if stack[-1] != self.context.tx.get_default_check_template_hash(self.context.nIn, self.context.precomputed_ctv_data)
+        if stack[-1] != self.context.tx.get_default_check_template_hash(self.context.nIn, self.context.precomputed_ctv_data):
             return self.errors_with(errors.script_err_template_mismatch)
 
         return self.return_as_nop()


### PR DESCRIPTION
Python requires a colon at the end of an if statement to denote the beginning of the block of code that will be executed if the condition is True. If the colon is omitted, a syntax error will occur, and the code will not run. Since the syntax error will prevent the code from running, it won't introduce any vulnerabilities by itself. However, it will cause the application to fail at the point where the code is parsed, which might expose other issues if error handling is not implemented properly.