### PR TITLE
Fix: Use plural “bytes” in serialization table to match field size co…

### DIFF
--- a/bip-0032.mediawiki
+++ b/bip-0032.mediawiki
@@ -130,7 +130,7 @@ The first 32 bits of the identifier are called the key fingerprint.
 ===Serialization format===
 
 Extended public and private keys are serialized as follows:
-* 4 byte: version bytes (mainnet: 0x0488B21E public, 0x0488ADE4 private; testnet: 0x043587CF public, 0x04358394 private)
+* 4 bytes: version bytes (mainnet: 0x0488B21E public, 0x0488ADE4 private; testnet: 0x043587CF public, 0x04358394 private)
 * 1 byte: depth: 0x00 for master nodes, 0x01 for level-1 derived keys, ....
 * 4 bytes: the fingerprint of the parent's key (0x00000000 if master key)
 * 4 bytes: child number. This is ser<sub>32</sub>(i) for i in x<sub>i</sub> = x<sub>par</sub>/i, with x<sub>i</sub> the key being serialized. (0x00000000 if master key)


### PR DESCRIPTION
…nvention

Aligns the first field in the serialization table with the rest, which use plural “bytes” (e.g., “4 bytes: child number”) for consistency.