### PR TITLE
bip-0062: add nLockTime exception case as an overflow of 4-byte int

### DIFF
--- a/bip-0062.mediawiki
+++ b/bip-0062.mediawiki
@@ -112,7 +112,7 @@ The native data type of stack elements is byte arrays, but some operations inter
 * -32767..-128 and 128..32767: normal 2-byte data push; (02 FF FF)..(02 80 80) and (02 80 00)..(02 FF 7F)
 * -8388607..-32768 and 32768..8388607: normal 3-byte data push; (03 FF FF FF)..(03 00 80 80) and (03 00 80 00)..(03 FF FF 7F)
 * -2147483647..-8388608 and 8388608..2147483647: normal 4-byte data push; (04 FF FF FF FF)..(04 00 00 80 80) and (04 00 00 80 00)..(04 FF FF FF 7F)
-* Any other numbers cannot be encoded.
+* Any other numbers cannot be encoded (except nLockTime, which can be up to 2**32-1 as an operand of OP_CHECKLOCKTIMEVERIFY following [https://github.com/bitcoin/bips/blob/master/bip-0065.mediawiki BIP65]).
 
 In particular, note that zero could be encoded as (01 80) (negative zero) if using the non-shortest form is allowed.
 


### PR DESCRIPTION
BIP62 states number is strictly limited 4 byte int range, but it breaks forward compatibility with BIP65 as now. Add exception case of locktime number(which can be up to 2**32-1) to correct.