### PR TITLE
BIP32 amendment: base58chk-encoded extended keys are always 111 chars

### DIFF
--- a/bip-0032.mediawiki
+++ b/bip-0032.mediawiki
@@ -137,7 +137,7 @@ Extended public and private keys are serialized as follows:
 * 32 bytes: the chain code
 * 33 bytes: the public key or private key data (ser<sub>P</sub>(K) for public keys, 0x00 || ser<sub>256</sub>(k) for private keys)
 
-This 78 byte structure can be encoded like other Bitcoin data in Base58, by first adding 32 checksum bits (derived from the double SHA-256 checksum), and then converting to the Base58 representation. This results in a Base58-encoded string of up to 112 characters. Because of the choice of the version bytes, the Base58 representation will start with "xprv" or "xpub" on mainnet, "tprv" or "tpub" on testnet.
+This 78 byte structure can be encoded like other Bitcoin data in Base58, by first adding 32 checksum bits (derived from the double SHA-256 checksum), and then converting to the Base58 representation. This results in a Base58-encoded string of exactly 111 characters. Because of the choice of the version bytes, the Base58 representation will start with "xprv" or "xpub" on mainnet, "tprv" or "tpub" on testnet.
 
 Note that the fingerprint of the parent only serves as a fast way to detect parent and child nodes in software, and software must be willing to deal with collisions. Internally, the full 160-bit identifier could be used.
 


### PR DESCRIPTION
*Replaces https://github.com/bitcoin/bips/pull/727 with with cherry-picked 81644ddfa131bb0e387ead2cc309ca18e57542b1; note that BIP32 has status `Final`. The description below is copied from that PR.*

Base58chk-encoded extended keys are always 111 characters long.  Amend wording of BIP32 accordingly.

**Diff:**
-This results in a Base58-encoded string of up to 112 characters.
+This results in a Base58-encoded string of exactly 111 characters.

**Proof:**
Version bytes: `0x0488b21e` (“xpub”), `0x0488ade4` (“xprv”), `0x043587cf` (“tpub”), `0x04358394` (“tprv”)

Largest version byte is `0x0488b21e`, smallest `0x04358394`.

Largest “possible” key:
```
kL = 0x0488b21effffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff (78 bytes)
b58chk(kL) = xpubEPi3iGSX9RiyuXPTijevUmMctBDQs2TWCMgUd3qKp6qCgUc8RUsPdPBrRC6whFeWTg37DcmnJJiKFL73DH4sjdApJkXBD3vFcBP4xHq3fPY
len(b58chk(kL)) = 111
```

Smallest “possible” key:
```
kS = 0x043583940000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 (78 bytes)
b58chk(kS) = tprv8ZgxMBicQKsPcsbCVeqqF1KVdH7gwDJbxbzpCxDUsoXHdb6SnTPYxdwSAKDC6KKJzv7khnNWRAJQsRA8BBQyiSfYnRt6zuu4vZQGKjeW4YF
len(b58chk(kS)) = 111
```