### PR TITLE
Reduce scope of BIP173 to native segwit v0

### DIFF
--- a/bip-0173.mediawiki
+++ b/bip-0173.mediawiki
@@ -11,6 +11,7 @@
   Created: 2017-03-20
   License: BSD-2-Clause
   Replaces: 142
+  Superseded-By: 350
 </pre>
 
 ==Introduction==
@@ -403,3 +404,12 @@ separator).
 This document is inspired by the [https://rusty.ozlabs.org/?p=578 address proposal] by Rusty Russell, the
 [https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2014-February/004402.html base32] proposal by Mark Friedenbach, and had input from Luke Dashjr,
 Johnson Lau, Eric Lombrozo, Peter Todd, and various other reviewers.
+
+==Disclosures (added 2024)==
+
+Due to an oversight in the design of bech32, this checksum scheme is not always
+robust against
+[[https://gist.github.com/sipa/a9845b37c1b298a7301c33a04090b2eb|the insertion
+and deletion of fewer than 5 consecutive characters]]. Due to this weakness,
+[[bip-0350.mediawiki|BIP-350]] proposes using the scheme described in this BIP
+only for Native Segwit v0 outputs.


### PR DESCRIPTION
This is a follow-up to https://github.com/bitcoin/bips/pull/945 to reduce the scope of BIP173 to native segwit v0.

I expect that you may have feedback about the phrasing, @sipa.