### PR TITLE
Minor spelling/grammar fixups in BIPs 372 and 381

### DIFF
--- a/bip-0372.mediawiki
+++ b/bip-0372.mediawiki
@@ -121,7 +121,7 @@ P2C tweaks commit to external data, some of which may represent certain value
 (like in some sidechains, single-use-seal applications like RGB etc). Creation
 of such outputs much allow hardware devices to understand the structure of such
 extra-transaction data, which may be in different formats and constantly
-involve. Thus, this should be addresses with a separate standards (or be a
+evolve. Thus, this should be addressed with a separate standards (or be a
 vendor-based). The current proposal only touches the question of spending an
 output which contained previously created P2C commitment, which does not creates
 a new commitment and does not provides that kind of risk of extra-blockchain
@@ -181,7 +181,7 @@ TBD
     Timestamping with Bitcoin.
     <https://petertodd.org/2016/opentimestamps-announcement>
 [4] Adam Back, Matt Corallo, Luke Dashjr, et al. Enabling Blockchain
-    Innovations with Pegged Sidechains (commit5620e43). Appenxix A.
+    Innovations with Pegged Sidechains (commit5620e43). Appendix A.
     <https://blockstream.com/sidechains.pdf>;.
 [5] Maxim Orlovsky, Rene Pickhardt, Federico Tenga, et al. Key
     tweaking: collision- resistant elliptic curve-based commitments.

--- a/bip-0381.mediawiki
+++ b/bip-0381.mediawiki
@@ -111,7 +111,7 @@ Invalid descriptors
 
 * <tt>pk()</tt> only accepts key expressions: <tt>pk(pk(03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd))</tt>
 * <tt>pkh()</tt> only accepts key expressions: <tt>pkh(pk(03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd))</tt>
-* <tt>sh()</tt> only acceps script expressions: <tt>sh(03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd)</tt>
+* <tt>sh()</tt> only accepts script expressions: <tt>sh(03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd)</tt>
 * <tt>sh()</tt> is top level only: <tt>sh(sh(pkh(03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd)))</tt>
 
 ==Backwards Compatibility==

--- a/bip-0384.mediawiki
+++ b/bip-0384.mediawiki
@@ -71,7 +71,7 @@ Invalid descriptors
 ==Backwards Compatibility==
 
 <tt>combo()</tt> descriptors use the format and general operation specified in [[bip-0380.mediawiki|380]].
-As this is a wholly new descriptor, it is not compatible with any implementation.
+As this is a wholly new descriptor, it is not compatible with any implementations.
 However the scripts produced are standard scripts so existing software are likely to be familiar with them.
 
 ==Reference Implementation==


### PR DESCRIPTION
Changes to bip-0372.mediawiki:

"involve" → "evolve"
Corrects word choice as "evolve" better describes the progressive development of standards

"addresses" → "addressed"
Fixes verb tense to match the passive voice construction

"Appenxix" → "Appendix"
Fixes misspelling of "Appendix"

---

Changes to bip-0381.mediawiki:

"acceps" → "accepts"
Fixes misspelling of "accepts"

---

Changes to bip-0384.mediawiki:

"implementation" → "implementations"
Changes to plural form as it refers to multiple possible implementations