### PR TITLE
bip-0348: correct BIP number in referencing unknown key types

### DIFF
--- a/bip-0348.md
+++ b/bip-0348.md
@@ -129,8 +129,6 @@ This document is licensed under the 3-clause BSD license.
 
 [BIP 340]: https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki
 
-[BIP 341]: https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki
-
 [BIP 342]: https://github.com/bitcoin/bips/blob/master/bip-0342.mediawiki
 
 [BIP 349]: https://github.com/bitcoin/bips/blob/master/bip-0349.md

--- a/bip-0348.md
+++ b/bip-0348.md
@@ -28,7 +28,7 @@ message, and a signature. If the signature is valid for that public key and
 message, 1 is pushed to the stack. If the signature is the empty vector, 0 is
 pushed to the stack, and otherwise script execution fails.
 
-Only 32-byte keys are constrained. Similar to [BIP 341] unknown key types, for
+Only 32-byte keys are constrained. Similar to [BIP 342] unknown key types, for
 other key lengths no signature verification is performed and it is considered
 successful.
 


### PR DESCRIPTION
Unknown key types are defined as part of the Tapscript opcodes' semantics, in bip-0342. Not bip-0341.