### PR TITLE
fix: quote filename variable in link format checker script

### DIFF
--- a/scripts/link-format-chk.sh
+++ b/scripts/link-format-chk.sh
@@ -9,7 +9,7 @@
 ECODE=0
 FILES=""
 for fname in *.mediawiki; do
-    GRES=$(grep -n '](http' $fname)
+    GRES=$(grep -n '](http' "$fname")
     if [ "$GRES" != "" ]; then
         if [ $ECODE -eq 0 ]; then
             >&2 echo "Github Mediawiki format writes link as [URL text], not as [text](url):"


### PR DESCRIPTION
Quote the $fname variable in grep command to properly handle filenames containing spaces or special characters. This follows bash best practices and prevents potential shell injection or parsing issues.