### PR TITLE
Update BIP-352 status to Final

### DIFF
--- a/bip-0352.mediawiki
+++ b/bip-0352.mediawiki
@@ -5,7 +5,7 @@
   Author: josibake <josibake@protonmail.com>
           Ruben Somsen <rsomsen@gmail.com>
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0352
-  Status: Proposed
+  Status: Final
   Type: Standards Track
   Created: 2023-03-09
   License: BSD-2-Clause


### PR DESCRIPTION
Changed the status of BIP-352 from Proposed to Final to reflect its acceptance and finalization. This update marks the completion of the review process and the formal acceptance of the proposal.