### PR TITLE
BIP 70: fix link to payment request generator

### DIFF
--- a/bip-0070.mediawiki
+++ b/bip-0070.mediawiki
@@ -302,7 +302,7 @@ Protocol Buffers : https://developers.google.com/protocol-buffers/
 
 ==Reference implementation==
 
-Create Payment Request generator : https://bitcoincore.org/~gavin/createpaymentrequest.php ([[https://github.com/gavinandresen/paymentrequest|source]])
+Create Payment Request generator : https://developer.bitcoin.org/examples/payment_processing.html ([[https://github.com/gavinandresen/paymentrequest|source]])
 
 BitcoinJ : https://bitcoinj.github.io/payment-protocol#introduction
 


### PR DESCRIPTION
Replaced outdated link to “Create Payment Request generator” in bip-0070.mediawiki:

https://bitcoincore.org/~gavin/createpaymentrequest.php → https://developer.bitcoin.org/examples/payment_processing.html