### PR TITLE
BIP48: Partially revert recent changes, move to final

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -272,13 +272,13 @@ Those proposing changes should consider that ultimately consent may rest with th
 | Justus Ranvier
 | Informational
 | Final
-|- style="background-color: #ffffcf"
+|- style="background-color: #cfffcf"
 | [[bip-0048.mediawiki|48]]
 | Applications
 | Multi-Script Hierarchy for Multi-Sig Wallets
 | Fontaine
 | Standard
-| Proposed
+| Final
 |- style="background-color: #cfffcf"
 | [[bip-0049.mediawiki|49]]
 | Applications

--- a/bip-0048.mediawiki
+++ b/bip-0048.mediawiki
@@ -192,13 +192,6 @@ Public derivation is used at this level.
 |second
 |m / 48' / 0' / 1' / 2' / 0 / 1
 |-
-|mainnet
-|first
-|p2tr
-|external
-|first
-|m / 48' / 0' / 0' / 3' / 0 / 0
-|-
 |testnet
 |first
 |p2sh-p2wsh

--- a/bip-0048.mediawiki
+++ b/bip-0048.mediawiki
@@ -5,7 +5,7 @@
   Author: Fontaine <dentondevelopment@protonmail.com>
   Comments-Summary: No comments
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0048
-  Status: Proposed
+  Status: Final
   Type: Standards Track
   Created: 2020-12-16
   License: MIT

--- a/bip-0048.mediawiki
+++ b/bip-0048.mediawiki
@@ -113,9 +113,6 @@ The following path represents Native Segwit (p2wsh) mainnet, account 0:
 
 The recommended default for wallets is pay to witness script hash <code>m/48'/0'/0'/2'</code>.
 
-To add new script types submit a PR to this specification and include it in the list above:
-<code>X'</code>: Future script type <code>m/48'/0'/0'/X'</code></br>
-
 ===Change===
 
 Constant 0 is used for external chain and constant 1 for internal chain (also

--- a/bip-0048.mediawiki
+++ b/bip-0048.mediawiki
@@ -99,20 +99,17 @@ Hardened derivation is used at this level.
 
 ===Script===
 
-This level splits the key space into three separate <code>script_type</code>(s). To provide
+This level splits the key space into two separate <code>script_type</code>(s). To provide
 forward compatibility for future script types this specification can be easily extended.
 
-Currently the only script types covered by this BIP are Native Segwit (p2wsh),
-Nested Segwit (p2sh-p2wsh), and Taproot (p2tr).
+Currently the only script types covered by this BIP are Native Segwit (p2wsh) and
+Nested Segwit (p2sh-p2wsh).
 
 The following path represents Nested Segwit (p2sh-p2wsh) mainnet, account 0:
 <code>1'</code>: Nested Segwit (p2sh-p2wsh) <code>m/48'/0'/0'/1'</code></br>
 
 The following path represents Native Segwit (p2wsh) mainnet, account 0:
 <code>2'</code>: Native Segwit (p2wsh) <code>m/48'/0'/0'/2'</code></br>
-
-The following path represents Taproot (p2tr) mainnet, account 0:
-<code>3'</code>: Taproot (p2tr) <code>m/48'/0'/0'/3'</code></br>
 
 The recommended default for wallets is pay to witness script hash <code>m/48'/0'/0'/2'</code>.
 
@@ -257,13 +254,6 @@ Public derivation is used at this level.
 |change
 |second
 |m / 48' / 1' / 1' / 2' / 1 / 1
-|-
-|testnet
-|first
-|p2tr
-|external
-|first
-|m / 48' / 1' / 0' / 3' / 0 / 0
 |}
 
 


### PR DESCRIPTION
As discussed on https://github.com/bitcoin/bips/pull/1835#pullrequestreview-2837827946, the addition to P2TR was incompletely specified, and BIP48 should no longer be changed. Therefore, I propose to revert the changes, and to move BIP48 to final instead.