### PR TITLE
Add: Python-BIP38 package on Other Implementation

### DIFF
--- a/bip-0038.mediawiki
+++ b/bip-0038.mediawiki
@@ -216,6 +216,7 @@ Click "Tools" then "PPEC Keygen" (provisional name)
 
 ==Other implementations==
 * Javascript - https://github.com/bitcoinjs/bip38
+* Python - https://github.com/meherett/python-bip38
 
 ==Test vectors==
 


### PR DESCRIPTION
It supports both `No EC-multiply` and `EC-multiply` modes.