### PR TITLE
Fix dead link in BIP-70: Update Mozilla root store URL

### DIFF
--- a/bip-0070.mediawiki
+++ b/bip-0070.mediawiki
@@ -262,7 +262,7 @@ occurs.
 
 Trusted root certificates may be obtained from the operating system;
 if validation is done on a device without an operating system, the
-[http://www.mozilla.org/projects/security/certs/included/index.html Mozilla root store] is recommended.
+[https://www.mozilla.org/about/governance/policies/security-group/certs/policy/ Mozilla root store] is recommended.
 
 ==Extensibility==
 


### PR DESCRIPTION


## Changes

- **File:** `bip-0070.mediawiki`
- **Line 265:** Updated Mozilla root store URL
  - **From:** `http://www.mozilla.org/projects/security/certs/included/index.html`
  - **To:** `https://www.mozilla.org/about/governance/policies/security-group/certs/policy/`

