### PR TITLE
BIP-340: fix `lift_x` calls in test vector generation script

### DIFF
--- a/bip-0340/test-vectors.py
+++ b/bip-0340/test-vectors.py
@@ -27,14 +27,14 @@ def vector0():
     # we should have at least one test vector where the point reconstructed
     # from the public key has a square and one where it has a non-square Y
     # coordinate. In this one Y is non-square.
-    pubkey_point = lift_x(pubkey)
+    pubkey_point = lift_x(int_from_bytes(pubkey))
     assert(not has_square_y(pubkey_point))
 
     # For historical reasons (R tiebreaker was squareness and not evenness)
     # we should have at least one test vector where the point reconstructed
     # from the R.x coordinate has a square and one where it has a non-square Y
     # coordinate. In this one Y is non-square.
-    R = lift_x(sig[0:32])
+    R = lift_x(int_from_bytes(sig[0:32]))
     assert(not has_square_y(R))
 
     return (seckey, pubkey, aux_rand, msg, sig, "TRUE", None)
@@ -47,7 +47,7 @@ def vector1():
     sig = schnorr_sign(msg, seckey, aux_rand)
 
     # The point reconstructed from the R.x coordinate has a square Y coordinate.
-    R = lift_x(sig[0:32])
+    R = lift_x(int_from_bytes(sig[0:32]))
     assert(has_square_y(R))
 
     return (seckey, pubkey_gen(seckey), aux_rand, msg, sig, "TRUE", None)
@@ -60,12 +60,12 @@ def vector2():
 
     # The point reconstructed from the public key has a square Y coordinate.
     pubkey = pubkey_gen(seckey)
-    pubkey_point = lift_x(pubkey)
+    pubkey_point = lift_x(int_from_bytes(pubkey))
     assert(has_square_y(pubkey_point))
 
     # This signature vector would not verify if the implementer checked the
     # evenness of the X coordinate of R instead of the Y coordinate.
-    R = lift_x(sig[0:32])
+    R = lift_x(int_from_bytes(sig[0:32]))
     assert(R[0] % 2 == 1)
 
     return (seckey, pubkey, aux_rand, msg, sig, "TRUE", None)
@@ -119,8 +119,9 @@ def vector5():
     msg = default_msg
     sig = schnorr_sign(msg, seckey, default_aux_rand)
 
-    pubkey = bytes_from_int(0xEEFDEA4CDB677750A420FEE807EACF21EB9898AE79B9768766E4FAA04A2D4A34)
-    assert(lift_x(pubkey) is None)
+    pubkey_int = 0xEEFDEA4CDB677750A420FEE807EACF21EB9898AE79B9768766E4FAA04A2D4A34
+    pubkey = bytes_from_int(pubkey_int)
+    assert(lift_x(pubkey_int) is None)
 
     return (None, pubkey, None, msg, sig, "FALSE", "public key not on the curve")
 
@@ -197,9 +198,9 @@ def vector11():
     sig = schnorr_sign(msg, seckey, default_aux_rand)
 
     # Replace R's X coordinate with an X coordinate that's not on the curve
-    x_not_on_curve = bytes_from_int(0x4A298DACAE57395A15D0795DDBFD1DCB564DA82B0F269BC70A74F8220429BA1D)
+    x_not_on_curve = 0x4A298DACAE57395A15D0795DDBFD1DCB564DA82B0F269BC70A74F8220429BA1D
     assert(lift_x(x_not_on_curve) is None)
-    sig = x_not_on_curve + sig[32:64]
+    sig = bytes_from_int(x_not_on_curve) + sig[32:64]
 
     return (None, pubkey_gen(seckey), None, msg, sig, "FALSE", "sig[0:32] is not an X coordinate on the curve")
 
@@ -242,10 +243,10 @@ def vector14():
     sig = schnorr_sign(msg, seckey, default_aux_rand)
     pubkey_int = p + 1
     pubkey = bytes_from_int(pubkey_int)
-    assert(lift_x(pubkey) is None)
+    assert(lift_x(pubkey_int) is None)
     # If an implementation would reduce a given public key modulo p then the
     # pubkey would be valid
-    assert(lift_x(bytes_from_int(pubkey_int % p)) is not None)
+    assert(lift_x(pubkey_int % p) is not None)
 
     return (None, pubkey, None, msg, sig, "FALSE", "public key is not a valid X coordinate because it exceeds the field size")
 


### PR DESCRIPTION
The `lift_x` function in the BIP and the reference implementation expect an integer to be passed rather than a byte array.

Can be tested with:
```
$ python3 test-vectors.py > expected.csv
$ diff test-vectors.csv expected.csv
```
On master, the first call fails with
```
Traceback (most recent call last):
  File "/home/thestack/bips/bip-0340/test-vectors.py", line 267, in <module>
    vector0(),
    ^^^^^^^^^
  File "/home/thestack/bips/bip-0340/test-vectors.py", line 30, in vector0
    pubkey_point = lift_x(pubkey)
                   ^^^^^^^^^^^^^^
  File "/home/thestack/bips/bip-0340/reference.py", line 72, in lift_x
    if x >= p:
       ^^^^^^
TypeError: '>=' not supported between instances of 'bytes' and 'int'
```