### PR TITLE
BIP 99: update invalid link to hardfork-timewarp-0.11 branch

### DIFF
--- a/bip-0099.mediawiki
+++ b/bip-0099.mediawiki
@@ -350,9 +350,7 @@ worth of blocks).
 
 [3] https://github.com/bitcoin/bips/blob/master/bip-0009.mediawiki
 
-[4] https://github.com/bitcoin/bitcoin/compare/0.11...jtimon:hardfork-timewarp-0.11
-
-[5] Original references:
+[4] Original references:
 https://bitcointalk.org/index.php?topic=114751.0
 https://bitcointalk.org/index.php?topic=43692.msg521772#msg521772
 Rebased patch:

--- a/bip-0099.mediawiki
+++ b/bip-0099.mediawiki
@@ -350,7 +350,9 @@ worth of blocks).
 
 [3] https://github.com/bitcoin/bips/blob/master/bip-0009.mediawiki
 
-[4] Original references:
+[4] https://github.com/jtimon/bitcoin/tree/hardfork-timewarp-0.11
+
+[5] Original references:
 https://bitcointalk.org/index.php?topic=114751.0
 https://bitcointalk.org/index.php?topic=43692.msg521772#msg521772
 Rebased patch:


### PR DESCRIPTION
This PR updates the link to the experimental hardfork-timewarp-0.11 branch, which was a PoC for a TimeWarp hardfork fix.