### PR TITLE
Move BIP 338 to Withdrawn

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1050,13 +1050,13 @@ Those proposing changes should consider that ultimately consent may rest with th
 | Tom Briar
 | Standard
 | Draft
-|-
+|- style="background-color: #ffcfcf"
 | [[bip-0338.mediawiki|338]]
 | Peer Services
 | Disable transaction relay message
 | Suhas Daftuar
 | Standard
-| Draft
+| Withdrawn
 |-
 | [[bip-0339.mediawiki|339]]
 | Peer Services

--- a/bip-0338.mediawiki
+++ b/bip-0338.mediawiki
@@ -5,7 +5,7 @@
   Author: Suhas Daftuar <sdaftuar@chaincode.com>
   Comments-Summary: No comments yet.
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0338
-  Status: Draft
+  Status: Withdrawn
   Type: Standards Track
   Created: 2020-09-03
   License: BSD-2-Clause


### PR DESCRIPTION
The PR implementing this BIP was never merged into Bitcoin Core, in favor of an alternative approach.