### PR TITLE
21: Remove other libraries from reference implementations

### DIFF
--- a/bip-0021.mediawiki
+++ b/bip-0021.mediawiki
@@ -120,11 +120,6 @@ Some future version that has variables which are (currently) not understood but 
 
 Characters must be URI encoded properly.
 
-== Reference Implementations ==
-=== Bitcoin clients ===
-* Bitcoin-Qt supports the old version of Bitcoin URIs (ie without the req- prefix), with Windows and KDE integration as of commit 70f55355e29c8e45b607e782c5d76609d23cc858.
+== Reference Implementation ==
 
-=== Libraries ===
-* Javascript - https://github.com/bitcoinjs/bip21
-* Java - https://github.com/SandroMachado/BitcoinPaymentURI
-* Swift - https://github.com/SandroMachado/BitcoinPaymentURISwift
+Bitcoin-Qt supports the old version of Bitcoin URIs (ie without the req- prefix), with Windows and KDE integration as of commit 70f55355e29c8e45b607e782c5d76609d23cc858.


### PR DESCRIPTION
Although not an "Other Implementations" section, people have been using the "Libraries" subsection of the "Reference Implementations" section in the same way. Thus removing this subsection with the same rationale as #1576.