### PR TITLE
BIP 324: fix python aad in complete_handshake

### DIFF
--- a/bip-0324.mediawiki
+++ b/bip-0324.mediawiki
@@ -384,7 +384,7 @@ def complete_handshake(peer, initiating, decoy_content_lengths=[]):
         if received_garbage[-16:] == peer.recv_garbage_terminator:
             # Receive, decode, and ignore version packet.
             # This includes skipping decoys and authenticating the received garbage.
-            v2_receive_packet(peer, aad=received_garbage)
+            v2_receive_packet(peer, aad=received_garbage[:-16])
             return
         else:
             received_garbage += recv(peer, 1)


### PR DESCRIPTION
The aad shouldn't include the garbage terminator. This tripped me up during implementation even though the text says it shouldn't be included.