### PR TITLE
BIP21: clarify that example addresses are intentionally invalid

### DIFF
--- a/bip-0021.mediawiki
+++ b/bip-0021.mediawiki
@@ -100,6 +100,8 @@ Please see the BNF grammar above for the normative syntax.
 
 === Examples ===
 
+Note: The addresses used in these examples are intentionally invalid to prevent accidental transactions.
+
 Just the address:
  bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W
 


### PR DESCRIPTION
Clarify to readers that the addresses used in the examples are intentionally invalid to prevent accidental transactions.