### PR TITLE
Update bip-0015.mediawiki

### DIFF
--- a/bip-0015.mediawiki
+++ b/bip-0015.mediawiki
@@ -36,7 +36,7 @@ Their FirstBits alias becomes:
 
 It is enough information to be given the FirstBits alias ''1brmlab''. When someone wishes to make a purchase, without FirstBits, they either have to type out their address laboriously by hand, scan their QR code (which requires a mobile handset that this author does not own) or find their address on the internet to copy and paste into the client to send bitcoins. FirstBits alleviates this impracticality by providing an easy method to make payments.
 
-Together with [[vanitygen|Vanitygen (vanity generator)]], it becomes possible to create memorable unique named addresses. Addresses that are meaningful, rather than an odd assemblage of letters and numbers but add context to the destination.
+Together with [vanitygen https://github.com/klynastor/supervanitygen], it becomes possible to create memorable unique named addresses. Addresses that are meaningful, rather than an odd assemblage of letters and numbers but add context to the destination.
 
 However FirstBits has its own problems. One is that the possible aliases one is able to generate is limited by the available computing power available. It may not be feasible to generate a complete or precise alias that is wanted- only approximates may be possible. It is also computationally resource intensive which means a large expenditure of power for generating unique aliases in the future, and may not scale up to the level of individuals at home or participants with hand-held devices in an environment of ubiquitous computing.
 


### PR DESCRIPTION
Fix broken link to vanitygen.  (Proof that the page was 404: https://archive.ph/iY5oI)

This is an attempt to change the destination link... 
FROM: https://bips.dev/15/vanitygen
TO: https://github.com/klynastor/supervanitygen
...using the syntax of Github Mediawiki format as mentioned [here](https://github.com/bitcoin/bips/blob/70d9b07ab80ab3c267ece48f74e4e2250226d0cc/scripts/link-format-chk.sh#L15C23-L15C61).