### PR TITLE
BIP374: remove debug print from test runner

### DIFF
--- a/bip-0374/run_test_vectors.py
+++ b/bip-0374/run_test_vectors.py
@@ -23,7 +23,6 @@ with open(FILENAME_GENERATE_PROOF_TEST, newline='') as csvfile:
     next(reader)
     for row in reader:
         (index, point_G_hex, seckey_a_hex, point_B_hex, aux_rand_hex, msg_hex, result_str, comment) = row
-        print(seckey_a_hex)
         G = GE() if point_G_hex == 'INFINITY' else GE.from_bytes(bytes.fromhex(point_G_hex))
         a = int.from_bytes(bytes.fromhex(seckey_a_hex), 'big')
         B = GE() if point_B_hex == 'INFINITY' else GE.from_bytes(bytes.fromhex(point_B_hex))


### PR DESCRIPTION
Remove leftover debug print statement that was printing private keys(seckey_a_hex) to console during test execution. Improves test output readability and consistency.