### PR TITLE
BIP-0010: replace TXSIGS with SIG in TxDP merge section

### DIFF
--- a/bip-0010.mediawiki
+++ b/bip-0010.mediawiki
@@ -95,7 +95,7 @@ In this transaction, there are two inputs, one of 150 BTC and the other of 12 BT
 
 The style of communication is taken directly from PGP/GPG, which uses blocks of ASCII like this to communicate encrypted messages and signatures.  This serialization is compact, and will be interpreted the same in all character encodings.  It can be copied inline into an email, or saved in a text file.  The advantage over the analogous PGP encoding is that there are some human readable elements to it, for users that wish to examine the TxDP packet manually, instead of requiring a program to parse the core elements of the TxDP.
 
-A party receiving this TxDP can simply add their signature to the appropriate _TXINPUT_ line.  If that is the last signature required, they can broadcast it themselves.  Any software that implements this standard should be able to combine multiple TxDPs into a single TxDP.  However, even without the programmatic support, a user could manually combine them by copying the appropriate _TXSIGS_ lines between serializations, though it is not the recommended method for combining TxDPs.
+A party receiving this TxDP can simply add their signature to the appropriate _TXINPUT_ line.  If that is the last signature required, they can broadcast it themselves.  Any software that implements this standard should be able to combine multiple TxDPs into a single TxDP.  However, even without the programmatic support, a user could manually combine them by copying the appropriate _SIG_ lines between serializations, though it is not the recommended method for combining TxDPs.
 
 == Reference Implementation ==
 


### PR DESCRIPTION
Fix a documentation inconsistency in bip-0010.mediawiki: replace _TXSIGS_ with _SIG_ in the paragraph describing manual merging of TxDPs.
_SIG_ is the token defined in the earlier format spec; _TXSIGS_ was not defined and could cause confusion.