### PR TITLE
BIP374: fix division logic in __truediv__ method of FE class

### DIFF
--- a/bip-0374/secp256k1.py
+++ b/bip-0374/secp256k1.py
@@ -80,7 +80,7 @@ class FE:
 
     def __truediv__(self, a):
         """Compute the ratio of two field elements (second may be int)."""
-        return FE(self, a)
+        return FE(self._num, self._den * a)
 
     def __pow__(self, a):
         """Raise a field element to an integer power."""


### PR DESCRIPTION
I noticed an issue in the `__truediv__` method of the `FE` class where the division was being performed incorrectly. The method was returning `FE(self, a)`, which doesn’t account for the numerator and denominator fields (`_num` and `_den`). 

To fix this, I’ve updated the code to return `FE(self._num, self._den * a)`, which properly creates a new `FE` object with the same numerator and the denominator multiplied by the given argument `a`.
