### PR TITLE
BIP-345: withdraw

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1127,13 +1127,13 @@ Those proposing changes should consider that ultimately consent may rest with th
 | Shinobius, Michael Folkson
 | Standard
 | Final
-|-
+|- style="background-color: #ffcfcf"
 | [[bip-0345.mediawiki|345]]
 | Consensus (soft fork)
 | OP_VAULT
 | James O'Beirne, Greg Sanders
 | Standard
-| Draft
+| Withdrawn
 |-
 | [[bip-0347.mediawiki|347]]
 | Consensus (soft fork)

--- a/bip-0345.mediawiki
+++ b/bip-0345.mediawiki
@@ -5,12 +5,13 @@
   Author: James O'Beirne <vaults@au92.org>
           Greg Sanders <gsanders87@gmail.com>
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0345
-  Status: Draft
+  Status: Withdrawn
   Type: Standards Track
   Created: 2023-02-03
   License: BSD-3-Clause
   Post-History: 2023-01-09: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2023-January/021318.html [bitcoin-dev] OP_VAULT announcement
                 2023-03-01: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2023-March/021510.html [bitcoin-dev] BIP for OP_VAULT
+  Superseded-By: 443
 </pre>
 
 


### PR DESCRIPTION
This proposal has basically been replaced by #1793. See https://delvingbitcoin.org/t/withdrawing-op-vault-bip-345/1670 for rationale.