### PR TITLE
BIP119: Fix plotting of pending transactions for congestion control rates

### DIFF
--- a/bip-0119/simulation.py
+++ b/bip-0119/simulation.py
@@ -122,8 +122,8 @@ if __name__ == "__main__":
 
 
     par1.set_ylabel("Confirmed but Pending Transactions")
-    p4, = par1.plot(blocktimes_c1, unspendable2, "c", label="Congestion Control Pending (2x Rate)")
-    p4, = par1.plot(blocktimes_c2, unspendable, "r", label="Congestion Control Pending (1x Rate)")
+    p4, = par1.plot(blocktimes_c1, unspendable, "c", label="Congestion Control Pending (1x Rate)")
+    p4b, = par1.plot(blocktimes_c2, unspendable2, "r", label="Congestion Control Pending (2x Rate)")
     par1.yaxis.label.set_color(p4.get_color())
 
 


### PR DESCRIPTION
Correct the assignment of variables when plotting "Confirmed but Pending Transactions" in the simulation. Now, the 1x rate line uses blocktimes_c1 and unspendable, and the 2x rate line uses blocktimes_c2 and unspendable2, ensuring the graph labels and data match correctly. This improves the accuracy and clarity of the simulation results visualization.