### PR TITLE
ci: Fix link checks

### DIFF
--- a/bip-0197.mediawiki
+++ b/bip-0197.mediawiki
@@ -79,7 +79,7 @@ The Seizable Collateral script takes the following form:
 
 ==Compatibility==
 
-BIP 197 is compatible with [ERC 1850](https://github.com/ethereum/EIPs/pull/1850) for [atomic loans](https://arxiv.org/pdf/1901.05117.pdf) with Ethereum. Can be extended in the future to be compatible with other HTLC and smart contract compatible chains.
+BIP 197 is compatible with [https://github.com/ethereum/EIPs/pull/1850 ERC 1850] for [https://arxiv.org/pdf/1901.05117.pdf atomic loans] with Ethereum. Can be extended in the future to be compatible with other HTLC and smart contract compatible chains.
 
 ==Motivation==
 

--- a/bip-0310.mediawiki
+++ b/bip-0310.mediawiki
@@ -190,7 +190,7 @@ send the mask, in this case a default full mask is used.
 
 * '''"version-rolling.mask"''' (REQUIRED, ''TMask'')
 ::- Bits set to 1 are allowed to be changed by the miner. If a miner changes bits with mask value 0, the server will reject the submit.
-::- The server SHOULD return the largest mask possible (as many bits set to 1 as possible). This can be useful in a mining proxy setup when a proxy needs to negotiate the best mask for its future clients. There is a [Draft BIP](https://github.com/bitcoin/bips/pull/661/files) describing available nVersion bits. The server SHOULD pick a mask that preferably covers all bits specified in the BIP.
+::- The server SHOULD return the largest mask possible (as many bits set to 1 as possible). This can be useful in a mining proxy setup when a proxy needs to negotiate the best mask for its future clients. There is a [https://github.com/bitcoin/bips/pull/661/files Draft BIP] describing available nVersion bits. The server SHOULD pick a mask that preferably covers all bits specified in the BIP.
 
 * '''"version-rolling.min-bit-count"''' (REQUIRED, ''TMask'')
 ::- The miner also provides a minimum number of bits that it needs for efficient version rolling in hardware. Note that this parameter provides important diagnostic information to the pool server. If the requested bit count exceeds the limit of the pool server, the miner always has the chance to operate in a degraded mode without using full hashing power. The pool server SHOULD NOT terminate miner connection if this rare mismatch case occurs.

--- a/scripts/link-format-chk.sh
+++ b/scripts/link-format-chk.sh
@@ -8,16 +8,14 @@
 
 ECODE=0
 FILES=""
-for fname in $(git diff --name-only HEAD $(git merge-base HEAD master)); do
-    if [[ $fname == *.mediawiki ]]; then
-        GRES=$(grep -n '](http' $fname)
-        if [ "$GRES" != "" ]; then
-            if [ $ECODE -eq 0 ]; then
-                >&2 echo "Github Mediawiki format writes link as [URL text], not as [text](url):"
-            fi
-            ECODE=1
-            echo "- $fname:$GRES"
+for fname in *.mediawiki; do
+    GRES=$(grep -n '](http' $fname)
+    if [ "$GRES" != "" ]; then
+        if [ $ECODE -eq 0 ]; then
+            >&2 echo "Github Mediawiki format writes link as [URL text], not as [text](url):"
         fi
+        ECODE=1
+        echo "- $fname:$GRES"
     fi
 done
 exit $ECODE


### PR DESCRIPTION
The link format CI check is currently silently failing, for example https://github.com/bitcoin/bips/actions/runs/8914643431/job/24482636376.

This failure is caused by Github Actions cloning as little as possible for CI, so the git commands in the script end up failing. This checkout was done in order to check current PRs, however, it's not much more expensive nor onerous to just always check the links in the entire repo, and would allow this check to actually work. This PR does that, and also fixes the broken link formats in BIPs 197 and 310.