### PR TITLE
Render author email addresses in markdown BIPs

### DIFF
--- a/bip-0348.md
+++ b/bip-0348.md
@@ -1,4 +1,4 @@
-<pre>
+```
   BIP: 348
   Layer: Consensus (soft fork)
   Title: CHECKSIGFROMSTACK
@@ -9,7 +9,7 @@
   Type: Standards Track
   Created: 2024-11-26
   License: BSD-3-Clause
-</pre>
+```
 
 ## Abstract
 

--- a/bip-0349.md
+++ b/bip-0349.md
@@ -1,4 +1,4 @@
-<pre>
+```
   BIP: 349
   Layer: Consensus (soft fork)
   Title: OP_INTERNALKEY
@@ -9,7 +9,7 @@
   Type: Standards Track
   Created: 2024-11-14
   License: BSD-3-Clause
-</pre>
+```
 
 ## Abstract
 

--- a/bip-0379.md
+++ b/bip-0379.md
@@ -1,4 +1,4 @@
-<pre>
+```
   BIP: 379
   Layer: Applications
   Title: Miniscript
@@ -13,7 +13,7 @@
   Type: Informational
   Created: 2023-10-10
   License: CC0-1.0
-</pre>
+```
 
 ## Abstract
 


### PR DESCRIPTION
@ajtowns pointed out in his [BIP 3 review]( https://github.com/bitcoin/bips/pull/1712#discussion_r1946113305) that the author email addresses in the preamble of BIPs in markdown format were not being rendered.