### PR TITLE
BIP125: update status of Opt-in Full RBF Signaling to Obsolete

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -679,13 +679,13 @@ Those proposing changes should consider that ultimately consent may rest with th
 | Eric Lombrozo, William Swanson
 | Informational
 | Rejected
-|- style="background-color: #ffffcf"
+|- style="background-color: #ffcfcf"
 | [[bip-0125.mediawiki|125]]
 | Applications
 | Opt-in Full Replace-by-Fee Signaling
 | David A. Harding, Peter Todd
 | Standard
-| Proposed
+| Obsolete
 |-
 | [[bip-0126.mediawiki|126]]
 |

--- a/bip-0125.mediawiki
+++ b/bip-0125.mediawiki
@@ -6,7 +6,7 @@
           Peter Todd <pete@petertodd.org>
   Comments-Summary: No comments yet.
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0125
-  Status: Proposed
+  Status: Obsolete
   Type: Standards Track
   Created: 2015-12-04
   License: PD


### PR DESCRIPTION
BIP125 has been in Accepted / Proposed status since at least 8 years and could use a status update.

At the same time, the network appears to have largely adopted full RBF by default. See https://github.com/bitcoin/bitcoin/pull/30493 and https://github.com/bitcoin/bitcoin/pull/30592.

Perhaps this BIP should be updated from Proposed to one of Final, Replaced, or Obsolete. 

Update: Obsolete chosen, per author feedback.