### PR TITLE
BIP373: Clarify where keys in MuSig fields may appear in the Taproot output

### DIFF
--- a/bip-0373.mediawiki
+++ b/bip-0373.mediawiki
@@ -59,9 +59,9 @@ to identify master keys, and these fingerprints require full compressed public k
 the aggregate key as a full public key, signers that are unaware of the MuSig2 outside of the PSBT
 will still be able to identify which keys are derived from the aggregate key by computing and then
 comparing the fingerprints. This is necessary for the signer to apply the correct tweaks to their
-partial signature.</ref> from the <tt>KeyAgg</tt> algorithm. This key may or may not
-be in the script directly (as x-only). It may instead be a parent public key from which the public keys in the
-script were derived.
+partial signature.</ref> from the <tt>KeyAgg</tt> algorithm. This key may or may not appear
+(as x-only) in the Taproot output key, the internal key, or in a script. It may instead be a parent public
+key from which the Taproot output key, internal key, or keys in a script were derived.
 | A list of the compressed public keys of the participants in the MuSig2 aggregate key in the order
 required for aggregation. If sorting was done, then the keys must be in the sorted order.
 |-
@@ -75,10 +75,10 @@ required for aggregation. If sorting was done, then the keys must be in the sort
 |-
 | The compressed public key of the participant providing this nonce, followed by the plain public
 key the participant is providing the nonce for, followed by the BIP 341 tapleaf hash of
-the Taproot leaf script that will be signed. If the aggregate key is the taproot internal key or the
-taproot output key, then the tapleaf hash must be omitted. The plain public key must be
-the key found in the script and not the aggregate public key that it was derived from, if it was
-derived from an aggregate key.
+the Taproot leaf script that will be signed. If the aggregate key is the Taproot internal key or the
+Taproot output key, then the tapleaf hash must be omitted. The plain public key must be
+the Taproot output key or found in a script. It is not the internal key nor the aggregate public key that
+it was derived from, if it was derived from an aggregate key.
 | The public nonce produced by the <tt>NonceGen</tt> algorithm.
 |-
 | rowspan="2"|MuSig2 Participant Partial Signature
@@ -91,10 +91,10 @@ derived from an aggregate key.
 |-
 | The compressed public key of the participant providing this partial signature, followed by the
 plain public key the participant is providing the signature for, followed by the BIP 341 tapleaf hash
-of the Taproot leaf script that will be signed. If the aggregate key is the taproot internal key or
-the taproot output key, then the tapleaf hash must be omitted. Note that the plain public key must
-be the key found in the script and not the aggregate public key that it was derived from, if it was
-derived from an aggregate key.
+of the Taproot leaf script that will be signed. If the aggregate key is the Taproot internal key or
+the Taproot output key, then the tapleaf hash must be omitted. Note that the plain public key must be
+the Taproot output key or found in a script. It is not the internal key nor the aggregate public key that
+it was derived from, if it was derived from an aggregate key.
 | The partial signature produced by the <tt>Sign</tt> algorithm.
 |}
 
@@ -118,8 +118,8 @@ The new per-output types are defined as follows:
 | rowspan="2"|0, 2
 |-
 | The MuSig2 aggregate plain public key from the <tt>KeyAgg</tt> algorithm. This key may or may not
-be in the script directly. It may instead be a parent public key from which the public keys in the
-script were derived.
+appear (as x-only) in the Taproot output key, the internal key, or in a script. It may instead be a parent
+public key from which the Taproot output key, internal key, or keys in a script were derived.
 | A list of the compressed public keys of the participants in the MuSig2 aggregate key in the order
 required for aggregation. If sorting was done, then the keys must be in the sorted order.
 |}


### PR DESCRIPTION
- The aggregate pubkey in `PSBT_{IN,OUT}_MUSIG2_PARTICIPANT_PUBKEYS` does not have to appear anywhere in the Taproot output.
- The plain pubkeys in `PSBT_IN_MUSIG2_PUB_NONCE` and `PSBT_IN_MUSIG2_PARTIAL_SIG` must be either the output pubkey, or appears in a script, and not the internal key.