### PR TITLE
BIP374: in tests, pass message when verifying proof with message

### DIFF
--- a/bip-0374/reference.py
+++ b/bip-0374/reference.py
@@ -144,5 +144,5 @@ class DLEQTests(unittest.TestCase):
                 proof_damaged[random.randrange(len(proof))] ^= 1 << (
                     random.randrange(8)
                 )
-                success = dleq_verify_proof(A, B, C, bytes(proof_damaged))
+                success = dleq_verify_proof(A, B, C, bytes(proof_damaged), m=message)
                 self.assertFalse(success)


### PR DESCRIPTION
Ensure consistency by passing m=message when verifying a tampered proof
Strengthens the test to match the proof generation context
No behavior change expected; tests pass locally