### PR TITLE
388: fix incorrect example

### DIFF
--- a/bip-0388.mediawiki
+++ b/bip-0388.mediawiki
@@ -242,7 +242,7 @@ Common single-signature account patterns:
 Common multisig schemes:
 * <tt>wsh(multi(2,@0/**,@1/**))</tt> - SegWit 2-of-2 multisig, keys in order.
 * <tt>sh(sortedmulti(2,@0/**,@1/**,@2/**))</tt> - Legacy 2-of-3 multisig, sorted keys.
-* <tt>tr(musig(@0/**,@1/**))</tt> - MuSig2 2-of-2 in the taproot keypath
+* <tt>tr(musig(@0,@1)/**)</tt> - MuSig2 2-of-2 in the taproot keypath
 
 Some miniscript policies in <tt>wsh</tt>:
 * <tt>wsh(and_v(v:pk(@0/**),or_d(pk(@1/**),older(12960))))</tt> - Trust-minimized second factor, degrading to a single signature after about 90 days.


### PR DESCRIPTION
As per the test vectors, musig key expressions require the aggregation step to precede the change/address_index derivations in wallet policies.