### PR TITLE
BIP327: update status from Draft to Active

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1022,13 +1022,13 @@ Those proposing changes should consider that ultimately consent may rest with th
 | Chris Belcher
 | Informational
 | Draft
-|-
+|- style="background-color: #cfffcf"
 | [[bip-0327.mediawiki|327]]
 |
 | MuSig2 for BIP340-compatible Multi-Signatures
 | Jonas Nick, Tim Ruffing, Elliott Jin
 | Informational
-| Draft
+| Active
 |-
 | [[bip-0328.mediawiki|328]]
 | Applications

--- a/bip-0327.mediawiki
+++ b/bip-0327.mediawiki
@@ -4,7 +4,7 @@
   Author: Jonas Nick <jonasd.nick@gmail.com>
           Tim Ruffing <crypto@timruffing.de>
           Elliott Jin <elliott.jin@gmail.com>
-  Status: Draft
+  Status: Active
   License: BSD-3-Clause
   Type: Informational
   Created: 2022-03-22


### PR DESCRIPTION
Following the merge of https://github.com/bitcoin-core/secp256k1/pull/1479, it looks like the status of BIP327 "MuSig2 for BIP340-compatible Multi-Signatures" can be updated from Draft to Active.