### PR TITLE
BIP374: add subtraction operator for GE class

### DIFF
--- a/bip-0374/reference.py
+++ b/bip-0374/reference.py
@@ -87,11 +87,10 @@ def dleq_verify_proof(
     s = int.from_bytes(proof[32:], "big")
     if s >= GE.ORDER:
         return False
-    # TODO: implement subtraction operator (__sub__) for GE class to simplify these terms
-    R1 = s * G + (-e * A)
+    R1 = s * G - e * A
     if R1.infinity:
         return False
-    R2 = s * B + (-e * C)
+    R2 = s * B - e * C
     if R2.infinity:
         return False
     if e != dleq_challenge(A, B, C, R1, R2, m, G):

--- a/bip-0374/secp256k1.py
+++ b/bip-0374/secp256k1.py
@@ -240,6 +240,10 @@ class GE:
             return self
         return GE(self.x, -self.y)
 
+    def __sub__(self, a):
+        """Subtract a group element from another."""
+        return self + (-a)
+
     def to_bytes_compressed(self):
         """Convert a non-infinite group element to 33-byte compressed encoding."""
         assert not self.infinity


### PR DESCRIPTION
This commit implements the subtraction operator (__sub__) for the GE (Group Element) class in the secp256k1.py file as requested in the TODO comment in reference.py.

The implementation is straightforward, leveraging the existing __neg__ method to define subtraction as addition with the negated element: self + (-a).

After implementing the operator, the code in reference.py was simplified by replacing expressions like:
s * G + (-e * A) with s * G - e * A

This makes the code more readable and directly matches the mathematical notation used in the BIP-0374 specification.