### PR TITLE
fix: Improve get_second_key security by removing zero key return

### DIFF
--- a/bip-0327/reference.py
+++ b/bip-0327/reference.py
@@ -211,11 +211,13 @@ def hash_keys(pubkeys: List[PlainPk]) -> bytes:
     return tagged_hash('KeyAgg list', b''.join(pubkeys))
 
 def get_second_key(pubkeys: List[PlainPk]) -> PlainPk:
+    if not pubkeys:
+        raise ValueError('The pubkeys list cannot be empty.')
     u = len(pubkeys)
     for j in range(1, u):
         if pubkeys[j] != pubkeys[0]:
             return pubkeys[j]
-    return PlainPk(b'\x00'*33)
+    raise InvalidContributionError(0, "pubkey")  # All keys are the same
 
 def key_agg_coeff(pubkeys: List[PlainPk], pk_: PlainPk) -> int:
     pk2 = get_second_key(pubkeys)


### PR DESCRIPTION
- Add empty list check with ValueError
- Replace zero key return with InvalidContributionError for identical keys
- Prevent potential cryptographic vulnerabilities from zero key usage