### PR TITLE
BIP352: add warning against omitting outputs

### DIFF
--- a/bip-0352.mediawiki
+++ b/bip-0352.mediawiki
@@ -312,7 +312,7 @@ After the inputs have been selected, the sender can create one or more outputs f
 *** If no additional outputs are required, continue to the next ''B<sub>m</sub>'' with ''k++''<ref name="why_not_the_same_tn">''' Why not re-use ''t<sub>k</sub>'' when paying different labels to the same receiver?''' If paying the same entity but to two separate labeled addresses in the same transaction without incrementing ''k'', an outside observer could subtract the two output values and observe that this value is the same as the difference between two published silent payment addresses and learn who the recipient is.</ref>
 ** Optionally, if the sending wallet implements receiving silent payments, it can create change outputs by sending to its own silent payment address using label ''m = 0'', following the steps above
 
-All generated outputs MUST be present in the final transaction. Otherwise, if a some output ''P<sub>i</sub>'' with ''i < k'' is omitted, the receiver will not be able to find outputs ''P<sub>j</sub>'' where ''i < j <= k''.
+All generated outputs MUST be present in the final transaction. If an output ''P<sub>i</sub>'' with ''i < k'' is omitted, the receiver will not be able to find outputs ''P<sub>j</sub>'' where ''i < j <= k''.
 
 === Receiver ===
 


### PR DESCRIPTION
While implied by the specification, add an explicit warning that generated outputs MUST not be omitted from the final transaction.