### PR TITLE
BIP-372: Fix references and links formatting and minor typos

### DIFF
--- a/bip-0372.mediawiki
+++ b/bip-0372.mediawiki
@@ -31,7 +31,7 @@ Key tweaking is a procedure for creating a cryptographic commitment to a
 message using elliptic curve properties. The procedure uses the discrete log
 problem (DLP) to commit to an extra-transaction message. This is done by adding
 to a public key (for which the output owner knows the corresponding private key)
-a hash of the message multiplied on the generator point G of the elliptic curve.
+a hash of the message multiplied by the generator point G of the elliptic curve.
 This produces a tweaked public key containing the commitment. Later, in order
 to spend an output containing the P2C commitment, the same commitment should be
 added to the corresponding private key.
@@ -94,7 +94,7 @@ The new per-input type is defined as follows:
 | <tt><pubkey></tt>
 | 33 bytes of compact public key serialization specifying to which keys the
 P2C tweak may be applied (i.e. this MUST be a value of a public key before the
-tweak is applied). BIP-340 keys are serialized by appending `02`
+tweak is applied). BIP-340 keys are serialized by appending `0x02`
 byte.<ref>'''Why compressed public keys are not distinguished from BIP-340
 public keys''' We follow the logic of BIP32 key derivation, which does not
 distinguish them. The type of the key is defined by the input type,
@@ -146,7 +146,7 @@ public keys:
 - P2PKH,
 - P2SH,
 - witness v0 P2WPKH and P2WSH,
-- nested witness v0 P2WPKH-P2SH and P2WSH-P2SH,
+- nested witness v0 P2WPKH-P2SH and P2WSH-P2SH
 
 Post-0 witness versions, including taproot outputs and future witness versions,
 may not be supported or covered by this BIP and may require the addition of new
@@ -172,20 +172,16 @@ TBD
 
 ==References==
 
-[1] Ilja Gerhardt, Timo Hanke. Homomorphic Payment Addresses and the
-    Pay-to-Contract Protocol. arXiv:1212.3257 \[cs.CR\]
-    <https://arxiv.org/pdf/1212.3257.pdf>
-[2] Eternity Wall's "sign-to-contract" article.
-    <https://blog.eternitywall.com/2018/04/13/sign-to-contract/>
-[3] Peter Todd. OpenTimestamps: Scalable, Trust-Minimized, Distributed
-    Timestamping with Bitcoin.
-    <https://petertodd.org/2016/opentimestamps-announcement>
-[4] Adam Back, Matt Corallo, Luke Dashjr, et al. Enabling Blockchain
-    Innovations with Pegged Sidechains (commit5620e43). Appendix A.
-    <https://blockstream.com/sidechains.pdf>;.
-[5] Maxim Orlovsky, Rene Pickhardt, Federico Tenga, et al. Key
-    tweaking: collision- resistant elliptic curve-based commitments.
-    LNPBP-1 Standard.
-    <https://github.com/LNP-BP/LNPBPs/blob/master/lnpbp-0001.md>
-[6] Peter Todd. Single-use-seals. LNPBP-8 Standard.
-    <https://github.com/LNP-BP/LNPBPs/blob/master/lnpbp-0008.md>
+[1] Ilja Gerhardt, Timo Hanke. ''Homomorphic Payment Addresses and the Pay-to-Contract Protocol.'' arXiv:1212.3257 [cs.CR]. [https://arxiv.org/pdf/1212.3257.pdf arxiv.org/pdf/1212.3257.pdf]
+
+[2] Eternity Wall. ''Sign-to-contract.'' [https://blog.eternitywall.com/2018/04/13/sign-to-contract/ blog.eternitywall.com]
+
+[3] Peter Todd. ''OpenTimestamps: Scalable, Trust-Minimized, Distributed Timestamping with Bitcoin.'' [https://petertodd.org/2016/opentimestamps-announcement petertodd.org]
+
+[4] Adam Back, Matt Corallo, Luke Dashjr, et al. ''Enabling Blockchain Innovations with Pegged Sidechains (commit5620e43). Appendix A.'' [https://blockstream.com/sidechains.pdf blockstream.com/sidechains.pdf]
+
+[5] Maxim Orlovsky, Rene Pickhardt, Federico Tenga, et al. ''Key tweaking: collision-resistant elliptic curve-based commitments. LNPBP-1 Standard.'' [https://github.com/LNP-BP/LNPBPs/blob/master/lnpbp-0001.md LNPBP-1 on GitHub]
+
+[6] Peter Todd. ''Single-use-seals. LNPBP-8 Standard.'' [https://github.com/LNP-BP/LNPBPs/blob/master/lnpbp-0008.md LNPBP-8 on GitHub]
+
+


### PR DESCRIPTION
Fixed incorrect preposition in key tweaking explanation:
  - `multiplied on` → `multiplied by`
 
- Clarified BIP-340 key serialization:
  - `appending '02'` → `appending '0x02'`
 
- Removed unnecessary trailing comma in the list of output types

- Removed erroneous semicolon after URL