### PR TITLE
Remove broken hyperlink to Vanitygen

### DIFF
--- a/bip-0015.mediawiki
+++ b/bip-0015.mediawiki
@@ -36,7 +36,7 @@ Their FirstBits alias becomes:
 
 It is enough information to be given the FirstBits alias ''1brmlab''. When someone wishes to make a purchase, without FirstBits, they either have to type out their address laboriously by hand, scan their QR code (which requires a mobile handset that this author does not own) or find their address on the internet to copy and paste into the client to send bitcoins. FirstBits alleviates this impracticality by providing an easy method to make payments.
 
-Together with [vanitygen https://github.com/klynastor/supervanitygen], it becomes possible to create memorable unique named addresses. Addresses that are meaningful, rather than an odd assemblage of letters and numbers but add context to the destination.
+Together with Vanitygen (vanity generator), it becomes possible to create memorable unique named addresses. Addresses that are meaningful, rather than an odd assemblage of letters and numbers but add context to the destination.
 
 However FirstBits has its own problems. One is that the possible aliases one is able to generate is limited by the available computing power available. It may not be feasible to generate a complete or precise alias that is wanted- only approximates may be possible. It is also computationally resource intensive which means a large expenditure of power for generating unique aliases in the future, and may not scale up to the level of individuals at home or participants with hand-held devices in an environment of ubiquitous computing.
 

--- a/bip-0015.mediawiki
+++ b/bip-0015.mediawiki
@@ -36,7 +36,7 @@ Their FirstBits alias becomes:
 
 It is enough information to be given the FirstBits alias ''1brmlab''. When someone wishes to make a purchase, without FirstBits, they either have to type out their address laboriously by hand, scan their QR code (which requires a mobile handset that this author does not own) or find their address on the internet to copy and paste into the client to send bitcoins. FirstBits alleviates this impracticality by providing an easy method to make payments.
 
-Together with [[vanitygen|Vanitygen (vanity generator)]], it becomes possible to create memorable unique named addresses. Addresses that are meaningful, rather than an odd assemblage of letters and numbers but add context to the destination.
+Together with [vanitygen https://github.com/klynastor/supervanitygen], it becomes possible to create memorable unique named addresses. Addresses that are meaningful, rather than an odd assemblage of letters and numbers but add context to the destination.
 
 However FirstBits has its own problems. One is that the possible aliases one is able to generate is limited by the available computing power available. It may not be feasible to generate a complete or precise alias that is wanted- only approximates may be possible. It is also computationally resource intensive which means a large expenditure of power for generating unique aliases in the future, and may not scale up to the level of individuals at home or participants with hand-held devices in an environment of ubiquitous computing.
 


### PR DESCRIPTION
Originally I opened https://github.com/bitcoin/bips/pull/1611 when I spotted a broken hyperlink in https://github.com/bitcoin/bips/blob/master/bip-0015.mediawiki.  I suggested changing the hyperlink to https://github.com/klynastor/supervanitygen, but since an email sent to the BIP Champion at genjix@riseup.net bounced back as undeliverable ("550 5.1.1 : Recipient address rejected: User unknown"), [@murch](https://github.com/murchandamus/murchandamus) suggested just removing the hyperlink altogether rather than guess at what it should be set to.

I agree that no hyperlink is better than a broken one, so the existing hyperlink should be removed.

I am closing https://github.com/bitcoin/bips/pull/1611 and opening this new PR instead.