### PR TITLE
BIP127: Replace network_magic with BIP44 coin_type in ProofOfReserves message

### DIFF
--- a/bip-0127.mediawiki
+++ b/bip-0127.mediawiki
@@ -133,11 +133,10 @@ message ProofOfReserves {
 	// additional fields.
 	uint32 version = 1;
 
-	// The network magic for the network in which the proofs are valid.
-	// 0xD9B4BEF9 for mainnet, 0x0709110B for testnet
-	//TODO consider BIP44 coin type ids instead:
-	// https://github.com/satoshilabs/slips/blob/master/slip-0044.md
-	uint32 network_magic = 2;
+	// The coin type id from SLIP-0044 for the network in which the proofs are valid.
+	// 0 (0x80000000) for Bitcoin mainnet, 1 (0x80000001) for Testnet (all coins)
+	// See SLIP-0044 for the full registry: https://github.com/satoshilabs/slips/blob/master/slip-0044.md
+	uint32 coin_type = 2;
 
 	// The commitment message for this proof-of-reserves.
 	// This message is global for all the proofs.


### PR DESCRIPTION
This commit updates the ProofOfReserves message in the Protocol Buffers specification
to use BIP44 coin type IDs from SLIP-0044 instead of network magic values.

The changes include:
- Renaming the field from 'network_magic' to 'coin_type'
- Updating the comments to reference the SLIP-0044 registry
- Adding examples for Bitcoin mainnet (0x80000000) and Testnet (0x80000001)
