### PR TITLE
BIP48: Add P2SH-P2WSH and P2TR mainnet examples

### DIFF
--- a/bip-0048.mediawiki
+++ b/bip-0048.mediawiki
@@ -148,6 +148,13 @@ Public derivation is used at this level.
 |-
 |mainnet
 |first
+|p2sh-p2wsh
+|external
+|first
+|m / 48' / 0' / 0' / 1' / 0 / 0
+|-
+|mainnet
+|first
 |p2wsh
 |external
 |first
@@ -187,6 +194,13 @@ Public derivation is used at this level.
 |external
 |second
 |m / 48' / 0' / 1' / 2' / 0 / 1
+|-
+|mainnet
+|first
+|p2tr
+|external
+|first
+|m / 48' / 0' / 0' / 3' / 0 / 0
 |-
 |testnet
 |first


### PR DESCRIPTION
Follow-up to https://github.com/bitcoin/bips/pull/1835.