### PR TITLE
CI: Allow `Version` field in checks as per BIP 3

### DIFF
--- a/scripts/buildtable.pl
+++ b/scripts/buildtable.pl
@@ -37,6 +37,9 @@ my %MiscField = (
 	'Requires' => undef,
 	'Superseded-By' => undef,
 );
+my %VersionField = (
+	'Version' => undef,
+);
 
 my %ValidLayer = (
 	'Consensus (soft fork)' => undef,
@@ -178,6 +181,8 @@ while (++$bipnum <= $topbip) {
 			die "Invalid date format in $fn" unless $val =~ /^20\d{2}\-(?:0\d|1[012])\-(?:[012]\d|30|31)$/;
 		} elsif (exists $EmailField{$field}) {
 			$val =~ m/^(\S[^<@>]*\S) \<[^@>]*\@[\w.]+\.\w+\>$/ or die "Malformed $field line in $fn";
+		} elsif (exists $VersionField{$field}) {
+			$val =~ m/^(\d+\.\d+\.\d+)$/ or die "Malformed $field line in $fn";
 		} elsif (not exists $MiscField{$field}) {
 			die "Unknown field $field in $fn";
 		}


### PR DESCRIPTION
[BIP 3 introduced](https://github.com/bitcoin/bips/blob/master/bip-0003.md#changelog) a `Version` field in the header with semver inspired syntax. This PR allows the inclusion of this field and checks that it matches the `<MAJOR.MINOR.PATCH>` format.