### PR TITLE
BIP 345: Fix OP_VAULT_RECOVER specification for the recovery-sPK-hash

### DIFF
--- a/bip-0345.mediawiki
+++ b/bip-0345.mediawiki
@@ -307,7 +307,8 @@ where
 After the stack is parsed, the following validation checks are performed:
 
 * Let the output at index <code><recovery-vout-idx></code> be called ''recoveryOut''.
-* If the scriptPubKey of ''recoveryOut'' does not have a tagged hash equal to <code><recovery-sPK-hash></code> (<code>tagged_hash("VaultRecoverySPK", recoveryOut.scriptPubKey) == recovery-sPK-hash</code>, where <code>tagged_hash()</code> is from the [https://github.com/bitcoin/bips/blob/master/bip-0340/reference.py BIP-0340 reference code]), script execution MUST fail and terminate immediately.
+* Compute the scriptPubKey tagged hash for ''recoveryOut'' as <code>output-sPK-hash = tagged_hash("VaultRecoverySPK", CompactSize(len(recoveryOut.scriptPubKey)) || recoveryOut.scriptPubKey)</code>, where <code>tagged_hash()</code> is from the [https://github.com/bitcoin/bips/blob/master/bip-0340/reference.py BIP-0340 reference code].
+* If the ''recoveryOut'' <code>output-sPK-hash</code> is not equal to <code><recovery-sPK-hash></code>, script execution MUST fail and terminate immediately.
 ** Implementation recommendation: if ''recoveryOut'' does not have an <code>nValue</code> greater than or equal to this input's amount, the script SHOULD fail and terminate immediately.
 * Queue a deferred check that ensures the <code>nValue</code> of ''recoveryOut'' contains the entire <code>nValue</code> of this input.<ref>'''How do recovery transactions pay for fees?''' If the recovery is unauthorized, fees are attached either via CPFP with an ephemeral anchor or as inputs which are solely spent to fees (i.e. no change output). If the recovery is authorized, fees can be attached in any manner, e.g. unrelated inputs and outputs or CPFP via anchor.</ref>
 ** This deferred check could be characterized in terms of the pseudocode below as <code>RecoveryCheck(<recovery-vout-idx>, input_amount)</code>.


### PR DESCRIPTION
The recovery scriptPubKey needs to be prefixed with its CompactSize-encoded length when computing the sPK hash.

I verified this by:
- Checking the [functional tests](https://github.com/jamesob/bitcoin/commit/5e59c074703f0913db7ee004b99d086857d10ad6#diff-65a47d52759ba7800338bacb3005836bdc0f3962de356621e5c50887c85c4af8R1407-R1409), where `recovery_spk_tagged_hash()` is implemented using [`ser_string()`](https://github.com/bitcoin/bitcoin/blob/af3dee0b8d456a8aa9ade9c6e7f4283a90590eae/test/functional/test_framework/messages.py#L148-L149) which adds the CompactSize-encoded length prefix
- Using an [implementation in Minsc](https://min.sc/v0.3/#gist=d8ac58dadc7377c3e231b4c7735ee5c5) to construct a [transaction](https://mutinynet.com/tx/944db06a37842fea9f7db117a0118221ee4bbdb0116354c562adcd12edaa365e) spending using `OP_VAULT_RECOVER` and broadcasting it to mutinynet (see line 2 for the recovery sPK hash computation)
- Checking with @jamesob 

Alternatively, the implementation could be amended to match the current specification and drop the length prefix. Since this is committing to a single element, the length isn't really necessary.