### PR TITLE
BIP300: fix up markup in comment header

### DIFF
--- a/bip-0300.mediawiki
+++ b/bip-0300.mediawiki
@@ -408,7 +408,7 @@ If an OP_DRIVECHAIN input is spent, the additional rules for M5 or M6 (see above
 
 <!--
 
-====Weight adjustments====
+Weight adjustments
 
 To account for the additional drivechain checks, each message adds to the block's weight:
 


### PR DESCRIPTION
this section is (rightly) commented out, but it still (wrongly) shows up at the table of contents in the beginning, this should fix it