### PR TITLE
bip3: Switch to SPDX identifiers

### DIFF
--- a/bip-0003.md
+++ b/bip-0003.md
@@ -436,14 +436,14 @@ acceptable license.
 In other words, a new BIP must specify an SPDX License Expression that is either "L" or equivalent to "L OR E" for some
 acceptable license L from the following list and another SPDX License Expression E.
 
-* BSD-2-Clause: [OSI-approved BSD 2-clause license](https://opensource.org/licenses/BSD-2-Clause)
-* BSD-3-Clause: [OSI-approved BSD 3-clause license](https://opensource.org/licenses/BSD-3-Clause)
+* BSD-2-Clause: [BSD 2-Clause License](https://opensource.org/licenses/BSD-2-Clause)
+* BSD-3-Clause: [BSD 3-Clause License](https://opensource.org/licenses/BSD-3-Clause)
 * CC0-1.0: [Creative Commons CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/)
 * FSFAP: [FSF All Permissive License](https://www.gnu.org/prep/maintain/html_node/License-Notices-for-Other-Files.html)
 * CC-BY-4.0: [Creative Commons Attribution 4.0 International](https://creativecommons.org/licenses/by/4.0/)
-* MIT: [Expat/MIT/X11 license](https://opensource.org/licenses/MIT)
-* Apache-2.0: [Apache License, version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
-* BSL-1.0: [Boost Software License, version 1.0](http://www.boost.org/LICENSE_1_0.txt)
+* MIT: [Expat/MIT/X11 License](https://opensource.org/licenses/MIT)
+* Apache-2.0: [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+* BSL-1.0: [Boost Software License 1.0](https://www.boost.org/LICENSE_1_0.txt)
 
 #### Not Acceptable Licenses
 
@@ -451,7 +451,7 @@ All licenses not explicitly included in the above lists are not acceptable terms
 However, BIPs predating this proposal were accepted under other terms, and should use one the following identifiers.
 
 * LicenseRef-PD: Placed into the public domain
-* OPUBL-1.0: [Open Publication License, version 1.0](http://opencontent.org/openpub/)
+* OPUBL-1.0: [Open Publication License 1.0](https://opencontent.org/openpub/)
 
 ## BIP Editors
 
@@ -747,15 +747,15 @@ feedback, and helpful comments.
     The following previously acceptable licenses were retained per request of reviewers, even though they have so far
     never been used in the BIPs process:
 
-    * Apache-2.0: [Apache License, version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
-    * BSL-1.0: [Boost Software License, version 1.0](http://www.boost.org/LICENSE_1_0.txt)
+    * Apache-2.0: [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+    * BSL-1.0: [Boost Software License 1.0](https://www.boost.org/LICENSE_1_0.txt)
 
     The following previously acceptable licenses have never been used in the BIPs Process and have been dropped:
 
-    * AGPL-3.0+: [GNU Affero General Public License (AGPL), version 3 or newer](http://www.gnu.org/licenses/agpl-3.0.en.html)
-    * FDL-1.3: [GNU Free Documentation License, version 1.3](http://www.gnu.org/licenses/fdl-1.3.en.html)
-    * GPL-2.0+: [GNU General Public License (GPL), version 2 or newer](http://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html)
-    * LGPL-2.1+: [GNU Lesser General Public License (LGPL), version 2.1 or newer](http://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html)
+    * AGPL-3.0+: [GNU Affero General Public License (AGPL) 3](https://www.gnu.org/licenses/agpl-3.0.en.html)
+    * FDL-1.3: [GNU Free Documentation License 1.3](https://www.gnu.org/licenses/fdl-1.3.en.html)
+    * GPL-2.0+: [GNU General Public License (GPL) 2 or newer](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html)
+    * LGPL-2.1+: [GNU Lesser General Public License (LGPL) 2.1 or newer](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html)
 
     Why are software licenses included?
 


### PR DESCRIPTION
This has been discussed in https://github.com/bitcoin/bips/pull/1819#pullrequestreview-2770098094/

See individual commit messages for further rationale. I can squash the commits if this will be cleaner.  

This doesn't touch all the "License" and "License-Code" headers yet. Let's first agree on the changes, and then we can implement them.