### PR TITLE
BIP352: fix byte unpacking and avoid mutable default argument

### DIFF
--- a/bip-0352/bitcoin_utils.py
+++ b/bip-0352/bitcoin_utils.py
@@ -32,13 +32,11 @@ def deser_txid(txid: str):
 
 
 def deser_compact_size(f: BytesIO):
-    view = f.getbuffer()
-    nbytes = view.nbytes;
-    view.release()
-    if (nbytes == 0):
-        return 0 # end of stream
+    b = f.read(1)
+    if not b:
+        return 0  # end of stream
 
-    nit = struct.unpack("<B", f.read(1))[0]
+    nit = struct.unpack("<B", b)[0]
     if nit == 253:
         nit = struct.unpack("<H", f.read(2))[0]
     elif nit == 254:

--- a/bip-0352/reference.py
+++ b/bip-0352/reference.py
@@ -4,7 +4,7 @@
 
 import hashlib
 import json
-from typing import List, Tuple, Dict, cast
+from typing import List, Tuple, Dict, cast, Optional
 from sys import argv, exit
 from functools import reduce
 from itertools import permutations
@@ -152,7 +152,9 @@ def create_outputs(input_priv_keys: List[Tuple[ECKey, bool]], outpoints: List[CO
     return list(set(outputs))
 
 
-def scanning(b_scan: ECKey, B_spend: ECPubKey, A_sum: ECPubKey, input_hash: bytes, outputs_to_check: List[ECPubKey], labels: Dict[str, str] = {}) -> List[Dict[str, str]]:
+def scanning(b_scan: ECKey, B_spend: ECPubKey, A_sum: ECPubKey, input_hash: bytes, outputs_to_check: List[ECPubKey], labels: Optional[Dict[str, str]] = None) -> List[Dict[str, str]]:
+    if labels is None:
+        labels = {}
     G = ECKey().set(1).get_pubkey()
     ecdh_shared_secret = input_hash * b_scan * A_sum
     k = 0


### PR DESCRIPTION
- Fixed `deser_compact_size` to correctly unpack the first byte instead of reading twice.  

- Updated `scanning` to use `Optional[Dict]` with safe default (`None` → `{}`) to prevent mutable default argument issues.  
