### PR TITLE
390: Fix created date

### DIFF
--- a/bip-0390.mediawiki
+++ b/bip-0390.mediawiki
@@ -7,7 +7,7 @@
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0390
   Status: Draft
   Type: Informational
-  Created: 2024-01-15
+  Created: 2024-06-04
   License: CC0-1.0
 </pre>
 


### PR DESCRIPTION
BIP 390 was assigned on [2024-06-04](https://github.com/bitcoin/bips/pull/1540#pullrequestreview-2097428451)