### PR TITLE
Fix typos in BIP-0370 and BIP-0373

### DIFF
--- a/bip-0370.mediawiki
+++ b/bip-0370.mediawiki
@@ -42,7 +42,7 @@ PSBT Version 2 (PSBTv2) only specifies new fields and field inclusion/exclusion 
 <tt>PSBT_GLOBAL_UNSIGNED_TX</tt> must be excluded in PSBTv2.
 <tt>PSBT_GLOBAL_VERSION</tt> must be included in PSBTv2 and set to version number 2<ref>'''What happened to version number 1?'''
 Version number 1 is skipped because PSBT Version 0 has been colloquially referred to as version 1. Originally this BIP was to be
-version 1, but because it has been colloquially referred to as version 2 during its design phrase, it was decided to change the
+version 1, but because it has been colloquially referred to as version 2 during its design phase, it was decided to change the
 version number to 2 so that there would not be any confusion</ref>.
 
 The new global types for PSBT Version 2 are as follows:

--- a/bip-0373.mediawiki
+++ b/bip-0373.mediawiki
@@ -130,7 +130,7 @@ required for aggregation. If sorting was done, then the keys must be in the sort
 ===Updater===
 
 When an updater observes a Taproot output which involves a MuSig2 aggregate public key that it is
-aware if, it can add a <tt>PSBT_IN_MUSIG2_PARTICIPANT_PUBKEYS</tt> field containing the public keys
+aware of, it can add a <tt>PSBT_IN_MUSIG2_PARTICIPANT_PUBKEYS</tt> field containing the public keys
 of the participants. This aggregate public key may be directly in the script, the Taproot internal
 key, the Taproot output key, or a public key from which the key in the script was derived from.
 
@@ -171,7 +171,7 @@ partial signature for their key. The result will be added to the PSBT in a
 <tt>PSBT_IN_MUSIG2_PARTIAL_SIG</tt> field.
 
 Signers must remember to apply any relevant tweaks such as a tweak that is the result of performing
-BIP 32 unhardened dervation with the aggregate public key as the parent key.
+BIP 32 unhardened derivation with the aggregate public key as the parent key.
 
 If all other signers have provided a <tt>PSBT_IN_MUSIG2_PARTIAL_SIG</tt>, then the final signer may
 perform the <tt>PartialSigAgg</tt> algorithm and produce a BIP 340 compatible signature that can be


### PR DESCRIPTION


This PR fixes several typographical errors in two BIP documents.

Changes in bip-0370.mediawiki:
- "phrase" → "phase"
  - Corrects the usage of "design phrase" to "design phase", as "phase" is the correct term for a stage or period in a process

Changes in bip-0373.mediawiki:
- "dervation" → "derivation"
  - Fixes misspelling of "derivation" in the context of BIP32 key derivation
- "if," → "of,"
  - Corrects grammatical error in the sentence about PSBT field awareness

Rationale:
These changes improve the technical accuracy and readability of the documentation:
1. "Phase" is the correct term for describing a stage in the design process
2. "Derivation" is the proper technical term for BIP32 key generation
3. "Of" is the correct preposition in the context of being aware of something

