### PR TITLE
buildtable.pl: Also check .md files

### DIFF
--- a/scripts/buildtable.pl
+++ b/scripts/buildtable.pl
@@ -96,6 +96,9 @@ my %emails;
 my $bipnum = 0;
 while (++$bipnum <= $topbip) {
 	my $fn = sprintf "bip-%04d.mediawiki", $bipnum;
+	if (!-e $fn) {
+		$fn = sprintf "bip-%04d.md", $bipnum;
+	}
 	-e $fn || next;
 	open my $F, "<$fn";
 	while (<$F> !~ m[^(?:\xef\xbb\xbf)?<pre>$]) {


### PR DESCRIPTION
Adds markdown `.md` files to `buildtable.pl` so that it builds and checks them too.

Since markdown allows html tags, the check for a `<pre>` tag is fine to leave in; all `.md` formatted bips will be required to have a preamble section like formatted in the same way as the mediawiki ones.