### PR TITLE
Fix BIP-99 Formatting

### DIFF
--- a/bip-0099.mediawiki
+++ b/bip-0099.mediawiki
@@ -113,7 +113,7 @@ planned consensus fork to migrate all Bitcoin-qt 0.7- users could
 remove those additional consensus restrictions.
 Had libconsensus being implemented without depending on levelDB,
 those additional restrictions wouldn't have been part of "the specification"
- and this would just have been a bug in the
+and this would just have been a bug in the
 consensus rules, just a consensus-critical bug in a set of
 implementations, concretely all satoshi-bitcoin-0.7-or-less (which
 happened to be a huge super majority of the users), but other


### PR DESCRIPTION
This extra space appears to unintentionally trigger the markup rules for preformatted text.