### PR TITLE
BIPs 174 and 375: fix PSBT_OUT_SP_V0_LABEL value

### DIFF
--- a/bip-0174.mediawiki
+++ b/bip-0174.mediawiki
@@ -715,7 +715,7 @@ required for aggregation. If sorting was done, then the keys must be in the sort
 | [[bip-0375.mediawiki|375]]
 |-
 | Silent Payment Label
-| <tt>PSBT_OUT_SP_V0_LABEL = 0x10</tt>
+| <tt>PSBT_OUT_SP_V0_LABEL = 0x0a</tt>
 | None
 | No key data
 | <tt><32-bit little endian uint label></tt>

--- a/bip-0375.mediawiki
+++ b/bip-0375.mediawiki
@@ -128,7 +128,7 @@ The new per-output types are defined as follows:
 | 2
 |-
 | Silent Payment Label
-| <tt>PSBT_OUT_SP_V0_LABEL = 0x10</tt>
+| <tt>PSBT_OUT_SP_V0_LABEL = 0x0a</tt>
 | None
 | No key data
 | <tt><32-bit little endian uint label></tt>


### PR DESCRIPTION
Assuming a by one increment in the keytype of the silent payments output fields, the following numeral to 0x09 in the hexadecimal system is 0x0a, not 0x10.