### PR TITLE
BIP125: update status to Final

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -679,13 +679,13 @@ Those proposing changes should consider that ultimately consent may rest with th
 | Eric Lombrozo, William Swanson
 | Informational
 | Rejected
-|- style="background-color: #ffcfcf"
+|- style="background-color: #cfffcf"
 | [[bip-0125.mediawiki|125]]
 | Applications
 | Opt-in Full Replace-by-Fee Signaling
 | David A. Harding, Peter Todd
 | Standard
-| Obsolete
+| Final
 |-
 | [[bip-0126.mediawiki|126]]
 |

--- a/bip-0125.mediawiki
+++ b/bip-0125.mediawiki
@@ -6,7 +6,7 @@
           Peter Todd <pete@petertodd.org>
   Comments-Summary: No comments yet.
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0125
-  Status: Obsolete
+  Status: Final
   Type: Standards Track
   Created: 2015-12-04
   License: PD


### PR DESCRIPTION
Discussing #1692 with @luke-jr, realized that we may not have followed BIP2 process when updating BIP125 from Proposed to Obsolete.

Per BIP2:

"A Proposed BIP may progress to Final only when specific criteria reflecting real-world adoption has occurred."

"When a Final BIP is no longer relevant, its status may be changed to Replaced or Obsolete (which is equivalent to Replaced). This change must also be objectively verifiable and/or discussed."

BIP125 saw real-world adoption, so it would make sense to update it from Proposed to Final. But arguably not from Proposed to Replaced/Obsolete as done in #1692, as it was not final, not replaced by another BIP, and still relevant (also supported in at least one bitcoin implementation).

