### PR TITLE
BIP69: fix link

### DIFF
--- a/bip-0069.mediawiki
+++ b/bip-0069.mediawiki
@@ -162,7 +162,7 @@ Outputs:
 * [[https://github.com/bitcoinjs/bip69/blob/master/test/fixtures.json|BitcoinJS Test Fixtures]]
 * [[https://www.npmjs.com/package/bip69|NodeJS]]
 * [[https://github.com/blockchain/My-Wallet-V3/blob/v3.8.0/src/transaction.js#L120-L142|Blockchain.info public beta]]
-* [[https://github.com/btcsuite/btcutil/blob/master/txsort/txsort.go|Btcsuite]]
+* [[https://github.com/btcsuite/btcd/blob/master/btcutil/txsort/txsort.go|Btcsuite]]
 
 ==Acknowledgements==
 


### PR DESCRIPTION
Fixes an out-of-date link:

before

https://github.com/btcsuite/btcutil/blob/master/txsort/txsort.go

after

https://github.com/btcsuite/btcd/blob/master/btcutil/txsort/txsort.go

