### PR TITLE
process: Allow Markdown alongside mediawiki

### DIFF
--- a/bip-0002.mediawiki
+++ b/bip-0002.mediawiki
@@ -102,7 +102,7 @@ The BIP editors are intended to fulfill administrative and editorial responsibil
 
 ===Specification===
 
-BIPs should be written in mediawiki format.
+BIPs should be written in mediawiki or Markdown format.
 
 Each BIP should have the following parts:
 


### PR DESCRIPTION
Mediawiki is a PITA and greatly reduces readability and editability of the original text documents, without almost any benefits in rendering compared to Markdown. Tooling for formatting and rendering in mediawiki format is almost non-existent, increasing the barrier to entry for new BIP authors.