### PR TITLE
Explicitly mention care around payment instruction expiry in 353

### DIFF
--- a/bip-0353.mediawiki
+++ b/bip-0353.mediawiki
@@ -46,6 +46,8 @@ User and domain names which are not expressible using standard printable ASCII M
 
 Note that because resolvers are not required to support resolving non-ASCII identifiers, wallets SHOULD avoid using non-ASCII identifiers.
 
+For payment instructions that have a built-in expiry time (e.g. Lightning BOLT 12 offers), care must be taken to ensure that the DNS records expire prior to the expiry of the payment instructions. Otherwise, senders may have payment instructions cached locally which have expired, preventing payment.
+
 === Resolution ===
 
 Clients resolving Bitcoin payment instructions MUST ignore any TXT records at the same label which do not begin with (ignoring case) "bitcoin:". Resolvers encountering multiple "bitcoin:"-matching TXT records at the same label MUST treat the records as invalid and refuse to use any payment instructions therein.


### PR DESCRIPTION
If someone puts a lightning BOLT 12 offer in a BIP 353 entry with the offer expiring before the DNS entry's TTL (plus now), they may get stuck being unpayable, so its worth explicitly mentioning that people should take care here.