### PR TITLE
BIP16: fix formatting and terminology issues

### DIFF
--- a/bip-0016.mediawiki
+++ b/bip-0016.mediawiki
@@ -58,7 +58,7 @@ Examples:
 +3 signature operations:
     {2 [pubkey1] [pubkey2] [pubkey3] 3 OP_CHECKMULTISIG}
 
-+22 signature operations
++22 signature operations:
     {OP_CHECKSIG OP_IF OP_CHECKSIGVERIFY OP_ELSE OP_CHECKMULTISIGVERIFY OP_ENDIF}
 
 ==Rationale==
@@ -74,7 +74,7 @@ The signature operation counting rules are intended to be easy and quick to impl
 There is a 1-confirmation attack on old implementations, but it is expensive and difficult in practice. The attack is:
 
 # Attacker creates a pay-to-script-hash transaction that is valid as seen by old software, but invalid for new implementation, and sends themselves some coins using it.
-# Attacker also creates a standard transaction that spends the pay-to-script transaction, and pays the victim who is running old software.
+# Attacker also creates a standard transaction that spends the pay-to-script-hash transaction, and pays the victim who is running old software.
 # Attacker mines a block that contains both transactions.
 
 If the victim accepts the 1-confirmation payment, then the attacker wins because both transactions will be invalidated when the rest of the network overwrites the attacker's invalid block.
@@ -116,4 +116,4 @@ https://gist.github.com/gavinandresen/3966071
 * [[bip-0016/qa.mediawiki|Quality Assurance test checklist]]
 
 == References ==
-<references>
+<references></references>


### PR DESCRIPTION
- Add colon after "+22 signature operations" 
- Fix terminology by changing "pay-to-script transaction" to "pay-to-script-hash transaction" 
- Add closing tag "</references>" 