### PR TITLE
Add BIP 349: OP_INTERNALKEY

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1120,7 +1120,7 @@ Those proposing changes should consider that ultimately consent may rest with th
 | Ethan Heilman, Armin Sabouri
 | Standard
 | Draft
-|- style="background-color: #cfffcf"
+|-
 | [[bip-0349.md|349]]
 | Consensus (soft fork)
 | OP_INTERNALKEY

--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1121,6 +1121,13 @@ Those proposing changes should consider that ultimately consent may rest with th
 | Standard
 | Draft
 |- style="background-color: #cfffcf"
+| [[bip-internalkey.md|internalkey]]
+| Consensus (soft fork)
+| OP_INTERNALKEY
+| Brandon Black, Jeremy Rubin
+| Standard
+| Draft
+|- style="background-color: #cfffcf"
 | [[bip-0350.mediawiki|350]]
 | Applications
 | Bech32m format for v1+ witness addresses

--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1121,7 +1121,7 @@ Those proposing changes should consider that ultimately consent may rest with th
 | Standard
 | Draft
 |- style="background-color: #cfffcf"
-| [[bip-internalkey.md|internalkey]]
+| [[bip-0349.md|349]]
 | Consensus (soft fork)
 | OP_INTERNALKEY
 | Brandon Black, Jeremy Rubin

