### PR TITLE
BIP374: update reference.py and secp256k1.py to be executable

### DIFF
--- a/bip-0374/reference.py
+++ b/bip-0374/reference.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 """Reference implementation of DLEQ BIP for secp256k1 with unit tests."""
 
 from hashlib import sha256

--- a/bip-0374/secp256k1.py
+++ b/bip-0374/secp256k1.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2022-2023 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.


### PR DESCRIPTION
by adding to each a python shebang and changing their file permissions from 644 to 755, as mentioned in https://github.com/bitcoin/bips/pull/1734#issuecomment-2564476828.

These files don't need to be executable in order to run `gen_test_vectors.py` and `run_test_vectors.py` but it is helpful to allow developers to invoke them directly.
 
Before:

```bash
$ ./reference.py 
zsh: permission denied: ./reference.py
```

After:

```bash
$ ./reference.py 
```
