### PR TITLE
BIP158: fix btcutil gcs broken link.

### DIFF
--- a/bip-0158.mediawiki
+++ b/bip-0158.mediawiki
@@ -344,7 +344,7 @@ Light client: [https://github.com/lightninglabs/neutrino]
 
 Full-node indexing: https://github.com/Roasbeef/btcd/tree/segwit-cbf
 
-Golomb-Rice Coded sets: https://github.com/btcsuite/btcutil/blob/master/gcs
+Golomb-Rice Coded sets: https://github.com/btcsuite/btcd/tree/master/btcutil/gcs
 
 == Appendix A: Alternatives ==
 


### PR DESCRIPTION
https://github.com/btcsuite/btcutil/blob/master/gcs leads to a broken link. I'm assuming the correct replacement is at https://github.com/btcsuite/btcd/tree/master/btcutil/gcs since `btcutil` is a sub-package in `btcd`, as stated in https://github.com/btcsuite/btcutil/tree/master?tab=readme-ov-file