### PR TITLE
BIP48: Add p2tr script type derivation

### DIFF
--- a/bip-0048.mediawiki
+++ b/bip-0048.mediawiki
@@ -99,17 +99,20 @@ Hardened derivation is used at this level.
 
 ===Script===
 
-This level splits the key space into two separate <code>script_type</code>(s). To provide
+This level splits the key space into three separate <code>script_type</code>(s). To provide
 forward compatibility for future script types this specification can be easily extended.
 
-Currently the only script types covered by this BIP are Native Segwit (p2wsh) and
-Nested Segwit (p2sh-p2wsh).
+Currently the only script types covered by this BIP are Native Segwit (p2wsh),
+Nested Segwit (p2sh-p2wsh), and Taproot (p2tr).
 
 The following path represents Nested Segwit (p2sh-p2wsh) mainnet, account 0:
 <code>1'</code>: Nested Segwit (p2sh-p2wsh) <code>m/48'/0'/0'/1'</code></br>
 
 The following path represents Native Segwit (p2wsh) mainnet, account 0:
 <code>2'</code>: Native Segwit (p2wsh) <code>m/48'/0'/0'/2'</code></br>
+
+The following path represents Taproot (p2tr) mainnet, account 0:
+<code>3'</code>: Taproot (p2tr) <code>m/48'/0'/0'/3'</code></br>
 
 The recommended default for wallets is pay to witness script hash <code>m/48'/0'/0'/2'</code>.
 
@@ -240,6 +243,13 @@ Public derivation is used at this level.
 |change
 |second
 |m / 48' / 1' / 1' / 2' / 1 / 1
+|-
+|testnet
+|first
+|p2tr
+|external
+|first
+|m / 48' / 1' / 0' / 3' / 0 / 0
 |}
 
 


### PR DESCRIPTION
BIP48 currently defines script types only for p2wsh and p2sh-p2wsh, but not for the newer p2tr.

This PR proposes defining the the script_type for p2tr as `3`, to provide a clear standard for the derivation to use in p2tr scripts.