### PR TITLE
BIP69: fix function name typo in example code

### DIFF
--- a/bip-0069/bip-0069_examples.py
+++ b/bip-0069/bip-0069_examples.py
@@ -49,7 +49,7 @@ def output_cmp(output_tuple1, output_tuple2):
 	elif (output_tuple1[0] > output_tuple2[0]):
 		return 1
 	#tie-breaker: scriptPubKey_byte_arr
-	return bytearray_cmp(output_tuple1[1], output_tuple2[1])
+	return bytearr_cmp(output_tuple1[1], output_tuple2[1])
 
 def sort_outputs(output_tuples):
 	return sorted(output_tuples, cmp=output_cmp)


### PR DESCRIPTION
Corrected a typo in the output_cmp function where the non-existent function bytearray_cmp was called. Changed it to the correct function name bytearr_cmp to ensure proper output comparison and prevent runtime errors. This fix improves code reliability and consistency.