### PR TITLE
Create aladas-org_new_lang_proposals

### DIFF
--- a/bip-0039/aladas-org_new_lang_proposals
+++ b/bip-0039/aladas-org_new_lang_proposals
@@ -1,0 +1,8 @@
+We would like to submit BIP39 wordlists which built from word compilations and scripts to extract 2048 words with unique 3,4 prefix. 
+The proposed languages are Deutsch, Esperanto, Russian, Hindi, Greek and Latin
+
+They are used in this application, a wallet generator:
+https://www.npmjs.com/package/@aladas-org/cryptocalc
+
+And the wordlist are published here:
+https://github.com/ALADAS-org/Cryptocalc/tree/master/assets/mnemonics


### PR DESCRIPTION
We would like to submit BIP39 wordlists which built from word compilations and scripts to extract 2048 words with unique 3,4 prefix.  The proposed languages are Deutsch, Esperanto, Russian, Hindi, Greek and Latin

They are used in this application, a wallet generator: https://www.npmjs.com/package/@aladas-org/cryptocalc

And the wordlist are published here:
https://github.com/ALADAS-org/Cryptocalc/tree/master/assets/mnemonics