### PR TITLE
bitcoins => bitcoin

### DIFF
--- a/bip-0177.mediawiki
+++ b/bip-0177.mediawiki
@@ -28,7 +28,7 @@ By redefining the base unit as "one bitcoin," this BIP aligns user perception wi
 
 * Internally, the base units remain unchanged.
 * Historically, 1 bitcoin = 100,000,000 base units. Under this proposal, "1 bitcoin" equals one base unit.
-* What was previously referred to as "1 bitcoin" now corresponds to 100 million bitcoins under the new definition.
+* What was previously referred to as "1 bitcoin" now corresponds to 100 million bitcoin under the new definition.
 
 '''Terminology:'''
 
@@ -39,22 +39,22 @@ By redefining the base unit as "one bitcoin," this BIP aligns user perception wi
 '''Display and Formatting:'''
 
 * Applications SHOULD allow users to toggle between the legacy BTC format (1 BTC = 100,000,000 base units) and the new integral format (1 bitcoin = 1 base unit).
-* Use of the ₿ symbol MAY be used to represent base-unit bitcoins but is OPTIONAL.
+* Use of the ₿ symbol MAY be used to represent base-unit bitcoin but is OPTIONAL.
 
 Example 1:
 
 * Old display: <code>0.00010000 bitcoin</code>
-* New display: <code>₿10,000</code> or <code>10,000 bitcoins</code> or <code>0.00010000 BTC</code>
+* New display: <code>₿10,000</code> or <code>10,000 bitcoin</code> or <code>0.00010000 BTC</code>
 
 Example 2:
 
 * Old display: <code>10.23486 bitcoin</code>
-* New display: <code>₿1,023,486,000</code> or <code>1,023,486,000 bitcoins</code> or <code>10.23486 BTC</code>
+* New display: <code>₿1,023,486,000</code> or <code>1,023,486,000 bitcoin</code> or <code>10.23486 BTC</code>
 
 Example 3:
 
 * Old display: <code>0.345 BTC</code>
-* New display: No changes required or <code>₿34,500,000</code> or <code>34,500,000 bitcoins</code>
+* New display: No changes required or <code>₿34,500,000</code> or <code>34,500,000 bitcoin</code>
 
 NOTE: Traditional number display abbreviations, like <code>2.5M</code> for millions, are also optional.
 
@@ -134,10 +134,10 @@ Some wallets, such as Bitkit, have successfully adopted integer-only displays, d
 
 ===Test Vectors===
 
-* Old: <code>1.00000000 Bitcoin</code> → New: <code>₿100,000,000</code> (or <code>100,000,000 bitcoins</code>)
-* Old: <code>0.00010000 Bitcoin</code> → New: <code>₿10,000</code> (or <code>10,000 bitcoins</code>)
-* Old: <code>0.00500000 Bitcoin</code> → New: <code>₿500,000</code> (or <code>500,000 bitcoins</code>)
-* Old: <code>0.005 BTC</code> → New: <code>0.005 BTC</code> (or <code>₿500,000</code> or <code>500,000 bitcoins</code>)
+* Old: <code>1.00000000 Bitcoin</code> → New: <code>₿100,000,000</code> (or <code>100,000,000 bitcoin</code>)
+* Old: <code>0.00010000 Bitcoin</code> → New: <code>₿10,000</code> (or <code>10,000 bitcoin</code>)
+* Old: <code>0.00500000 Bitcoin</code> → New: <code>₿500,000</code> (or <code>500,000 bitcoin</code>)
+* Old: <code>0.005 BTC</code> → New: <code>0.005 BTC</code> (or <code>₿500,000</code> or <code>500,000 bitcoin</code>)
 
 All formerly fractional representations now directly correspond to whole-number multiples of the base unit.
 


### PR DESCRIPTION
I propose we use singular form bitcoin instead of plural form. It is cleaner.