### PR TITLE
fix: Add missing link to Value Overflow Incident in BIP-0099

### DIFF
--- a/bip-0099.mediawiki
+++ b/bip-0099.mediawiki
@@ -344,7 +344,7 @@ worth of blocks).
 
 [2] https://github.com/bitcoin/bips/blob/master/bip-0050.mediawiki
 
-[non_proportional_inflatacoin_fork] TODO missing link
+[non_proportional_inflatacoin_fork] https://en.bitcoin.it/wiki/Value_overflow_incident
 
 [spinoffs] https://bitcointalk.org/index.php?topic=563972.0
 


### PR DESCRIPTION
Added proper link to the Value Overflow Incident (August 2010) that created 184 billion BTC due to integer overflow, which was subsequently fixed through a controlled fork.

Resolves the TODO on line 347.