### PR TITLE
BIP3: drop optional License Code header

### DIFF
--- a/bip-0003.md
+++ b/bip-0003.md
@@ -396,7 +396,7 @@ For example, a preamble might include the following License header:
 
     License: CC0-1.0 OR MIT
 
-In this case, the BIP (including all auxiliary files) is made available under the terms of both Creative Commons CC0 1.0 Universal as well as the
+In this case, the BIP (including all auxiliary files) is made available under the terms of both CC0 1.0 Universal as well as the
 MIT License, and anyone may modify and redistribute it provided they comply with the terms of
 *either* license, at their option. In other words, the license list is an "OR choice", not an "AND also" requirement. See the [SPDX
 documentation](https://spdx.dev/ids/) and the [SPDX License List](https://spdx.org/licenses/) for further details.
@@ -426,7 +426,7 @@ acceptable license L from the following list and another SPDX License Expression
 
 * BSD-2-Clause: [BSD 2-Clause License](https://opensource.org/licenses/BSD-2-Clause)
 * BSD-3-Clause: [BSD 3-Clause License](https://opensource.org/licenses/BSD-3-Clause)
-* CC0-1.0: [Creative Commons CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/)
+* CC0-1.0: [CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/)
 * FSFAP: [FSF All Permissive License](https://www.gnu.org/prep/maintain/html_node/License-Notices-for-Other-Files.html)
 * CC-BY-4.0: [Creative Commons Attribution 4.0 International](https://creativecommons.org/licenses/by/4.0/)
 * MIT: [Expat/MIT/X11 License](https://opensource.org/licenses/MIT)
@@ -436,7 +436,7 @@ acceptable license L from the following list and another SPDX License Expression
 #### Not Acceptable Licenses
 
 All licenses not explicitly included in the above lists are not acceptable terms for a Bitcoin Improvement Proposal.
-However, BIPs predating this proposal were accepted under other terms, and should use one the following identifiers.
+However, BIPs predating this proposal were accepted under other terms, and should use one of the following identifiers.
 
 * LicenseRef-PD: Placed into the public domain
 * OPUBL-1.0: [Open Publication License 1.0](https://opencontent.org/openpub/)

--- a/bip-0003.md
+++ b/bip-0003.md
@@ -121,7 +121,6 @@ appear in the following order. Headers marked with "\*" are optional. All other 
   Type: <Specification | Informational | Process>
   Created: <Date of number assignment (yyyy-mm-dd), or "?">
   License: <SPDX License Expression>
-* License-Code: <SPDX License Expression for Code (if different)>
 * Discussion: <Noteworthy discussion threads in "yyyy-mm-dd: URL" format>
 * Version: <MAJOR.MINOR.PATCH>
 * Requires: <BIP number(s)>
@@ -147,8 +146,8 @@ appear in the following order. Headers marked with "\*" are optional. All other 
   Authors header. See the [BIP Ownership](#bip-ownership) section above.
 * Status — The stage of the workflow of the proposal. See the [Workflow](#workflow) section below.
 * Type — See the [BIP Types](#bip-types) section below for a description of the three BIP types.
-* License and License-Code — These headers specify SPDX License Expressions describing the licenses under which the
-  BIP and corresponding code are available. See the [BIP Licensing](#bip-licensing) section below.
+* License — The License header specifies SPDX License Expressions describing the terms under which the
+  BIP and its auxiliary files are available. See the [BIP Licensing](#bip-licensing) section below.
 * Discussion — The Discussion header points the audience to relevant discussions of the BIP, e.g., the mailing list
   thread in which the idea for the BIP was discussed, a thread where a new version of the BIP was presented, or relevant
   discussion threads on other platforms. Entries take the format "yyyy-mm-dd: URL", e.g., `2009-01-09:
@@ -402,24 +401,13 @@ MIT License, and anyone may modify and redistribute it provided they comply with
 *either* license, at their option. In other words, the license list is an "OR choice", not an "AND also" requirement. See the [SPDX
 documentation](https://spdx.dev/ids/) and the [SPDX License List](https://spdx.org/licenses/) for further details.
 
-It is also possible to specify that source code is licensed differently by including the optional License-Code header
-after the License header. Again, the licensing terms must be specified using an SPDX License Expression.
-
-Each auxiliary source code file or source directory should specify the license under which it is made available as is common in
+Wherever different from those specified in the License header, an auxiliary file or directory should specify the license terms under which it is made available as is common in
 software (e.g., with a [`SPDX-License-Identifier: <SPDX License Expression>` comment](https://spdx.dev/ids/),
-a license header, or a LICENSE/COPYING file). It is recommended to make any test vectors available
+a license header, or a LICENSE/COPYING file). Such exceptions should also be mentioned in the Copyright section. It is recommended to make any test vectors available
 under CC0-1.0 or FSFAP in addition to any other licenses to allow anyone to copy test vectors into their
-implementations without introducing license hindrances. Licenses listed in the License-Code header apply to all source directories,
-source code files, and test vectors provided with the BIP except those where a LICENSE file in a directory
-or the file header states otherwise.
+implementations without introducing license hindrances.
 
-For example, a preamble specifying the optional License-Code header might look like:
-
-    License:         CC0-1.0
-    License-Code:    MIT
-
-In this case, the source code in the BIP is not available under Creative Commons CC0 1.0 Universal, but is only available under the MIT
-License.
+A few BIP2-era BIPs (98, 116, 117, 330, 340) have a no longer used "License-Code" header indicating the license terms applicable to auxiliary source code files. For such cases, please refer to BIP2.
 
 It is recommended that source code included in a BIP (whether within the text or in auxiliary files) be licensed under the same license terms as the project it
 is proposed to modify, if any. For example, changes intended for Bitcoin Core would ideally be licensed (also) under the MIT
@@ -555,6 +543,7 @@ mentioned in the [Changelog](#changelog) section.
 - The "Post-History" header is replaced with the "Discussion" header.
 - The optional "Version" header is introduced.
 - The "Discussions-To" header is dropped as it has never been used in any BIP.
+- The "License-Code" header has been sunset, as it was used by only five BIPs (98, 116, 117, 330, 340) and created more ambiguity than clarity.
 - Introduce Deputies and optional "Deputies" header.
 - The BIP "Title" header may now contain up to 50 characters (increased from 44 in BIP 2).
 - The "Layer" header is optional for Specification BIPs or Informational BIPs, as it does not make sense for all BIPs.[^layer]
@@ -740,9 +729,11 @@ feedback, and helpful comments.
     * MIT: 2
     * CC-BY-4.0: 1
 
-    License-Code used:
+    License-Code used (previous BIP2 format):
 
-    * MIT: 4
+    * BSD-2-Clause: 1
+    * CC0-1.0: 1
+    * MIT: 5
 
     The following previously acceptable licenses were retained per request of reviewers, even though they have so far
     never been used in the BIPs process:


### PR DESCRIPTION
based on @real-or-random's https://github.com/bitcoin/bips/pull/1892#issuecomment-3051961323.

Also a couple of minor BIP3 touch-ups.