### PR TITLE
bip-0158: remove unused and unrelated "data pushes" definition

### DIFF
--- a/bip-0158.mediawiki
+++ b/bip-0158.mediawiki
@@ -39,9 +39,6 @@ that is designed to reduce the filter size for regular wallets.
 ''CompactSize'' is a compact encoding of unsigned integers used in the Bitcoin
 P2P protocol.
 
-''Data pushes'' are byte vectors pushed to the stack according to the rules of
-Bitcoin script.
-
 ''Bit streams'' are readable and writable streams of individual bits. The
 following functions are used in the pseudocode in this document:
 * <code>new_bit_stream</code> instantiates a new writable bit stream


### PR DESCRIPTION
This BIP is not in any way connected to the rules of Bitcoin script, i.e. the "data pushes" term is also not used anywhere and its definition can hence be removed.