### PR TITLE
Clarify permitted status of markdown

### DIFF
--- a/bip-0002.mediawiki
+++ b/bip-0002.mediawiki
@@ -409,7 +409,6 @@ Why is Public Domain no longer acceptable for new BIPs?
 * Non-image auxiliary files are permitted in the bip-XXXX subdirectory.
 * Email addresses are now required for authors.
 * The Post-History header may be provided as a link instead of a simple date.
-* Markdown format is no longer permitted for BIPs.
 * The Resolution header has been dropped, as it is not applicable to a decentralised system where no authority exists to make final decisions.
 
 ==See Also==


### PR DESCRIPTION
Originally BIP-2 disallowed markdown, but markdown formatting was permitted via #1504.

This removes the vestigial mention in the "Changes from BIP 1" section.