### PR TITLE
Require BIPs be "beyond the ideation phase" before being merged

### DIFF
--- a/bip-0002.mediawiki
+++ b/bip-0002.mediawiki
@@ -54,6 +54,7 @@ For a BIP to be accepted it must meet certain minimum criteria.
 It must be a clear and complete description of the proposed enhancement.
 The enhancement must represent a net improvement.
 The proposed implementation, if applicable, must be solid and must not complicate the protocol unduly.
+BIP drafts should not be merged until the idea has materially progressed beyond the ideation phase - it should have multiple implementations from independent authors released in different software packages, and/or have received material public discussion feedback from diverse contributors with the BIP champion actively working towards adoption for an extended time period. While BIPs are author documents which must only meet certain minimum criteria, the BIP editors should strive to ensure there are not an unnecessary number of BIPs which never progress into broad implementation across the bitcoin ecosystem.
 
 The BIP author may update the draft as necessary in the git repository. Updates to drafts should also be submitted by the author as pull requests.
 


### PR DESCRIPTION
As the BIP process restarts, one general risk in the BIPs is that they become (even more of) a dumping ground for half-baked ideas which even the BIP champion does not work on after the BIP is assigned. While simply never merging new BIPs addresses this issue, this isn't particularly sustainable, and we should instead have some concrete criteria here.

BIPs generally fall into a few categories with respect to when they should be considered ready for merge:
 * they're not particularly controversial (and not about consensus) and move forward towards adoption in several ecosystem projects relatively quickly or,
 * they generate lots of discussion, lots of feedback, the champion actively pushes the BIP forward and makes sustained arguments for adoption over some extended time period (this generally applies to consensus changes).

As long as the BIP champion is relatively actively pushing for adoption (i.e. active on the BIP outside of the BIP text itself) and actively addressing feedback on the BIP, the BIP should be merged, however if the BIP hasn't seen any adoption anywhere (outside of maybe one project the author wrote) and the BIP champion is off doing other things, I'd argue it clearly should simply be closed.

This commit adds some trivial but flexible text to that effect, requiring roughly the above criteria for merge.

I'd humbly suggest that we apply this criteria to new BIP number assignments (or at least BIP merges, even if they get a temporary number pre-merge) while we hash out whether this criteria makes sense.