### PR TITLE
Update README.mediawiki to reflect BIP-352 status change to Final

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1154,7 +1154,7 @@ Those proposing changes should consider that ultimately consent may rest with th
 | Silent Payments
 | josibake, Ruben Somsen
 | Standard
-| Proposed
+| Final
 |-
 | [[bip-0353.mediawiki|353]]
 | Applications


### PR DESCRIPTION
Updated the README.mediawiki file to reflect the status change of BIP-352 from Proposed to Final. This change ensures that the README accurately reflects the current status of the BIP.