### PR TITLE
BIPs 78 and 329: minor grammar and typo fix-ups

### DIFF
--- a/bip-0078.mediawiki
+++ b/bip-0078.mediawiki
@@ -208,7 +208,7 @@ It is advised to hard code the description of the well known error codes into th
 In some situation, the sender might want to pay some additional fee in the payjoin proposal.
 If such is the case, the sender must use both [[#optional-params|optional parameters]] <code>additionalfeeoutputindex=</code> and <code>maxadditionalfeecontribution=</code> to indicate which output and how much the receiver can subtract fee.
 
-There is several cases where a fee output is useful:
+There are several cases where a fee output is useful:
 
 * The sender's original transaction's fee rate is at the minimum accepted by the network, aka <code>minimum relay transaction fee rate</code>, which is typically 1 satoshi per vbyte.
 
@@ -281,7 +281,7 @@ It also allows the receiver to pay the fee for batching adding his own outputs.
 
 ==Rationale==
 
-There is several consequences of our proposal:
+There are several consequences of our proposal:
 
 * The receiver can bump the fee of the original transaction.
 * The receiver can modify the outputs of the original PSBT.
@@ -331,7 +331,7 @@ On top of this the receiver can poison analysis by randomly faking a round amoun
 ===<span id="output-substitution"></span>Payment output substitution===
 
 Unless disallowed by the sender explicitly via <code>disableoutputsubstitution=true</code> or by the BIP21 URL via the query parameter <code>pjos=0</code>, the receiver is free to decrease the amount or change the scriptPubKey output paying to himself.
-Note that if payment output substitution is disallowed, the reveiver can still increase the amount of the output. (See [[#reference-impl|the reference implementation]])
+Note that if payment output substitution is disallowed, the receiver can still increase the amount of the output. (See [[#reference-impl|the reference implementation]])
 
 For example, if the sender's scriptPubKey type is P2WPKH while the receiver's payment output in the original PSBT is P2SH, then the receiver can substitute the payment output to be P2WPKH to match the sender's scriptPubKey type.
 

--- a/bip-0329.mediawiki
+++ b/bip-0329.mediawiki
@@ -162,7 +162,7 @@ but should be given if they are readily available.
 
 === Address, Inputs, and Outputs ===
 
-* <tt>keypath</tt>: The data needed to build full descriptor down to the specific address.  This extends <tt>origin</tt> with the final two components that are unhardened (in the typical case, assuming BIP-84).  Provide string <tt>/1/123</tt> for <tt>wpkh([d34db33f/84'/0'/0'/1/123])</tt>. If the first character is not <tt>/</tt>, then it should be interpreted as a full descriptor, independant of <tt>origin</tt> (if any).
+* <tt>keypath</tt>: The data needed to build full descriptor down to the specific address.  This extends <tt>origin</tt> with the final two components that are unhardened (in the typical case, assuming BIP-84).  Provide string <tt>/1/123</tt> for <tt>wpkh([d34db33f/84'/0'/0'/1/123])</tt>. If the first character is not <tt>/</tt>, then it should be interpreted as a full descriptor, independent of <tt>origin</tt> (if any).
 
 === Inputs and Outputs ===
 


### PR DESCRIPTION
This pull request corrects several grammatical errors and typos in BIP-0329.mediawiki and BIP-0078.mediawiki files.
# Changes in BIP-0329.mediawiki:
Fixed incorrect word "independant" to "independent" in line 164:
   - * <tt>keypath</tt>: The data needed to build full descriptor down to the specific address.  This extends <tt>origin</tt> with the final two components that are unhardened (in the typical case, assuming BIP-84).  Provide string <tt>/1/123</tt> for <tt>wpkh([d34db33f/84'/0'/0'/1/123])</tt>. If the first character is not <tt>/</tt>, then it should be interpreted as a full descriptor, independant of <tt>origin</tt> (if any).
   + * <tt>keypath</tt>: The data needed to build full descriptor down to the specific address.  This extends <tt>origin</tt> with the final two components that are unhardened (in the typical case, assuming BIP-84).  Provide string <tt>/1/123</tt> for <tt>wpkh([d34db33f/84'/0'/0'/1/123])</tt>. If the first character is not <tt>/</tt>, then it should be interpreted as a full descriptor, independent of <tt>origin</tt> (if any).
  
# Changes in BIP-0078.mediawiki:
1. Fixed subject-verb agreement errors:
   - There is several cases where a fee output is useful:
   + There are several cases where a fee output is useful:
2. Fixed spelling error:
   - Note that if payment output substitution is disallowed, the reveiver can still increase the amount of the output. (See [[#reference-impl|the reference implementation]])
   + Note that if payment output substitution is disallowed, the receiver can still increase the amount of the output. (See [[#reference-impl|the reference implementation]])