### PR TITLE
BIP158: minor error message fixup in `gentestvectors.go`

### DIFF
--- a/bip-0158/gentestvectors.go
+++ b/bip-0158/gentestvectors.go
@@ -2,7 +2,7 @@
 // 5 blocks and collision space sizes of 1-32 bits. Change the RPC cert path
 // and credentials to run on your system. The program assumes you're running
 // a btcd with cfilter support, which mainline btcd doesn't have; in order to
-// circumvent this assumption, comment out the if block that checks for
+// circumvent this assumption, comment out the if block that checks the
 // filter size of DefaultP.
 
 package main
@@ -193,7 +193,7 @@ func main() {
 
 		block, err := client.GetBlock(blockHash)
 		if err != nil {
-			fmt.Println("Couldn't get block hash: ", err.Error())
+			fmt.Println("Couldn't get block data: ", err.Error())
 			return
 		}
 


### PR DESCRIPTION
Fix up error message:
  - `"Couldn't get block hash"` → `"Couldn't get block data"` for better clarity

Also minor grammar edit in code comment:
  - `"checks for filter size of DefaultP"` → `"checks the filter size of DefaultP"`
  
