### PR TITLE
BIP352: Add support for Pay-to-Anchor (P2A) in get_pubkey_from_input

### DIFF
--- a/bip-0352/reference.py
+++ b/bip-0352/reference.py
@@ -78,6 +78,11 @@ def get_pubkey_from_input(vin: VinInfo) -> ECPubKey:
             pubkey = ECPubKey().set(vin.prevout[2:])
             if (pubkey.valid) & (pubkey.compressed):
                 return pubkey
+    if is_p2a(vin.prevout): 
+        anchor_script = vin.scriptSig[1:] 
+        pubkey = ECPubKey().set(anchor_script)
+        if (pubkey.valid) & (pubkey.compressed): 
+                return pubkey
 
 
     return ECPubKey()


### PR DESCRIPTION
This commit adds a conditional statement to the get_pubkey_from_input function to handle Pay-to-Anchor (P2A) address types. The function now checks if the previous output is a P2A address type and extracts the public key from the anchor_script. This update ensures compatibility with the Bitcoin protocol for P2A address types and enhances the function's versatility in processing various address types.