### PR TITLE
scripts/diffcheck.sh: Use secure temp files and git archive for better safety

### DIFF
--- a/scripts/diffcheck.sh
+++ b/scripts/diffcheck.sh
@@ -1,10 +1,22 @@
 #!/bin/bash
 
-scripts/buildtable.pl >/tmp/table.mediawiki 2> /dev/null
-diff README.mediawiki /tmp/table.mediawiki | grep '^[<>] |' >/tmp/after.diff || true
-if git checkout HEAD^ && scripts/buildtable.pl >/tmp/table.mediawiki 2>/dev/null; then
-    diff README.mediawiki /tmp/table.mediawiki | grep '^[<>] |' >/tmp/before.diff || true
-    newdiff=$(diff -s /tmp/before.diff /tmp/after.diff -u | grep '^+')
+# Create secure temporary directories and ensure cleanup
+tmp_dir="$(mktemp -d)"; prev_dir="$(mktemp -d)"; trap 'rm -rf "$tmp_dir" "$prev_dir"' EXIT
+
+# Paths for current commit artifacts
+table_file="$tmp_dir/table.mediawiki"
+after_diff="$tmp_dir/after.diff"
+before_diff="$tmp_dir/before.diff"
+table_prev_file="$tmp_dir/table_prev.mediawiki"
+
+# Build table from current working tree and compute diff
+scripts/buildtable.pl >"$table_file" 2>/dev/null
+diff README.mediawiki "$table_file" | grep '^[<>] |' >"$after_diff" || true
+
+# Build table from previous commit without altering the working tree
+if git archive --format=tar HEAD^ | tar -x -C "$prev_dir" && perl "$prev_dir/scripts/buildtable.pl" >"$table_prev_file" 2>/dev/null; then
+    diff "$prev_dir/README.mediawiki" "$table_prev_file" | grep '^[<>] |' >"$before_diff" || true
+    newdiff=$(diff -s "$before_diff" "$after_diff" -u | grep '^+')
     if [ -n "$newdiff" ]; then
         echo "$newdiff"
         exit 1


### PR DESCRIPTION
## Summary
Refactor `scripts/diffcheck.sh` to improve security and reliability by replacing fixed `/tmp` paths with secure temporary directories and avoiding destructive `git checkout`.

## Changes
- **Secure temp files**: Use `mktemp -d` with automatic cleanup via `trap` instead of hardcoded `/tmp` paths
- **Non-destructive git operations**: Replace `git checkout HEAD^` with `git archive` to avoid modifying working tree state

