### PR TITLE
BIP94: Change timewarp delta to 7200 seconds

### DIFF
--- a/bip-0094.mediawiki
+++ b/bip-0094.mediawiki
@@ -62,7 +62,7 @@ The first block must contain the actual difficulty of the network and can theref
 
 In addition to a time warp attack potentially exacerbating the perpetual block storm attack, a time warp attack provides an alternative way to increase the block production rate even if the unintended reset of the actual difficulty due to the 20-minute exception was mitigated.
 
-To protect against the time warp attack, the following rule proposed as part of The Great Consensus Cleanup<ref>https://github.com/TheBlueMatt/bips/blob/cleanup-softfork/bip-XXXX.mediawiki</ref> is enforced: "The nTime field of each block whose height, mod 2016, is 0 must be greater than or equal to the nTime field of the immediately prior block minus 600. For the avoidance of doubt, such blocks must still comply with existing Median-Time-Past nTime restrictions."
+To protect against the time warp attack, the following rule proposed as part of The Great Consensus Cleanup<ref>https://github.com/TheBlueMatt/bips/blob/cleanup-softfork/bip-XXXX.mediawiki</ref> is enforced: "The nTime field of each block whose height, mod 2016, is 0 must be greater than or equal to the nTime field of the immediately prior block minus 7200. For the avoidance of doubt, such blocks must still comply with existing Median-Time-Past nTime restrictions." The originally proposed rule has been adapted to allow for a delta of 7200 seconds instead of only 600 seconds to allow honest miners to mine at the current time even if an attacking miner has postdated the timestamp up to the allowed 2 hours in the previous block.
 
 == Rationale ==
 


### PR DESCRIPTION
This aligns the BIP with the Bitcoin Core pull request and sets the allowed delta between the first block of the new difficulty period and the previous block to 7200 seconds (2 hours) instead of 600 seconds.

See also the discussion in the PR: https://github.com/bitcoin/bitcoin/pull/29775#discussion_r1704428831