### PR TITLE
BIP 0070: Fix output use

### DIFF
--- a/bip-0070.mediawiki
+++ b/bip-0070.mediawiki
@@ -55,7 +55,7 @@ The Protocol Buffers messages are defined in [[bip-0070/paymentrequest.proto|pay
 
 ===Output===
 
-Outputs are used in PaymentRequest messages to specify where a payment (or
+Outputs are used in PaymentDetails messages to specify where a payment (or
 part of a payment) should be sent. They are also used in Payment messages
 to specify where a refund should be sent.
 <pre>


### PR DESCRIPTION
## description
* `Output` is used in `PaymentDetails` rather than `PaymentRequest`

## how to review?
* https://github.com/bitcoin/bips/blob/master/bip-0070/paymentrequest.proto#L20
* https://github.com/bitcoin/bips/blob/master/bip-0070/paymentrequest.proto#L27-L33