### PR TITLE
BIP3: Move to Proposed

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -27,13 +27,13 @@ Those proposing changes should consider that ultimately consent may rest with th
 | Luke Dashjr
 | Process
 | Active
-|-
+|- style="background-color: #ffffcf"
 | [[bip-0003.md|3]]
 |
 | Updated BIP Process
 | Murch
 | Process
-| Draft
+| Proposed
 |-
 | [[bip-0008.mediawiki|8]]
 |

--- a/bip-0003.md
+++ b/bip-0003.md
@@ -3,7 +3,7 @@
   Title: Updated BIP Process
   Author: Murch <murch@murch.one>
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0003
-  Status: Draft
+  Status: Proposed
   Type: Process
   Created: 2025-01-09
   License: BSD-2-Clause


### PR DESCRIPTION
I was [finished with my planned work](https://gnusha.org/pi/bitcoindev/25449597-c5ed-42c5-8ac1-054feec8ad88@murch.one/) on 2025-02-03, and after a few more rounds of review, BIP3 got merged on 2025-02-20.

I have not received any additional review comments or change suggestions in over three weeks, so it seems to me that this proposal may be complete and ready for adoption, although amendments are of course still possible if anyone has further review, concerns, or suggestions. Please feel free to leave comments here or write to the mailing list.

Otherwise, I posit that this proposal is ready to be moved to Proposed.