### PR TITLE
BIP39: add license and copyright section

### DIFF
--- a/bip-0039.mediawiki
+++ b/bip-0039.mediawiki
@@ -11,6 +11,7 @@
   Status: Proposed
   Type: Standards Track
   Created: 2013-09-10
+  License: MIT
 </pre>
 
 ==Abstract==
@@ -21,6 +22,10 @@ a group of easy to remember words -- for the generation of deterministic wallets
 It consists of two parts: generating the mnemonic and converting it into a
 binary seed. This seed can be later used to generate deterministic wallets using
 BIP-0032 or similar methods.
+
+==Copyright==
+
+This BIP falls under the MIT License.
 
 ==Motivation==
 


### PR DESCRIPTION
These are required for legal use, and also per BIP-2, and they avoid user confusion as seen in https://github.com/bitcoin/bips/pull/1395#issuecomment-2393915807.

Choice of MIT license per BIP author feedback in https://github.com/bitcoin/bips/pull/1395#issuecomment-2393930721.

The license omission was likely an oversight.

BIP-39 predates BIP-2 by 2-3 years. BIP-1 (in force at the time, since superseded by BIP-2) did require a copyright or public domain section.