### PR TITLE
BIP119: remove James O'Beirne as co-author

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -641,7 +641,7 @@ Those proposing changes should consider that ultimately consent may rest with th
 | [[bip-0119.mediawiki|119]]
 | Consensus (soft fork)
 | CHECKTEMPLATEVERIFY
-| Jeremy Rubin, James O'Beirne
+| Jeremy Rubin
 | Standard
 | Draft
 |- style="background-color: #ffcfcf"

--- a/bip-0119.mediawiki
+++ b/bip-0119.mediawiki
@@ -3,7 +3,6 @@
   Layer: Consensus (soft fork)
   Title: CHECKTEMPLATEVERIFY
   Author: Jeremy Rubin <j@rubin.io>
-          James O'Beirne <vaults@au92.org>
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0119
   Status: Draft
   Type: Standards Track


### PR DESCRIPTION
I discussed removal with @jamesob at the beginning of the summer, as his focus is elsewhere these days. Original context on his addition is here https://github.com/bitcoin/bips/pull/1482.

Since the BIP editor community is more active these days, I'd like to see the addition of an editors/champion/draft-team metadata, and would love to add a volunteer or two to the BIP should it need any edits for that role.