### PR TITLE
BIP345: fix OP_SUCCESS188 hex value

### DIFF
--- a/bip-0345.mediawiki
+++ b/bip-0345.mediawiki
@@ -289,7 +289,7 @@ If none of the conditions fail, a single true value (<code>0x01</code>) is left 
 === <code>OP_VAULT_RECOVER</code> evaluation ===
 
 When evaluating <code>OP_VAULT_RECOVER</code> (<code>OP_SUCCESS188</code>,
-<code>0xbb</code>), the expected format of the stack, shown top to bottom, is:
+<code>0xbc</code>), the expected format of the stack, shown top to bottom, is:
 
 <source>
 <recovery-sPK-hash>


### PR DESCRIPTION
`OP_SUCCESS188` is `0xbc`, not `0xbb`.