### PR TITLE
BIP46 clarify witness

### DIFF
--- a/bip-0046.mediawiki
+++ b/bip-0046.mediawiki
@@ -90,7 +90,7 @@ month = 1 + index % 12
 To derive the address from the above calculated public key and timelock, we create a <tt>witness script</tt> which locks the funds until the <tt>timelock</tt>, and then checks the signature of the <tt>derived_key</tt>. The <tt>witness script</tt> is hashed with SHA256 to produce a 32-byte hash value that forms the <tt>witness program</tt> in the output script of the P2WSH address.
 
     witnessScript: <timelock> OP_CHECKLOCKTIMEVERIFY OP_DROP <derived_key> OP_CHECKSIG
-    witness:      <signature> <pubkey>
+    witness:      <signature> <witnessScript>
     scriptSig:    (empty)
     scriptPubKey: 0 <32-byte-hash>
                   (0x0020{32-byte-hash})


### PR DESCRIPTION
In BIP46, the witness in the address derivation section states `<signature> <pubkey>`, which is incorrect. It should say `<signature> <witnessScript>` as specified for P2WSH in [BIP141](https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#user-content-P2WSH).