### PR TITLE
BIP85: revert XPRV breaking changes for application 32'

### DIFF
--- a/bip-0085.mediawiki
+++ b/bip-0085.mediawiki
@@ -439,8 +439,7 @@ BIP32, BIP39
 
 * 1.0 (2020-07)
 * 2.0.0 (2024-09-22)
-    * Swap chain code and private key bytes in application 32' for consistentcy with BIP-32 (major change)
-    * Correct derived entropy for application 128169' test vector (major change)
+    * Correct derived entropy for application 707764' test vector (bugfix)
     * Clarify big endian serialization
     * Add the Portuguese language (9') to application 39'
     * Add dice application 89101'

--- a/bip-0085.mediawiki
+++ b/bip-0085.mediawiki
@@ -239,9 +239,10 @@ OUTPUT
 ===XPRV===
 Application number: 32'
 
-Consistent with BIP32, use the first (leftmost) 32 bytes of the derived entropy as the
-private key<ref name="curve-order" />. Prepend an empty byte (<code>0x00</code>)
-per BIP32 on master key serialization. Use the last (rightmost) 32 bytes as the chain code.
+Taking 64 bytes of the HMAC digest, the first 32 bytes are the chain code,
+and second 32 bytes are the private key for BIP32 XPRV value.
+
+WARNING: This is not consistent with BIP-032
 
 Child number, depth, and parent fingerprint are forced to zero, as with any root
 private key.
@@ -258,7 +259,7 @@ INPUT:
 
 OUTPUT
 * DERIVED ENTROPY=ead0b33988a616cf6a497f1c169d9e92562604e38305ccd3fc96f2252c177682
-* DERIVED XPRV=xprv9s21ZrQH143K4Px85utdpu6DFvY2NpHkJajPoupAznfiacH2MC9LasyW4uvqKXNxLWcjqGTbHKAhoZoMAbmRe5g9tAPA7cUUX4UVA1vFKFm
+* DERIVED XPRV=xprv9s21ZrQH143K2srSbCSg4m4kLvPMzcWydgmKEnMmoZUurYuBuYG46c6P71UGXMzmriLzCCBvKQWBUv3vPB3m1SATMhp3uEjXHJ42jFg7myX
 
 ===HEX===
 Application number: 128169'


### PR DESCRIPTION
* revert (only) breaking changes wrt XPRV (application 32')
* no need to mention `0x00` private key prepend as it is defined in BIP-032