### PR TITLE
Update bip-0321.mediawiki to remove duplicate address example

### DIFF
--- a/bip-0321.mediawiki
+++ b/bip-0321.mediawiki
@@ -149,9 +149,6 @@ Address with recipient's name as label:
 Request 20.30 BTC to "Luke-Jr":
  bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?amount=20.3&label=Luke-Jr
 
-Address with recipient's name as label:
- bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?label=Luke-Jr
-
 Request 50 BTC with message:
  bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?amount=50&label=Luke-Jr&message=Donation%20for%20project%20xyz
 


### PR DESCRIPTION
Removing duplicate address example that's exactly the same as above.
@TheBlueMatt 