### PR TITLE
BIP-3: update dead link in `bip-0003.md`

### DIFF
--- a/bip-0003.md
+++ b/bip-0003.md
@@ -596,13 +596,13 @@ The licenses of existing BIPs remain untouched.
 ## Copyright
 
 This BIP is licensed under the [BSD-2-Clause License](https://opensource.org/licenses/BSD-2-Clause). Some content was
-adapted from [BIP 2](BIP-0002.mediawiki) which was also licensed under the BSD-2-Clause.
+adapted from [BIP 2](bip-0002.mediawiki) which was also licensed under the BSD-2-Clause.
 
 ## Related Work
 
 - [BIP 1: BIP Purpose and Guidelines](bip-0001.mediawiki)
-- [BIP 2: BIP Process, revised](BIP-0002.mediawiki)
-- [BIP 123: BIP Classification](BIP-0123.mediawiki)
+- [BIP 2: BIP Process, revised](bip-0002.mediawiki)
+- [BIP 123: BIP Classification](bip-0123.mediawiki)
 - [RFC 822: Standard for ARPA Internet Text Messages](https://datatracker.ietf.org/doc/html/rfc822)
 - [RFC 2223: Instructions to RFC Authors](https://datatracker.ietf.org/doc/html/rfc2223)
 - [RFC 7282: On Consensus and Humming in the IETF](https://tools.ietf.org/html/rfc7282)


### PR DESCRIPTION
Hi! I fixed broken links in `bip-0003.md`. The issue was caused by incorrect letter casing in file references (`BIP-0002.mediawiki` → `bip-0002.mediawiki` and `BIP-0123.mediawiki` → `bip-0123.mediawiki`). The links have been updated to match the correct filenames, ensuring proper navigation.

