### PR TITLE
clarify bip68 and bip112 description of required transaction versions

### DIFF
--- a/bip-0068.mediawiki
+++ b/bip-0068.mediawiki
@@ -25,7 +25,7 @@ The transaction nLockTime is used to prevent the mining of a transaction until a
 
 ==Specification==
 
-This specification defines the meaning of sequence numbers for transactions with an nVersion greater than or equal to 2 for which the rest of this specification relies on.
+This specification defines the meaning of sequence numbers for transactions with an nVersion greater than or equal to 2, or any negative version, for which the rest of this specification relies on.
 
 All references to median-time-past (MTP) are as defined by BIP113.
 

--- a/bip-0112.mediawiki
+++ b/bip-0112.mediawiki
@@ -29,7 +29,7 @@ When executed, if any of the following conditions are true, the script interpret
 * the stack is empty; or
 * the top item on the stack is less than 0; or
 * the top item on the stack has the disable flag (1 << 31) unset; and
-** the transaction version is less than 2; or
+** the transaction version is non-negative and less than 2, i.e. 0 or 1; or
 ** the transaction input sequence number disable flag (1 << 31) is set; or
 ** the relative lock-time type is not the same; or
 ** the top stack item is greater than the transaction input sequence (when masked according to the BIP68);


### PR DESCRIPTION
https://delvingbitcoin.org/t/disclosure-btcd-consensus-bugs-due-to-usage-of-signed-transaction-version/455

Seems like a good idea to be clear up front on the nversion requirements even if we're relying on the implementation-as-spec aspects of the bips. 

