### PR TITLE
BIP-373: denote different public key types/purposes consistently

### DIFF
--- a/bip-0373.mediawiki
+++ b/bip-0373.mediawiki
@@ -45,17 +45,18 @@ The new per-input types are defined as follows:
 |-
 | rowspan="2"|MuSig2 Participant Public Keys
 | rowspan="2"|<tt>PSBT_IN_MUSIG2_PARTICIPANT_PUBKEYS = 0x1a</tt>
-| <tt><33 byte plain aggregate pubkey></tt>
-| <tt><33 byte compressed pubkey>*</tt>
+| <tt><33 byte aggregate pubkey (compressed)></tt>
+| <tt><33 byte participant pubkey (compressed)>*</tt>
 | rowspan="2"|
 | rowspan="2"|
 | rowspan="2"| 0, 2
 |-
-| The MuSig2 aggregate plain public key<ref>'''Why the plain aggregate public key instead of x-only?'''
+| The MuSig2 aggregate public key (compressed) <ref>'''Why the compressed aggregate public key instead of x-only?'''
 BIP 32 requires public keys to include their evenness byte. Aggregate public keys are expected to be
 derived from, following [[bip-0328.mediawiki|BIP 328]], and therefore will
 need to include the evenness. Furthermore, PSBT_IN_TAP_BIP32_DERIVATION fields include fingerprints
-to identify master keys, and these fingerprints require full compressed public keys. By including
+to identify master keys, and these fingerprints require y-coordinate of the public key,
+so x-only serialization can't be used. By including
 the aggregate key as a full public key, signers that are unaware of the MuSig2 outside of the PSBT
 will still be able to identify which keys are derived from the aggregate key by computing and then
 comparing the fingerprints. This is necessary for the signer to apply the correct tweaks to their
@@ -67,32 +68,32 @@ required for aggregation. If sorting was done, then the keys must be in the sort
 |-
 | rowspan="2"|MuSig2 Public Nonce
 | rowspan="2"|<tt>PSBT_IN_MUSIG2_PUB_NONCE = 0x1b</tt>
-| <tt><33 byte compressed pubkey> <33 byte plain pubkey> <32 byte hash or omitted></tt>
+| <tt><33 byte participant pubkey (compressed)> <33 byte aggregate pubkey (compressed)> <32 byte hash or omitted></tt>
 | <tt><66 byte public nonce></tt>
 | rowspan="2"|
 | rowspan="2"|
 | rowspan="2"| 0, 2
 |-
-| The compressed public key of the participant providing this nonce, followed by the plain public
+| The compressed public key of the participant providing this nonce, followed by the compressed aggregate public
 key the participant is providing the nonce for, followed by the BIP 341 tapleaf hash of
 the Taproot leaf script that will be signed. If the aggregate key is the Taproot internal key or the
-Taproot output key, then the tapleaf hash must be omitted. The plain public key must be
+Taproot output key, then the tapleaf hash must be omitted. The compressed participant public key must be
 the Taproot output key or found in a script. It is not the internal key nor the aggregate public key that
 it was derived from, if it was derived from an aggregate key.
 | The public nonce produced by the <tt>NonceGen</tt> algorithm.
 |-
 | rowspan="2"|MuSig2 Participant Partial Signature
 | rowspan="2"|<tt>PSBT_IN_MUSIG2_PARTIAL_SIG = 0x1c</tt>
-| <tt><33 byte compressed pubkey> <33 byte plain pubkey> <32 byte hash or omitted></tt>
+| <tt><33 byte participant pubkey (compressed)> <33 byte aggregate pubkey (compressed)> <32 byte hash or omitted></tt>
 | <tt><32 byte partial signature></tt>
 | rowspan="2"|
 | rowspan="2"|
 | rowspan="2"| 0, 2
 |-
 | The compressed public key of the participant providing this partial signature, followed by the
-plain public key the participant is providing the signature for, followed by the BIP 341 tapleaf hash
+compressed public key the participant is providing the signature for, followed by the BIP 341 tapleaf hash
 of the Taproot leaf script that will be signed. If the aggregate key is the Taproot internal key or
-the Taproot output key, then the tapleaf hash must be omitted. Note that the plain public key must be
+the Taproot output key, then the tapleaf hash must be omitted. Note that the compressed participant public key must be
 the Taproot output key or found in a script. It is not the internal key nor the aggregate public key that
 it was derived from, if it was derived from an aggregate key.
 | The partial signature produced by the <tt>Sign</tt> algorithm.
@@ -111,13 +112,13 @@ The new per-output types are defined as follows:
 |-
 | rowspan="2"|MuSig2 Participant Public Keys
 | rowspan="2"|<tt>PSBT_OUT_MUSIG2_PARTICIPANT_PUBKEYS = 0x08</tt>
-| <tt><33 byte compressed pubkey></tt>
-| <tt><33 byte compressed pubkey>*</tt>
+| <tt><33 byte aggregate pubkey (compressed)></tt>
+| <tt><33 byte participant pubkey (compressed)>*</tt>
 | rowspan="2"|
 | rowspan="2"|
 | rowspan="2"|0, 2
 |-
-| The MuSig2 aggregate plain public key from the <tt>KeyAgg</tt> algorithm. This key may or may not
+| The MuSig2 compressed aggregate public key from the <tt>KeyAgg</tt> algorithm. This key may or may not
 appear (as x-only) in the Taproot output key, the internal key, or in a script. It may instead be a parent
 public key from which the Taproot output key, internal key, or keys in a script were derived.
 | A list of the compressed public keys of the participants in the MuSig2 aggregate key in the order


### PR DESCRIPTION
While reviewing https://github.com/bitcoin/bitcoin/pull/31247 a while ago I noticed that the mentioned public keys in the PSBT fields of this BIP are quite confusing. This is mostly due to a non-consistent mention of types (plain vs. x-only) and a purpose that is sometimes missing. This PR aims to improve this in the following ways:
- be specific about the purpose of pubkey types in PSBT fields ("plain pubkey" alone doesn't say a lot, especially if it's used repeatedly within a field; explicitly call it "aggregate pubkey" or "participant pubkey" if applicable)
- replace all uses of "plain pubkey" by "compressed pubkey" (the only category that should matter is whether the pubkey type is "x-only" or "plain")
- use consistent word order, e.g. prefer "compressed aggregate public key" over "aggregate compressed public key"

Another possibility would be to even get rid of the "plain/compressed" terminology completely. From the fact that "x-only" is not explicitly mentioned and the size of 33 bytes it should be obvious that this is a plain public key.