### PR TITLE
Adds license to bip-0039.mediawiki

### DIFF
--- a/bip-0039.mediawiki
+++ b/bip-0039.mediawiki
@@ -11,6 +11,7 @@
   Status: Proposed
   Type: Standards Track
   Created: 2013-09-10
+  License: CC0-1.0
 </pre>
 
 ==Abstract==
@@ -204,3 +205,7 @@ Python:
 
 Dart:
 * https://github.com/dart-bitcoin/bip39
+
+==Copyright==
+
+This document and associated word lists are licensed under Creative Commons CC0 1.0 Universal.


### PR DESCRIPTION
I noticed that BIP-0039 does not specify a license. 

This PR adds a [CC0 1.0 license](https://creativecommons.org/share-your-work/public-domain/cc0/) to BIP-0039. I think CC0 is appropriate in this case, given that there is no code in this BIP. But I'm not an expert. 

I think, as a matter of practicality, the word lists should also be covered by this CC0 license as well. I've attempted to explain that in my edit, though I am not a lawyer and welcome edits/suggestions. 