### PR TITLE
Remove two BIP32 vectors

### DIFF
--- a/bip-0032.mediawiki
+++ b/bip-0032.mediawiki
@@ -5,6 +5,7 @@ RECENT CHANGES:
 * (15 Jan 2014) Rename keys with index ≥ 0x80000000 to hardened keys, and add explicit conversion functions.
 * (24 Feb 2017) Added test vectors for hardened derivation with leading zeros
 * (4 Nov 2020) Added new test vectors for hardened derivation with leading zeros
+* (17 Nov 2023) Remove test vectors that imply a limited set of valid versions
 
 <pre>
   BIP: 32
@@ -302,8 +303,6 @@ These vectors test that invalid extended keys are recognized as invalid.
 * xpub661no6RGEX3uJkY4bNnPcw4URcQTrSibUZ4NqJEw5eBkv7ovTwgiT91XX27VbEXGENhYRCf7hyEbWrR3FewATdCEebj6znwMfQkhRYHRLpJ (zero depth with non-zero parent fingerprint)
 * xprv9s21ZrQH4r4TsiLvyLXqM9P7k1K3EYhA1kkD6xuquB5i39AU8KF42acDyL3qsDbU9NmZn6MsGSUYZEsuoePmjzsB3eFKSUEh3Gu1N3cqVUN (zero depth with non-zero index)
 * xpub661MyMwAuDcm6CRQ5N4qiHKrJ39Xe1R1NyfouMKTTWcguwVcfrZJaNvhpebzGerh7gucBvzEQWRugZDuDXjNDRmXzSZe4c7mnTK97pTvGS8 (zero depth with non-zero index)
-* DMwo58pR1QLEFihHiXPVykYB6fJmsTeHvyTp7hRThAtCX8CvYzgPcn8XnmdfHGMQzT7ayAmfo4z3gY5KfbrZWZ6St24UVf2Qgo6oujFktLHdHY4 (unknown extended key version)
-* DMwo58pR1QLEFihHiXPVykYB6fJmsTeHvyTp7hRThAtCX8CvYzgPcn8XnmdfHPmHJiEDXkTiJTVV9rHEBUem2mwVbbNfvT2MTcAqj3nesx8uBf9 (unknown extended key version)
 * xprv9s21ZrQH143K24Mfq5zL5MhWK9hUhhGbd45hLXo2Pq2oqzMMo63oStZzF93Y5wvzdUayhgkkFoicQZcP3y52uPPxFnfoLZB21Teqt1VvEHx (private key 0 not in 1..n-1)
 * xprv9s21ZrQH143K24Mfq5zL5MhWK9hUhhGbd45hLXo2Pq2oqzMMo63oStZzFAzHGBP2UuGCqWLTAPLcMtD5SDKr24z3aiUvKr9bJpdrcLg1y3G (private key n not in 1..n-1)
 * xpub661MyMwAqRbcEYS8w7XLSVeEsBXy79zSzH1J8vCdxAZningWLdN3zgtU6Q5JXayek4PRsn35jii4veMimro1xefsM58PgBMrvdYre8QyULY (invalid pubkey 020000000000000000000000000000000000000000000000000000000000000007)


### PR DESCRIPTION
Two of the BIP32 vectors imply that the 4 byte version possibility space is limited.

However, the BIP itself is unclear about whether anything besides the 4 versions xpub, xprv, tpub, tprv is valid or not. Parenthesis is not sufficient.

Since BIP32 doesn't prescribe anything in regards to derivation scheme (it only suggests one as an example), or script type (it makes no mention and keeps the topic only on deriving keypairs).

So prescribing the version field as "it MUST be one of these 4 values" seems odd.

In the 11 years since adoption, there have been plenty of uses of BIP32 HD keys with alternative versions, both within and outside of the Bitcoin mainnet and testnet networks. (zprv etc. is one such example)

tl;dr We should make it clear that any version is valid BIP32, but that 4 specific ones are prescribed a meaning of "pertaining to mainnet" and "pertaining to testnet".

Alternatively: We should specify that bip32 should only treat those 4 versions as valid, all other MUST hard fail.