### PR TITLE
390: clarifications on KEY expression restrictions

### DIFF
--- a/bip-0379.md
+++ b/bip-0379.md
@@ -13,6 +13,7 @@
   Type: Informational
   Created: 2023-10-10
   License: CC0-1.0
+  Requires: 380
 ```
 
 ## Abstract

--- a/bip-0381.mediawiki
+++ b/bip-0381.mediawiki
@@ -10,6 +10,7 @@
   Type: Informational
   Created: 2021-06-27
   License: BSD-2-Clause
+  Requires: 380
 </pre>
 
 ==Abstract==

--- a/bip-0382.mediawiki
+++ b/bip-0382.mediawiki
@@ -10,6 +10,7 @@
   Type: Informational
   Created: 2021-06-27
   License: BSD-2-Clause
+  Requires: 380
 </pre>
 
 ==Abstract==

--- a/bip-0383.mediawiki
+++ b/bip-0383.mediawiki
@@ -10,6 +10,7 @@
   Type: Informational
   Created: 2021-06-27
   License: BSD-2-Clause
+  Requires: 380
 </pre>
 
 ==Abstract==

--- a/bip-0384.mediawiki
+++ b/bip-0384.mediawiki
@@ -10,6 +10,7 @@
   Type: Informational
   Created: 2021-06-27
   License: BSD-2-Clause
+  Requires: 380
 </pre>
 
 ==Abstract==

--- a/bip-0385.mediawiki
+++ b/bip-0385.mediawiki
@@ -10,6 +10,7 @@
   Type: Informational
   Created: 2021-06-27
   License: BSD-2-Clause
+  Requires: 380
 </pre>
 
 ==Abstract==

--- a/bip-0386.mediawiki
+++ b/bip-0386.mediawiki
@@ -10,6 +10,7 @@
   Type: Informational
   Created: 2021-06-27
   License: BSD-2-Clause
+  Requires: 380
 </pre>
 
 ==Abstract==

--- a/bip-0387.mediawiki
+++ b/bip-0387.mediawiki
@@ -10,6 +10,7 @@
   Type: Informational
   Created: 2024-04-17
   License: BSD-2-Clause
+  Requires: 380
 </pre>
 
 ==Abstract==

--- a/bip-0389.mediawiki
+++ b/bip-0389.mediawiki
@@ -9,6 +9,7 @@
   Type: Informational
   Created: 2022-07-26
   License: BSD-2-Clause
+  Requires: 380
 </pre>
 
 ==Abstract==

--- a/bip-0390.mediawiki
+++ b/bip-0390.mediawiki
@@ -9,7 +9,7 @@
   Type: Informational
   Created: 2024-06-04
   License: CC0-1.0
-  Requires: 380
+  Requires: 380, 328
 </pre>
 
 ==Abstract==
@@ -30,6 +30,9 @@ in a MuSig2 aggregate key to be expressed in descriptors so that wallets can mor
 
 A new key expression is defined: <tt>musig()</tt>.
 
+In the following sections, the term <tt>KEY</tt> refers to key expressions as defined in BIPs 380
+and 389.
+
 ===<tt>musig(KEY, KEY, ..., KEY)</tt>===
 
 The <tt>musig(KEY, KEY, ..., KEY)</tt> expression can only be used inside of a <tt>tr()</tt>
@@ -49,16 +52,17 @@ backed up, or guess, the correct order of keys.</ref>.
 
 ===<tt>musig(KEY, KEY, ..., KEY)/NUM/.../*</tt>===
 
-<tt>musig(KEY, KEY, ..., KEY)/NUM/.../*</tt> expressions are also allowed, with the same usage
-restrictions as in the previous section. The aggregate public key
-is first computed as described above, with the keys also being sorted after all derivation and prior
-to aggregation. Then further BIP 32 derivation will be performed on the aggregate public key as described in
-[[bip-0328.mediawiki|BIP 328]]. As there is no aggregate private key,
-only unhardened derivation from the aggregate public key is allowed, and thus the derivation steps
-following the <tt>musig()</tt> expression cannot contain
-<tt>/NUMh</tt> or <tt>/NUM'</tt> derivation steps nor <tt>/*h</tt>, or <tt>/*'</tt> child derivation.
-For these <tt>musig()</tt> expressions, the KEY expressions contained within must be xpubs or derived from
-xpubs, and cannot contain child derivation as specified by a <tt>/*</tt>, <tt>/*'</tt>, <tt>/*h</tt>, or multipath as specified with <tt>/<NUM;NUM;...></tt>.
+<tt>musig(KEY, KEY, ..., KEY)/NUM/.../*</tt> expressions are also allowed if no KEY expression
+contains child derivation as specified by <tt>/*</tt> or multipath as specified with
+<tt>/<NUM;NUM;...></tt>, in addition to the same usage restrictions as in the previous section. The KEY expressions
+additionally must be xpubs or derived from xpubs. The aggregate public key is first computed as
+described above, with the keys also being sorted after all derivation and prior to aggregation.
+Then further BIP 32 derivation will be performed on the aggregate public key as described in
+[[bip-0328.mediawiki|BIP 328]]. The <tt>/NUM/.../*</tt> following the <tt>musig()</tt> specifies
+the derivation path to be used when deriving from the aggregate public key. <tt>/*</tt> is also
+optional. As there is no aggregate private key, only unhardened derivation from the aggregate public
+key is allowed. Thus these derivation steps cannot contain <tt>/NUMh</tt> or <tt>/NUM'</tt>
+nor can child derivation be specified as <tt>/*h</tt>, or <tt>/*'</tt>.
 
 ==Test Vectors==
 
@@ -99,6 +103,7 @@ Invalid descriptors
 * Cannot have multipath participants if <tt>musig()</tt> is also multipath: <tt>tr(musig(xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL/<0;1>,xpub68NZiKmJWnxxS6aaHmn81bvJeTESw724CRDs6HbuccFQN9Ku14VQrADWgqbhhTHBaohPX4CjNLf9fq9MYo6oDaPPLPxSb7gwQN3ih19Zm4Y)/<2;3>)</tt>
 * <tt>musig()</tt> cannot have hardened derivation steps: <tt>tr(musig(xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL,xpub68NZiKmJWnxxS6aaHmn81bvJeTESw724CRDs6HbuccFQN9Ku14VQrADWgqbhhTHBaohPX4CjNLf9fq9MYo6oDaPPLPxSb7gwQN3ih19Zm4Y)/0h/*)</tt>
 * <tt>musig()</tt> cannot have hardened child derivation: <tt>tr(musig(xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL,xpub68NZiKmJWnxxS6aaHmn81bvJeTESw724CRDs6HbuccFQN9Ku14VQrADWgqbhhTHBaohPX4CjNLf9fq9MYo6oDaPPLPxSb7gwQN3ih19Zm4Y)/0/*h)</tt>
+* <tt>musig()</tt> cannot have participants with child derivation when <tt>musig()</tt> has derivation steps: <tt>tr(musig(xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL/*,xpub68NZiKmJWnxxS6aaHmn81bvJeTESw724CRDs6HbuccFQN9Ku14VQrADWgqbhhTHBaohPX4CjNLf9fq9MYo6oDaPPLPxSb7gwQN3ih19Zm4Y/*)/1/2</tt>
 
 ==Backwards Compatibility==
 

--- a/bip-0390.mediawiki
+++ b/bip-0390.mediawiki
@@ -9,6 +9,7 @@
   Type: Informational
   Created: 2024-06-04
   License: CC0-1.0
+  Requires: 380
 </pre>
 
 ==Abstract==


### PR DESCRIPTION
Clarifies the restrictions on KEY expressions around when child derivation is allowed.

Also added a `Requires` header to all of the descriptor BIPs since they require reading 380 first.