### PR TITLE
BIP388: Fix incorrect use of return for raising exception

### DIFF
--- a/bip-0388/wallet_policies.py
+++ b/bip-0388/wallet_policies.py
@@ -68,7 +68,7 @@ class WalletPolicy(object):
 
         # there should not be any remaining "@" expressions
         if desc.find("@") != -1:
-            return Exception("Invalid descriptor template: contains invalid key index")
+            raise Exception("Invalid descriptor template: contains invalid key index")
 
         return desc
 


### PR DESCRIPTION
`return` was being used incorrectly to handle an exception. Instead of returning the exception, it should be raised using `raise`.
