### PR TITLE
README: remove BIP 63 from the README index

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -308,13 +308,6 @@ Those proposing changes should consider that ultimately consent may rest with th
 | Pieter Wuille
 | Standard
 | Withdrawn
-|-
-| 63
-| Applications
-| Stealth Addresses
-| Peter Todd
-| Standard
-| BIP number allocated
 |- style="background-color: #ffcfcf"
 | [[bip-0064.mediawiki|64]]
 | Peer Services


### PR DESCRIPTION
In this commit, I propose we remove BIP 63 from the README index. The BIP number was assigned in [this
PR](https://github.com/bitcoin/bips/pull/14), but no document was ever committed to the repo (?).

Alternatively, based on BIP 2, we could just move it to the Rejected (or Obsolete) status, as the PR above was originally made more than 10 years ago:

> BIPs should be changed from Draft or Proposed status, to Rejected
> status, upon request by any person, if they have not made progress in
> three years.

AFAICT, the concept was ultimately described in BIP 47 (Reusable Payment Codes for Hierarchical Deterministic Wallets): https://github.com/bitcoin/bips/blob/master/bip-0047.mediawiki