--- a/bip-0349.md
+++ b/bip-0349.md
@@ -1,9 +1,9 @@
 ```
-BIP: XXX
+BIP: 349
 Layer: Consensus (soft fork)
 Title: OP_INTERNALKEY
 Author: Brandon Black <freedom@reardencode.com>, Jeremy Rubin <j@rubin.io>
-Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-XXXX
+Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0349
 Status: Draft
 Type: Standards Track
 Created: 2023-12-22
@@ -19,8 +19,8 @@ pushes the _taproot internal key_ to the stack.
 
 When verifying taproot script path spends having leaf version `0xc0` (as
 defined in [BIP 342]), `OP_INTERNALKEY` replaces `OP_SUCCESS203` (0xcb).
-`OP_INTERNALKEY` pushes the _taproot internal key_, denoted as _P_ in
-[BIP 341], to the stack.
+`OP_INTERNALKEY` pushes the 32-byte x-only representation of the _taproot
+internal key_ (referred to as _p_), as defined in [BIP 341], to the stack.
 
 ## Motivation
 

--- a/bip-0349.md
+++ b/bip-0349.md
@@ -7,7 +7,7 @@
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0349
   Status: Draft
   Type: Standards Track
-  Created: 2023-12-22
+  Created: 2024-11-14
   License: BSD-3-Clause
 </pre>
 

--- a/bip-0349.md
+++ b/bip-0349.md
@@ -1,14 +1,15 @@
-```
-BIP: 349
-Layer: Consensus (soft fork)
-Title: OP_INTERNALKEY
-Author: Brandon Black <freedom@reardencode.com>, Jeremy Rubin <j@rubin.io>
-Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0349
-Status: Draft
-Type: Standards Track
-Created: 2023-12-22
-License: BSD-3-Clause
-```
+<pre>
+  BIP: 349
+  Layer: Consensus (soft fork)
+  Title: OP_INTERNALKEY
+  Author: Brandon Black <freedom@reardencode.com>
+          Jeremy Rubin <j@rubin.io>
+  Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0349
+  Status: Draft
+  Type: Standards Track
+  Created: 2023-12-22
+  License: BSD-3-Clause
+</pre>
 
 ## Abstract
 

--- a/bip-internalkey.md
+++ b/bip-internalkey.md
@@ -13,13 +13,14 @@ License: BSD-3-Clause
 ## Abstract
 
 This BIP describes a new tapscript opcode (`OP_INTERNALKEY`) which
-pushes the taproot internal key to the stack.
+pushes the _taproot internal key_ to the stack.
 
 ## Specification
 
-When verifying taproot script spends having leaf version `0xc0` (as defined in
-[BIP 342]), `OP_INTERNALKEY` replaces `OP_SUCCESS203` (0xcb). `OP_INTERNALKEY`
-pushes the taproot internal key, as defined in [BIP 341], to the stack.
+When verifying taproot script path spends having leaf version `0xc0` (as
+defined in [BIP 342]), `OP_INTERNALKEY` replaces `OP_SUCCESS203` (0xcb).
+`OP_INTERNALKEY` pushes the _taproot internal key_, denoted as _P_ in
+[BIP 341], to the stack.
 
 ## Motivation
 
@@ -27,14 +28,14 @@ pushes the taproot internal key, as defined in [BIP 341], to the stack.
 
 When building taproot outputs, especially those secured by an aggregate key
 representing more than one signer, the parties may wish to collaborate on
-signing with the taproot internal key, but only with additional script
+signing with the _taproot internal key_, but only with additional script
 restrictions. In this case, `OP_INTERNALKEY` saves 8 vBytes.
 
 ### Mitigated control block overhead for scripts using hash locks
 
-In cases where script path spending is not desired, the internal key may be set
-to a NUMS point whose bytes would otherwise be required in a tapscript. This
-could be used with any hash locked transaction, for example, to save 8 vBytes.
+In cases where key path spending is not desired, the internal key may be set to
+a NUMS point whose bytes would otherwise be required in a tapscript. This could
+be used with any hash locked transaction, for example, to save 8 vBytes.
 
 Note: The internal key must be the X coordinate of a point on the SECP256K1
 curve, so any such hash must be checked and modified until it is such an X

--- a/bip-internalkey.md
+++ b/bip-internalkey.md
@@ -1,0 +1,70 @@
+```
+BIP: XXX
+Layer: Consensus (soft fork)
+Title: OP_INTERNALKEY
+Author: Brandon Black <freedom@reardencode.com>, Jeremy Rubin <j@rubin.io>
+Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-XXXX
+Status: Draft
+Type: Standards Track
+Created: 2023-12-22
+License: BSD-3-Clause
+```
+
+## Abstract
+
+This BIP describes a new tapscript opcode (`OP_INTERNALKEY`) which
+pushes the taproot internal key to the stack.
+
+## Specification
+
+When verifying taproot script spends having leaf version `0xc0` (as defined in
+[BIP 342]), `OP_INTERNALKEY` replaces `OP_SUCCESS203` (0xcb). `OP_INTERNALKEY`
+pushes the taproot internal key, as defined in [BIP 341], to the stack.
+
+## Motivation
+
+### Key spend with additional conditions
+
+When building taproot outputs, especially those secured by an aggregate key
+representing more than one signer, the parties may wish to collaborate on
+signing with the taproot internal key, but only with additional script
+restrictions. In this case, `OP_INTERNALKEY` saves 8 vBytes.
+
+### Mitigated control block overhead for scripts using hash locks
+
+In cases where script path spending is not desired, the internal key may be set
+to a NUMS point whose bytes would otherwise be required in a tapscript. This
+could be used with any hash locked transaction, for example, to save 8 vBytes.
+
+Note: The internal key must be the X coordinate of a point on the SECP256K1
+curve, so any such hash must be checked and modified until it is such an X
+coordinate. This will typically take approximately 2 attempts.
+
+## Reference Implementation
+
+A reference implementation is provided here:
+
+https://github.com/bitcoin/bitcoin/pull/29269
+
+## Backward Compatibility
+
+By constraining the behavior of an OP_SUCCESS opcode, deployment of the BIP
+can be done in a backwards compatible, soft-fork manner. If anyone were to
+rely on the OP_SUCCESS behavior of `OP_SUCCESS203`, `OP_INTERNALKEY` would
+invalidate their spend.
+
+## Deployment
+
+TBD
+
+## Credits
+
+TODO
+
+## Copyright
+
+This document is licensed under the 3-clause BSD license.
+
+[BIP 341]: https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki
+
+[BIP 342]: https://github.com/bitcoin/bips/blob/master/bip-0342.mediawiki


### PR DESCRIPTION
OP_INTERNALKEY is a new BIP342 tapscript only opcode (upgraded using OP_SUCCESS semantics) that takes bytes 1-32 (0-index, inclusive) from the BIP341 taproot control block and places them on the stack. This BIP describes that behavior.