### PR TITLE
38: Remove other implementation section and dead reference implementation link

### DIFF
--- a/bip-0038.mediawiki
+++ b/bip-0038.mediawiki
@@ -209,8 +209,7 @@ The preliminary values of 16384, 8, and 8 are hoped to offer the following prope
 ==Reference implementation==
 Added to alpha version of Casascius Bitcoin Address Utility for Windows available at:
 
-* via https: https://casascius.com/btcaddress-alpha.zip
-* at github: https://github.com/casascius/Bitcoin-Address-Utility
+* https://github.com/casascius/Bitcoin-Address-Utility
 
 Click "Tools" then "PPEC Keygen" (provisional name)
 

--- a/bip-0038.mediawiki
+++ b/bip-0038.mediawiki
@@ -214,9 +214,6 @@ Added to alpha version of Casascius Bitcoin Address Utility for Windows availabl
 
 Click "Tools" then "PPEC Keygen" (provisional name)
 
-==Other implementations==
-* Javascript - https://github.com/bitcoinjs/bip38
-
 ==Test vectors==
 
 ===No compression, no EC multiply===


### PR DESCRIPTION
Removes the "Other Implementations" section, same rationale as #1576.

Since one of the reference implementation links is dead, I've also removed that.