### PR TITLE
BIPs 67 and 301: fix links

### DIFF
--- a/bip-0067.mediawiki
+++ b/bip-0067.mediawiki
@@ -126,7 +126,7 @@ The authors wish to thank BtcDrak and Luke-Jr for their involvement & contributi
 * [[https://github.com/bitpay/bitcore/blob/50a868cb8cdf2be04bb1c5bf4bcc064cc06f5888/lib/script/script.js#L541|Bitcore]]
 * [[https://github.com/haskoin/haskoin-core/blob/b41b1deb0989334a7ead6fc993fb8b02f0c00810/haskoin-core/Network/Haskoin/Script/Parser.hs#L112-L122|Haskoin]] - Bitcoin implementation in Haskell
 * [[https://github.com/etotheipi/BitcoinArmory/blob/268db0f3fa20c989057bd43343a43b2edbe89aeb/armoryengine/ArmoryUtils.py#L1441|Armory]]
-* [[https://github.com/bitcoinj/bitcoinj/blob/master/core/src/main/java/org/bitcoinj/script/ScriptBuilder.java#L331|BitcoinJ]]
+* [[https://github.com/bitcoinj/bitcoinj/blob/f7ea0b92a619800c143b0142dc70306da33119a9/core/src/main/java/org/bitcoinj/script/ScriptBuilder.java#L331|BitcoinJ]]
 
 == References ==
 <references>

--- a/bip-0301.mediawiki
+++ b/bip-0301.mediawiki
@@ -98,7 +98,7 @@ To "Accept" a BMM proposal (endorsing Simon's side:block, and allowing Mary to a
     32-bytes - h* (obtained from Simon)
 </pre>
 
-[https://github.com/LayerTwo-Labs/bip300301_messages/blob/master/src/lib.rs#L252-L264 Code details here].
+[https://github.com/LayerTwo-Labs/bip300301_messages/blob/dd26518ff9505ea9088436797171799f359d0076/src/lib.rs#L256-L268 Code details here].
 
 If these OP_RETURN outputs are not present, then no Requests were accepted. (And, Mary would get no money from Requests.)
 


### PR DESCRIPTION
The original master file has been changed, and the line numbers referenced by the original URL are no longer accurate. Therefore, a fixed permanent link is used to replace it. The purpose of adopting a permanent link is to prevent the line numbers originally pointed to by the URL from becoming inaccurate again when further changes are made to the master branch.