### PR TITLE
BIP150: Deferred

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -832,7 +832,7 @@ Those proposing changes should consider that ultimately consent may rest with th
 | Peer Authentication
 | Jonas Schnelli
 | Standard
-| Draft
+| Deferred
 |- style="background-color: #ffcfcf"
 | [[bip-0151.mediawiki|151]]
 | Peer Services

--- a/bip-0150.mediawiki
+++ b/bip-0150.mediawiki
@@ -5,7 +5,7 @@
   Author: Jonas Schnelli <dev@jonasschnelli.ch>
   Comments-Summary: Discouraged for implementation (one person)
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0150
-  Status: Draft
+  Status: Deferred
   Type: Standards Track
   Created: 2016-03-23
   License: PD


### PR DESCRIPTION
Mark BIP150 as Deferred. More robust and private protocols have been drafted and need to be formalized into a BIP (see https://github.com/sipa/writeups/tree/ea9a3329fd33cc2c50e7ea65920e885d9caa454a/private-authentication-protocols for an example)