### PR TITLE
bip 2: allow markdown

### DIFF
--- a/bip-0002.mediawiki
+++ b/bip-0002.mediawiki
@@ -102,7 +102,7 @@ The BIP editors are intended to fulfill administrative and editorial responsibil
 
 ===Specification===
 
-BIPs should be written in mediawiki format.
+BIPs should be written in mediawiki or markdown format.
 
 Each BIP should have the following parts:
 


### PR DESCRIPTION
BIP authors should be allowed to write their BIPs in Markdown. The MediaWiki syntax that GitHub uses appears to be entirely undocumented (it does not always match mediawiki's documentation) which makes writing complex BIPs rather difficult. Markdown is much simpler and more concise.