### PR TITLE
BIP39: fix word in Italian wordlist special considerations

### DIFF
--- a/bip-0039/bip-0039-wordlists.md
+++ b/bip-0039/bip-0039-wordlists.md
@@ -76,7 +76,7 @@ Words chosen using the following rules:
 6. No plural words.
 7. No words that remind negative/sad/bad things.
 8. If both female/male words are available, choose male version.
-9. No words with double vocals (like: lineetta).
+9. No words with double vowels (like: lineetta).
 10. No words already used in other language mnemonic sets.
 11. If 3 of the first 4 letters are already used in the same sequence in another mnemonic word, there must be at least other 3 different letters.
 12. If 3 of the first 4 letters are already used in the same sequence in another mnemonic word, there must not be the same sequence of 3 or more letters.


### PR DESCRIPTION
Corrected terminology: "double vocals" → "double vowels"

### Explanation of Change:

1. The rule being described refers to spelling and letter patterns, specifically when two vowel letters appear together.
2. The term "vowels" is the proper linguistic term for such letters, while "vocals" is incorrect in this context.
3. The example "lineetta" demonstrates a double vowel pattern ('ee').