### PR TITLE
Update bip-0039.mediawiki to remove erroneous 'HMAC'

### DIFF
--- a/bip-0039.mediawiki
+++ b/bip-0039.mediawiki
@@ -90,7 +90,7 @@ present, an empty string "" is used instead.
 
 To create a binary seed from the mnemonic, we use the PBKDF2 function with a mnemonic
 sentence (in UTF-8 NFKD) used as the password and the string "mnemonic" + passphrase (again
-in UTF-8 NFKD) used as the salt. The iteration count is set to 2048 and HMAC-SHA512 is used as
+in UTF-8 NFKD) used as the salt. The iteration count is set to 2048 and SHA512 is used as
 the pseudo-random function. The length of the derived key is 512 bits (= 64 bytes).
 
 This seed can be later used to generate deterministic wallets using BIP-0032 or


### PR DESCRIPTION
Just a minor correction on the spec.

The current spec says 'HMAC-SHA512' but this is actually incorrect and possibly misleading. HMAC is not used at all in the PKDF part of the spec.

Instead, it should just say 'SHA512', which is correct.

I had to do a double-take when reading because BIP0032 does use an HMAC-SHA512 method, however I have confirmed with multiple implementations of this spec that everyone uses SHA512, not HMAC-SHA512.