### PR TITLE
Updated grammatical error relating to Forwarding Addresses

### DIFF
--- a/bip-0119.mediawiki
+++ b/bip-0119.mediawiki
@@ -503,7 +503,7 @@ For example, a exchange's hot wallet might use an address which can automaticall
 storage address after a relative timeout.
 
 The issue is that reusing addresses in this way can lead to loss of funds.
-Suppose one creates an template address which forwards 1 BTC to cold storage.
+Suppose one creates a template address which forwards 1 BTC to cold storage.
 Creating an output to this address with less than 1 BTC will be frozen permanently.
 Paying more than 1 BTC will lead to the funds in excess of 1BTC to be paid as a large miner fee.
 CHECKTEMPLATEVERIFY could commit to the exact amount of bitcoin provided by the inputs/amount of fee


### PR DESCRIPTION
Second sentence in the second paragraph of the Forwarding Addresses section, had a slight grammatical error that needed correcting. 

Helpful for the flurry of interested people keen on reviewing the BIP (i.e. Institutions, non-English nation-states)