### PR TITLE
Add locktime threshold definition to BIP65

### DIFF
--- a/bip-0065.mediawiki
+++ b/bip-0065.mediawiki
@@ -40,7 +40,7 @@ until that block height or block time has been reached the transaction output
 remains unspendable.
 
 The locktime threshold (`LOCKTIME_THRESHOLD`) is 500,000,000. Numbers below this threshold are interpreted
-as block height locktimes. Numbers greater than or equal to this threshold are interpreted as wall clock time locktimes.
+as block height locktimes. Numbers greater than or equal to this threshold are interpreted as wall clock (UNIX timestamp) locktimes.
 
 ==Motivation==
 


### PR DESCRIPTION
I don't believe it is defined, just referenced as a c++ value `LOCKTIME_THRESHOLD`.