### PR TITLE
BIP94 PR1781 editorial fixups

### DIFF
--- a/bip-0094.mediawiki
+++ b/bip-0094.mediawiki
@@ -101,13 +101,13 @@ The resulting genesis block hash is <code>00000000da84f2bafbbc53dee25a72ae507ff4
 
 The message start is defined as <code>0x1c163f28</code>. These four bytes were randomly generated and have no special meaning.
 
-=== Network Paramters ===
+=== Network Parameters ===
 
-The default p2p port for testnet 4 is `48333`.
+The default p2p port for Testnet 4 is `48333`.
 
 == Backwards Compatibility ==
 
-The rules used by Testnet 4 are backwards compatible to the rules of Testnet 3. Existing software that implements support for Testnet 3 would only require addition of the network parameters  (magic number, genesis block, etc.) to be able to follow Testnet 4. 
+The rules used by Testnet 4 are backwards compatible to the rules of Testnet 3. Existing software that implements support for Testnet 3 would only require addition of the network parameters  (magic number, genesis block, etc.) to be able to follow Testnet 4.
 
 However, implementations that only implement Testnet 3’s rules would accept a chain that violates Testnet 4’s rules and are therefore susceptible to being forked off. It is recommended that any implementations check blocks in regard to all the new rules of Testnet 4 and reject blocks that fail to comply.
 


### PR DESCRIPTION
Addresses https://github.com/bitcoin/bips/pull/1781#discussion_r1985677753 ("Parameters"), writes "Testnet 4" in the same manner as the BIP author, and removes an extra EOL space.