### PR TITLE
BIP-00{43,49,84}: move to Standards Track + BIP-0044: mark as Final

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -243,7 +243,7 @@ Those proposing changes should consider that ultimately consent may rest with th
 | Multi-Account Hierarchy for Deterministic Wallets
 | Marek Palatinus, Pavol Rusnak
 | Standard
-| Proposed
+| Final
 |- style="background-color: #ffffcf"
 | [[bip-0045.mediawiki|45]]
 | Applications

--- a/README.mediawiki
+++ b/README.mediawiki
@@ -235,7 +235,7 @@ Those proposing changes should consider that ultimately consent may rest with th
 | Applications
 | Purpose Field for Deterministic Wallets
 | Marek Palatinus, Pavol Rusnak
-| Informational
+| Standard
 | Final
 |- style="background-color: #ffffcf"
 | [[bip-0044.mediawiki|44]]
@@ -270,7 +270,7 @@ Those proposing changes should consider that ultimately consent may rest with th
 | Applications
 | Derivation scheme for P2WPKH-nested-in-P2SH based accounts
 | Daniel Weigl
-| Informational
+| Standard
 | Final
 |- style="background-color: #cfffcf"
 | [[bip-0050.mediawiki|50]]
@@ -439,7 +439,7 @@ Those proposing changes should consider that ultimately consent may rest with th
 | Applications
 | Derivation scheme for P2WPKH based accounts
 | Pavol Rusnak
-| Informational
+| Standard
 | Final
 |-
 | [[bip-0085.mediawiki|85]]

--- a/bip-0043.mediawiki
+++ b/bip-0043.mediawiki
@@ -7,7 +7,7 @@
   Comments-Summary: No comments yet.
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0043
   Status: Final
-  Type: Informational
+  Type: Standards Track
   Created: 2014-04-24
 </pre>
 

--- a/bip-0044.mediawiki
+++ b/bip-0044.mediawiki
@@ -6,7 +6,7 @@
           Pavol Rusnak <stick@satoshilabs.com>
   Comments-Summary: Mixed review (one person)
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0044
-  Status: Proposed
+  Status: Final
   Type: Standards Track
   Created: 2014-04-24
 </pre>

--- a/bip-0049.mediawiki
+++ b/bip-0049.mediawiki
@@ -6,7 +6,7 @@
   Comments-Summary: No comments yet.
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0049
   Status: Final
-  Type: Informational
+  Type: Standards Track
   Created: 2016-05-19
   License: PD
 </pre>

--- a/bip-0084.mediawiki
+++ b/bip-0084.mediawiki
@@ -6,7 +6,7 @@
   Comments-Summary: No comments yet.
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0084
   Status: Final
-  Type: Informational
+  Type: Standards Track
   Created: 2017-12-28
   License: CC0-1.0
 </pre>


### PR DESCRIPTION
I just noticed inconsistency between BIPs dealing with the account structures:
- BIP-00{43,49,84} were Informational, while BIP-00{44,86} are Standards Track => this PR changes the former to the Standards Track too
- BIP-0044 was not marked as Final where BIP-00{43,49,84,86} are => let's mark BIP-0044 as Final too