### PR TITLE
BIP-175: fix links

### DIFF
--- a/bip-0175.mediawiki
+++ b/bip-0175.mediawiki
@@ -244,7 +244,7 @@ Communication between payer and payee as well as hashing the contract and genera
 
 ==Reference implementations==
 
-* Reference wallet implementation, based on Copay project : https://github.com/commerceblock/copay ([[https://github.com/commerceblock/copay/pull/1|pull_request]])
+* Reference wallet implementation, based on Copay project : https://github.com/bitpay/wallet ([[https://github.com/bitpay/wallet/pull/1|pull_request]])
 * Reference implementation to Hash to Partial Derivation Path Mapping in javascript ([[https://github.com/commerceblock/pay-to-contract-lib/blob/master/lib/contract.js|https://github.com/commerceblock/pay-to-contract-lib]])
 
 ==Reference==


### PR DESCRIPTION
PR updates outdated references to the deprecated `commerceblock/copay` repository and replaces them with the actively maintained `bitpay/wallet` repository. The change ensures that dependencies and links point to the correct, maintained source.






