### PR TITLE
bip-0331: correct size of version field in sendpackages

### DIFF
--- a/bip-0331.mediawiki
+++ b/bip-0331.mediawiki
@@ -246,7 +246,7 @@ Four new protocol messages and two inv types are added.
 {|
 |  Field Name  ||  Type  ||  Size  ||  Purpose
 |-
-|versions || uint64_t || 4 || Bit field that is 64 bits wide, denoting the package versions supported by the sender.
+|versions || uint64_t || 8 || Bit field that is 64 bits wide, denoting the package versions supported by the sender.
 |-
 |}
 


### PR DESCRIPTION
Since the version is denoted as uint64, the size should be 8 bytes.