### PR TITLE
BIP327: reduce nonces robustly to avoid failure condition

### DIFF
--- a/bip-0327.mediawiki
+++ b/bip-0327.mediawiki
@@ -384,7 +384,8 @@ Algorithm ''NonceGen(sk, pk, aggpk, m, extra_in)'':
 ** Let ''m_prefixed = bytes(1, 1) || bytes(8, len(m)) || m''
 * If the optional argument ''extra_in'' is not present:
 ** Let ''extra_in = empty_bytestring''
-* Let ''k<sub>i</sub> = int(hash<sub>MuSig/nonce</sub>(rand || bytes(1, len(pk)) || pk || bytes(1, len(aggpk)) || aggpk || m_prefixed || bytes(4, len(extra_in)) || extra_in || bytes(1, i - 1))) mod n'' for ''i = 1,2''
+* Let ''k<sub>i</sub>' = int(hash<sub>MuSig/nonce</sub>(rand || bytes(1, len(pk)) || pk || bytes(1, len(aggpk)) || aggpk || m_prefixed || bytes(4, len(extra_in)) || extra_in || bytes(1, i - 1)))'' for ''i = 1,2''
+* Let ''k<sub>i</sub> = k<sub>i</sub>' mod (n-1) + 1'' <ref>Reducing the nonces mod ''n - 1'' and incrementing them ensures they are always valid non-zero scalars.</ref>
 * Fail if ''k<sub>1</sub> = 0'' or ''k<sub>2</sub> = 0''
 * Let ''R<sub>⁎,1</sub> = k<sub>1</sub>⋅G, R<sub>⁎,2</sub> = k<sub>2</sub>⋅G''
 * Let ''pubnonce = cbytes(R<sub>⁎,1</sub>) || cbytes(R<sub>⁎,2</sub>)''


### PR DESCRIPTION
Affects the draft [BIP 0327](https://github.com/bitcoin/bips/blob/master/bip-0327.mediawiki).

This is not ready for merging yet; we would still need to update the reference implementation and test vectors to match. I'm opening this PR as a suggestion to get consensus before going to such effort. 

The secret nonces $k_1$ and $k_2$ are currently generated by reducing $H(...) \mod n$ and failing if the result is zero. 

We could instead reduce them to a non-zero scalar in $[1, n)$ every time by reducing mod $n-1$ and incrementing. 