### PR TITLE
BIP119: appease typos linter

### DIFF
--- a/bip-0119.mediawiki
+++ b/bip-0119.mediawiki
@@ -591,7 +591,7 @@ OP_CHECKTEMPLATEVERIFY currently only verifies properties of 32 byte arguments.
 In the future, meaning could be ascribed to other length arguments. For
 example, a 33-byte argument could just the last byte as a control program. In
 that case, DefaultCheckTemplateVerifyHash could be computed when the flag byte
-is set to CTVHASH_ALL. Other programs could be added similar to SIGHASH_TYPEs.
+is set to CTVHASH_ALL. Other programs could be added similar to a SIGHASH_TYPE.
 For example, CTVHASH_GROUP could read data from the Taproot Annex for
 compatibility with SIGHASH_GROUP type proposals and allow dynamic malleability
 of which indexes get hashed for bundling.


### PR DESCRIPTION
The linter is raising with the following (e.g., in #1780 and #1783) that is resolved by this patch.

```bash
~/bitcoin/bips$ typos
error: `TYP` should be `TYPO`
  --> ./bip-0119.mediawiki:594:73
    |
594 | is set to CTVHASH_ALL. Other programs could be added similar to SIGHASH_TYPEs.
```
