### PR TITLE
BIP-0386: Fix uncompressed private key test vector

### DIFF
--- a/bip-0386.mediawiki
+++ b/bip-0386.mediawiki
@@ -101,7 +101,7 @@ Valid descriptors followed by the scripts they produce. Descriptors involving de
 
 Invalid Descriptors
 
-* Uncompressed private key: <tt>tr(5kyzdueo39z3fprtux2qbbwgnnp5ztd7yyr2sc1j299sbcnwjss)</tt>
+* Uncompressed private key: <tt>tr(5KYZdUEo39z3FPrtuX2QbbwGnNP5zTd7yyr2SC1j299sBCnWjss)</tt>
 * Uncompressed public key: <tt>tr(04a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd5b8dec5235a0fa8722476c7709c02559e3aa73aa03918ba2d492eea75abea235)</tt>
 * <tt>tr()</tt> nested in <tt>wsh</tt>: <tt>wsh(tr(a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd))</tt>
 * <tt>tr()</tt> nested in <tt>sh</tt>: <tt>sh(tr(a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd))</tt>


### PR DESCRIPTION
Base58 in the WIF format is case sensitive.
The following Test Vector will result in an error indicating the WIF version is invalid, regardless of the compression state of the public key.

```
5kyzdueo39z3fprtux2qbbwgnnp5ztd7yyr2sc1j299sbcnwjss
```

The following is probably what was intended:

```
5KYZdUEo39z3FPrtuX2QbbwGnNP5zTd7yyr2SC1j299sBCnWjss
```