### PR TITLE
BIP-383: fix output scripts

### DIFF
--- a/bip-0383.mediawiki
+++ b/bip-0383.mediawiki
@@ -43,14 +43,19 @@ When used at the top level, there can only be at most 3 keys.
 When used inside of a <tt>sh()</tt> expression, there can only be most 15 compressed public keys (this is limited by the P2SH script limit).
 Otherwise the maximum number of keys is 20.
 
-The output script produced also depends on the value of <tt>k</tt>. If <tt>k</tt> is less than or equal to 16:
+The output script produced also depends on the value of <tt>k</tt> and <tt>n</tt>. If <tt>n</tt> is less than or equal to 16, this means <tt>k</tt> must always be less than 16 and the output script must look like:
 <pre>
-OP_k KEY_1 KEY_2 ... KEY_n OP_CHECKMULTISIG
+OP_k KEY_1 KEY_2 ... KEY_n OP_n OP_CHECKMULTISIG
 </pre>
 
-if <tt>k</tt> is greater than 16:
+if <tt>n</tt> is greater than 16:
 <pre>
-k KEY_1 KEY_2 ... KEY_n OP_CHECKMULTISIG
+k KEY_1 KEY_2 ... KEY_n n OP_CHECKMULTISIG
+</pre>
+
+if <tt>n</tt> is greater than 16 but <tt>k</tt> is smaller than 16:
+<pre>
+OP_k KEY_1 KEY_2 ... KEY_n n OP_CHECKMULTISIG
 </pre>
 
 ===<tt>sortedmulti()</tt>===


### PR DESCRIPTION
The output scripts given in the specification are invalid for the bitcoin `OP_CHECKMULTISIG`.

The operator must be preceded with a push of the total number of keys - see https://bitcoin.stackexchange.com/questions/40669/checkmultisig-a-worked-out-example and https://en.bitcoin.it/wiki/OP_CHECKMULTISIG for the details.