### PR TITLE
383: Fix output scripts and reword minimal encoding explanation

### DIFF
--- a/bip-0383.mediawiki
+++ b/bip-0383.mediawiki
@@ -43,15 +43,14 @@ When used at the top level, there can only be at most 3 keys.
 When used inside of a <tt>sh()</tt> expression, there can only be most 15 compressed public keys (this is limited by the P2SH script limit).
 Otherwise the maximum number of keys is 20.
 
-The output script produced also depends on the value of <tt>k</tt>. If <tt>k</tt> is less than or equal to 16:
+The output script produced will be
 <pre>
-OP_k KEY_1 KEY_2 ... KEY_n OP_CHECKMULTISIG
+k KEY_1 KEY_2 ... KEY_n n OP_CHECKMULTISIG
 </pre>
 
-if <tt>k</tt> is greater than 16:
-<pre>
-k KEY_1 KEY_2 ... KEY_n OP_CHECKMULTISIG
-</pre>
+The values <tt>k</tt> and <tt>n</tt> must be minimally encoded integers.
+For values less than or equal to 16, they must be encoded using <tt>OP_0</tt> through <tt>OP_16</tt>.
+For values greater than 16, they must be a push of the signed little endian encoded value without padding.
 
 ===<tt>sortedmulti()</tt>===
 


### PR DESCRIPTION
Fixes the output script template to correctly include the `n` value.

Also changed how the minimal encoding is described to just describe it rather than an exhaustive list.

Alternate to #1860