### PR TITLE
BIP-0015 and BIP-0020: fix typos and improve text clarity

### DIFF
--- a/bip-0015.mediawiki
+++ b/bip-0015.mediawiki
@@ -12,7 +12,7 @@
 
 [[bip-0070.mediawiki|BIP 0070]] (payment protocol) may be seen as the alternative to Aliases.
 
-Using vanilla bitcoin, to send funds to a destination, an address in the form 1Hd44nkJfNAcPJeZyrGC5sKJS1TzgmCTjjZ is needed. The problem with using addresses is they are not easy to remember. An analogy can be thought if one were required to enter the IP address of their favourite websites if domain names did not exist.
+Using vanilla bitcoin, to send funds to a destination, an address in the form 1Hd44nkJfNAcPJeZyrGC5sKJS1TzgmCTjjZ is needed. The problem with using addresses is that they are not easy to remember. An analogy can be thought if one were required to enter the IP address of their favourite websites if domain names did not exist.
 
 This document aims to layout through careful argument, a bitcoin alias system. This is a big modification to the protocol that is not easily changed in the future and has big ramifications. There is impetus in getting it correct the first time. Aliases have to be robust and secure.
 

--- a/bip-0020.mediawiki
+++ b/bip-0020.mediawiki
@@ -54,7 +54,7 @@ Graphical bitcoin clients SHOULD register themselves as the handler for the "bit
 
 *label: Label for that address (e.g. name of receiver)
 *address: bitcoin address
-*message: message that shown to the user after scanning the QR code
+*message: message that is shown to the user after scanning the QR code
 *size: amount of base bitcoin units ([[#Transfer amount/size|see below]])
 *send: used to send bitcoin, rather than to request them
 *(others): optional, for future extensions

--- a/bip-0035.mediawiki
+++ b/bip-0035.mediawiki
@@ -24,7 +24,7 @@ Several use cases make it desirable to expose a network node's transaction memor
 ==Specification==
 
 # The mempool message is defined as an empty message where pchCommand == "mempool"
-# Upon receipt of a "mempool" message, the node will respond   with an "inv" message containing MSG_TX hashes of all the transactions in the node's transaction memory pool, if any.
+# Upon receipt of a "mempool" message, the node will respond with an "inv" message containing MSG_TX hashes of all the transactions in the node's transaction memory pool, if any.
 # The typical node behavior in response to an "inv" is "getdata". However, the reference Satoshi implementation ignores requests for transaction hashes outside that which is recently relayed. To support "mempool", an implementation must extend its "getdata" message support to querying the memory pool.
 # Feature discovery is enabled by checking two "version" message attributes:
 ## Protocol version >= 60002


### PR DESCRIPTION
This PR makes the following changes:

1. BIP-0015: Fixes typo in the word "that" and improves readability of the address example explanation

2. BIP-0020: Improves message text clarity by adding "is" in the QR code scanning message

These are minor text improvements that don't change the technical content of the BIPs but make them more readable and grammatically correct.