### PR TITLE
bip327: minor fixes

### DIFF
--- a/bip-0327.mediawiki
+++ b/bip-0327.mediawiki
@@ -619,7 +619,7 @@ Algorithm ''DeterministicSign(sk, aggothernonce, pk<sub>1..u</sub>, tweak<sub>1.
 * Let ''keyagg_ctx<sub>0</sub> = KeyAgg(pk<sub>1..u</sub>)''; fail if that fails
 * For ''i = 1 .. v'':
 ** Let ''keyagg_ctx<sub>i</sub> = ApplyTweak(keyagg_ctx<sub>i-1</sub>, tweak<sub>i</sub>, is_xonly_t<sub>i</sub>)''; fail if that fails
-* Let ''aggpk = GetPubkey(keyagg_ctx<sub>v</sub>)''
+* Let ''aggpk = GetXonlyPubkey(keyagg_ctx<sub>v</sub>)''
 * Let ''k<sub>i</sub> = int(hash<sub>MuSig/deterministic/nonce</sub>(sk' || aggothernonce || aggpk || bytes(8, len(m)) || m || bytes(1, i - 1))) mod n'' for ''i = 1,2''
 * Fail if ''k<sub>1</sub> = 0'' or ''k<sub>2</sub> = 0''
 * Let ''R<sub>⁎,1</sub> = k<sub>1</sub>⋅G, R<sub>⁎,2</sub> = k<sub>2</sub>⋅G''

--- a/bip-0327.mediawiki
+++ b/bip-0327.mediawiki
@@ -782,6 +782,8 @@ An exception to this rule is <code>MAJOR</code> version zero (0.y.z) which is fo
 The <code>MINOR</code> version is incremented whenever the inputs or the output of an algorithm changes in a backward-compatible way or new backward-compatible functionality is added.
 The <code>PATCH</code> version is incremented for other changes that are noteworthy (bug fixes, test vectors, important clarifications, etc.).
 
+* '''1.0.2''' (2024-07-22):
+** Fix minor bug in the specification of ''DeterministicSign'' and add small improvement to a ''PartialSigAgg'' test vector.
 * '''1.0.1''' (2024-05-14):
 ** Fix minor issue in ''PartialSigVerify'' vectors.
 * '''1.0.0''' (2023-03-26):
@@ -825,4 +827,4 @@ The <code>PATCH</code> version is incremented for other changes that are notewor
 
 == Acknowledgements ==
 
-We thank Brandon Black, Riccardo Casatta, Lloyd Fournier, Russell O'Connor, and Pieter Wuille for their contributions to this document.
+We thank Brandon Black, Riccardo Casatta, Sivaram Dhakshinamoorthy, Lloyd Fournier, Russell O'Connor, and Pieter Wuille for their contributions to this document.

--- a/bip-0327/gen_vectors_helper.py
+++ b/bip-0327/gen_vectors_helper.py
@@ -153,7 +153,8 @@ def sig_agg_vectors():
         "psig_indices": [7, 8],
         "error": {
             "type": "invalid_contribution",
-            "signer": 1
+            "signer": 1,
+            "contrib": "psig",
         },
         "comment": "Partial signature is invalid because it exceeds group size"
     }

--- a/bip-0327/reference.py
+++ b/bip-0327/reference.py
@@ -367,7 +367,7 @@ def sign(secnonce: bytearray, sk: bytes, session_ctx: SessionContext) -> bytes:
         raise ValueError('secret key value is out of range.')
     P = point_mul(G, d_)
     assert P is not None
-    pk = PlainPk(cbytes(P))
+    pk = cbytes(P)
     if not pk == secnonce[64:97]:
         raise ValueError('Public key does not match nonce_gen argument')
     a = get_session_key_agg_coeff(session_ctx, P)
@@ -430,7 +430,7 @@ def partial_sig_verify(psig: bytes, pubnonces: List[bytes], pubkeys: List[PlainP
     session_ctx = SessionContext(aggnonce, pubkeys, tweaks, is_xonly, msg)
     return partial_sig_verify_internal(psig, pubnonces[i], pubkeys[i], session_ctx)
 
-def partial_sig_verify_internal(psig: bytes, pubnonce: bytes, pk: PlainPk, session_ctx: SessionContext) -> bool:
+def partial_sig_verify_internal(psig: bytes, pubnonce: bytes, pk: bytes, session_ctx: SessionContext) -> bool:
     (Q, gacc, _, b, R, e) = get_session_values(session_ctx)
     s = int_from_bytes(psig)
     if s >= n:

--- a/bip-0327/reference.py
+++ b/bip-0327/reference.py
@@ -440,8 +440,6 @@ def partial_sig_verify_internal(psig: bytes, pubnonce: bytes, pk: PlainPk, sessi
     Re_s_ = point_add(R_s1, point_mul(R_s2, b))
     Re_s = Re_s_ if has_even_y(R) else point_negate(Re_s_)
     P = cpoint(pk)
-    if P is None:
-        return False
     a = get_session_key_agg_coeff(session_ctx, P)
     g = 1 if has_even_y(Q) else n - 1
     g_ = g * gacc % n

--- a/bip-0327/vectors/sig_agg_vectors.json
+++ b/bip-0327/vectors/sig_agg_vectors.json
@@ -143,7 +143,8 @@
             ],
             "error": {
                 "type": "invalid_contribution",
-                "signer": 1
+                "signer": 1,
+                "contrib": "psig"
             },
             "comment": "Partial signature is invalid because it exceeds group size"
         }


### PR DESCRIPTION
I made some minor corrections, which I believe are beneficial. Please let me know if any of them are incorrect or need modification.

Changes:
1. An error test vector doesn’t specify the `InvalidContributionError` type
2. In *DeterministicSign*, use `GetXonlyPubkey` instead of `GetPubkey` (doesn’t exist)
3. The `key_agg_and_tweak` fn doesn’t specify the return type
4. In `partial_sig_verify_internal`, the pubkey arg type should be `PlainPk` rather than `bytes`
5. Remove unnecessary `enumerate()` calls
    - I suspect this was initially used in debugging to find the failing test vector, and then it was forgotten.
6. In `test_sign_verify`, add an additional `assert` statement that checks if two pubnonces add up to the infinity aggnonce.

cc @jonasnick @real-or-random 