### PR TITLE
BIP379: add missing hexadecimal notations

### DIFF
--- a/bip-0379.md
+++ b/bip-0379.md
@@ -83,10 +83,10 @@ Miniscript is not a separate language, but rather a significant expansion of the
 |                                                          | `pkh(key)` = `c:pk_h(key)`    | `DUP HASH160 <HASH160(key)> EQUALVERIFY CHECKSIG`
 | nSequence ≥ n (and compatible)                           | `older(n)`                    | `<n> CHECKSEQUENCEVERIFY`
 | nLockTime ≥ n (and compatible)                           | `after(n)`                    | `<n> CHECKLOCKTIMEVERIFY`
-| len(x) = 32 and SHA256(x) = h                            | `sha256(h)`                   | `SIZE 32 EQUALVERIFY SHA256 <h> EQUAL`
-| len(x) = 32 and HASH256(x) = h                           | `hash256(h)`                  | `SIZE 32 EQUALVERIFY HASH256 <h> EQUAL`
-| len(x) = 32 and RIPEMD160(x) = h                         | `ripemd160(h)`                | `SIZE 32 EQUALVERIFY RIPEMD160 <h> EQUAL`
-| len(x) = 32 and HASH160(x) = h                           | `hash160(h)`                  | `SIZE 32 EQUALVERIFY HASH160 <h> EQUAL`
+| len(x) = 32 and SHA256(x) = h                            | `sha256(h)`                   | `SIZE <0x20> EQUALVERIFY SHA256 <h> EQUAL`
+| len(x) = 32 and HASH256(x) = h                           | `hash256(h)`                  | `SIZE <0x20> EQUALVERIFY HASH256 <h> EQUAL`
+| len(x) = 32 and RIPEMD160(x) = h                         | `ripemd160(h)`                | `SIZE <0x20> EQUALVERIFY RIPEMD160 <h> EQUAL`
+| len(x) = 32 and HASH160(x) = h                           | `hash160(h)`                  | `SIZE <0x20> EQUALVERIFY HASH160 <h> EQUAL`
 | (X and Y) or Z                                           | `andor(X,Y,Z)`                | `[X] NOTIF [Z] ELSE [Y] ENDIF`
 | X and Y                                                  | `and_v(X,Y)`                  | `[X] [Y]`
 |                                                          | `and_b(X,Y)`                  | `[X] [Y] BOOLAND`

--- a/bip-0379.md
+++ b/bip-0379.md
@@ -83,10 +83,10 @@ Miniscript is not a separate language, but rather a significant expansion of the
 |                                                          | `pkh(key)` = `c:pk_h(key)`    | `DUP HASH160 <HASH160(key)> EQUALVERIFY CHECKSIG`
 | nSequence ≥ n (and compatible)                           | `older(n)`                    | `<n> CHECKSEQUENCEVERIFY`
 | nLockTime ≥ n (and compatible)                           | `after(n)`                    | `<n> CHECKLOCKTIMEVERIFY`
-| len(x) = 32 and SHA256(x) = h                            | `sha256(h)`                   | `SIZE <20> EQUALVERIFY SHA256 <h> EQUAL`
-| len(x) = 32 and HASH256(x) = h                           | `hash256(h)`                  | `SIZE <20> EQUALVERIFY HASH256 <h> EQUAL`
-| len(x) = 32 and RIPEMD160(x) = h                         | `ripemd160(h)`                | `SIZE <20> EQUALVERIFY RIPEMD160 <h> EQUAL`
-| len(x) = 32 and HASH160(x) = h                           | `hash160(h)`                  | `SIZE <20> EQUALVERIFY HASH160 <h> EQUAL`
+| len(x) = 32 and SHA256(x) = h                            | `sha256(h)`                   | `SIZE 32 EQUALVERIFY SHA256 <h> EQUAL`
+| len(x) = 32 and HASH256(x) = h                           | `hash256(h)`                  | `SIZE 32 EQUALVERIFY HASH256 <h> EQUAL`
+| len(x) = 32 and RIPEMD160(x) = h                         | `ripemd160(h)`                | `SIZE 32 EQUALVERIFY RIPEMD160 <h> EQUAL`
+| len(x) = 32 and HASH160(x) = h                           | `hash160(h)`                  | `SIZE 32 EQUALVERIFY HASH160 <h> EQUAL`
 | (X and Y) or Z                                           | `andor(X,Y,Z)`                | `[X] NOTIF [Z] ELSE [Y] ENDIF`
 | X and Y                                                  | `and_v(X,Y)`                  | `[X] [Y]`
 |                                                          | `and_b(X,Y)`                  | `[X] [Y] BOOLAND`


### PR DESCRIPTION
Replace `SIZE <20> EQUALVERIFY` with `SIZE 32 EQUALVERIFY` for `sha256(h)`, `hash256(h)`, `ripemd160(h)`, and `hash160(h)`.  
`sha256`/`hash256` produce 32 bytes, not 20, so the original size check is incorrect.
