### PR TITLE
Mark BIP21 as replaced by 321, update 321 from Draft to Proposed

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -118,13 +118,13 @@ Those proposing changes should consider that ultimately consent may rest with th
 | Luke Dashjr
 | Standard
 | Replaced
-|- style="background-color: #cfffcf"
+|- style="background-color: #ffcfcf"
 | [[bip-0021.mediawiki|21]]
 | Applications
 | URI Scheme
 | Nils Schneider, Matt Corallo
 | Standard
-| Final
+| Replaced
 |- style="background-color: #cfffcf"
 | [[bip-0022.mediawiki|22]]
 | API/RPC
@@ -980,13 +980,13 @@ Those proposing changes should consider that ultimately consent may rest with th
 | BtcDrak
 | Standard
 | Draft
-|-
+|- style="background-color: #ffffcf"
 | [[bip-0321.mediawiki|321]]
 | Applications
 | URI Scheme
 | Matt Corallo
 | Standard
-| Draft
+| Proposed
 |-
 | [[bip-0322.mediawiki|322]]
 | Applications

--- a/bip-0021.mediawiki
+++ b/bip-0021.mediawiki
@@ -6,10 +6,17 @@
           Matt Corallo <bip21@bluematt.me>
   Comments-Summary: No comments yet.
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0021
-  Status: Final
+  Status: Replaced
   Type: Standards Track
   Created: 2012-01-29
+  Superseded-By: 321
 </pre>
+
+=Superseded by BIP 321=
+
+This BIP has been superseded and replaced with BIP 321. Please see [[bip-0321.mediawiki|BIP 321]] instead.
+
+=Original BIP=
 
 This BIP is a modification of an earlier [[bip-0020.mediawiki|BIP 0020]] by Luke Dashjr. BIP 0020 was based off an earlier document by Nils Schneider. The alternative payment amounts in BIP 0020 have been removed.
 

--- a/bip-0321.mediawiki
+++ b/bip-0321.mediawiki
@@ -5,7 +5,7 @@
   Author: Matt Corallo <bip21@bluematt.me>
   Comments-Summary: No comments yet.
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0321
-  Status: Draft
+  Status: Proposed
   Type: Standards Track
   Created: 2024-11-15
   License: BSD-2-Clause


### PR DESCRIPTION
Not sure what the right timeline for this is, but at some point this should happen.