### PR TITLE
BIP-0443: fix grammar, wording, and clarity improvements

### DIFF
--- a/bip-0443.mediawiki
+++ b/bip-0443.mediawiki
@@ -23,7 +23,7 @@ validated during the execution of the script, allowing introspection to the comm
 constrain the internal public key and taptree of one or more outputs, and possibly the committed data.
 
 In conjunction with an opcode for ''vector commitments''<ref>''Vector commitments'' are cryptographic primitives that
-allow to commit to a vector of values via a single short value. Hashing and concatenation trivially allow to commit to
+allow to committing to a vector of values via a single short value. Hashing and concatenation trivially allow to commit to
 an entire vector, and later reveal all of its elements. Merkle trees are among the simplest efficient vector
 commitments, allowing to reveal individual elements with logarithmically-sized proofs.</ref>, this allows to create and
 compose arbitrary state machines that define the possible future outcomes of a UTXO. The validity of a state transition
@@ -80,7 +80,7 @@ transaction (in order to define its program, and possibly its committed data).
 
 When checking the script of one or more outputs with <code>OP_CHECKCONTRACTVERIFY</code>, it is usually necessary to
 also check that the amount of the current input (that is, the UTXO being spent) is correctly distributed among the
-outputs in the expected way. Therefore, the opcode already includes an amount semantic that covers the common use cases.
+outputs in the expected way. Therefore, the opcode already includes an amount semantics that covers the common use cases.
 
 There are three supported modes for the opcode when checking an output, depending on the value of the <code>mode</code>
 parameter:
@@ -106,26 +106,26 @@ allows multiple inputs to aggregate (in full or in part) their amounts to the sa
 -----
 
 ::[[File:bip-0443/amount_example_1.png|framed|center|alt=1-to-1 amount logic|600px]]
-::'''Figure 1:''' A UTXO <code>A</code> sends the entire amount to some output contract <code>B</code>, using <code>CCV</code> with the <i>default</i> semantic.
+::'''Figure 1:''' A UTXO <code>A</code> sends the entire amount to some output contract <code>B</code>, using <code>CCV</code> with the <i>default</i> semantics.
 
 -----
 
 ::[[File:bip-0443/amount_example_2.png|framed|center|alt=3-to-1 aggregate amount logic|600px]]
-::'''Figure 2:''' Three UTXOs aggregate their amounts towards the same output contract, using <code>CCV</code> with the <i>default</i> semantic.
+::'''Figure 2:''' Three UTXOs aggregate their amounts towards the same output contract, using <code>CCV</code> with the <i>default</i> semantics.
 
 -----
 
 ::[[File:bip-0443/amount_example_3.png|framed|center|alt=split amount logic|600px]]
-::'''Figure 3:''' A UTXO <code>A</code> sends a portion of its amount to a contract <code>A'</code> identical to itself, and the rest to a different contract <code>B</code>. It would use <code>CCV</code> to introspect its own input's program, then to check the first output with the <i>deduct</i> semantic, then to check the second output with the <i>default</i> semantic to assign the residual amount.
+::'''Figure 3:''' A UTXO <code>A</code> sends a portion of its amount to a contract <code>A'</code> identical to itself, and the rest to a different contract <code>B</code>. It would use <code>CCV</code> to introspect its own input's program, then to check the first output with the <i>deduct</i> semantics, then to check the second output with the <i>default</i> semantics to assign the residual amount.
 
 -----
 
 ::[[File:bip-0443/amount_example_4.png|framed|center|alt=split and aggregate amount logic|600px]]
-::'''Figure 4:''' Similar to the previous example, but a second input <code>B</code> also checks the same output <code>X</code> with the <i>default</i> semantic, aggregating its input with the residual amount of the first input.
+::'''Figure 4:''' Similar to the previous example, but a second input <code>B</code> also checks the same output <code>X</code> with the <i>default</i> semantics, aggregating its input with the residual amount of the first input.
 
 -----
 
-Note that the ''deduct'' semantic does not allow to check the exact amount of its output. Therefore, in contracts using
+Note that the ''deduct'' semantics does not allow to check the exact amount of its output. Therefore, in contracts using
 a scheme similar to figure 3 or 4 above, amounts should be constrained either with a signature, or with future
 introspection opcodes that allow fixing the amount. In lack of that, amounts would be malleable.
 
@@ -176,7 +176,7 @@ If the <code><data></code> is non-empty, then the additive tweak for the data is
 
 In the following, the ''current input'' is the input whose script is being executed.
 
-The following value of the <code><mode></code> are defined:
+The following values of the <code><mode></code> are defined:
 * <code>CCV_MODE_CHECK_INPUT = -1</code>: Check an input's script; no amount check.
 * <code>CCV_MODE_CHECK_OUTPUT = 0</code>: Check an output's script; preserve the (possibly residual) amount.
 * <code>CCV_MODE_CHECK_OUTPUT_IGNORE_AMOUNT = 1</code>: Check an output's script; ignore amounts.
@@ -188,7 +188,7 @@ would always be hard-coded via a push in the script, the risk of mistakes seems 
 
 The following values of the other parameters have special meanings:
 * If the <code><taptree></code> is -1, it is replaced with the Merkle root of the current input's tapscript tree. If the taptree is the empty buffer, then the taptweak is skipped.
-* If the <code><pk></code> is 0, it is replaced with the NUMS x-only pubkey <code>0x50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0</code> defined in [[bip-0341.mediawiki|BIP-341]]. If the <code><pk></code> is -1, it is replaced with the taproot internal key of the current input.
+* If the <code><pk></code> is a minimally encoded 0, it is replaced with the NUMS x-only pubkey <code>0x50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0</code> defined in [[bip-0341.mediawiki|BIP-341]]. If the <code><pk></code> is -1, it is replaced with the taproot internal key of the current input.
 * If the <code><index></code> is -1, it is replaced with the index of the current input.
 * If the <code><data></code> is the empty buffer, then there is no data tweak for the input/output being checked.
 
@@ -252,7 +252,7 @@ This is executed at the beginning of the evaluation of each input's script. It i
 the full amount of the current input.
 
 <source lang="python">
-  residual_input_amount = input[this_input_index].amount
+  residual_input_amount = inputs[this_input_index].amount
 </source>
 
 ==== <code>OP_CHECKCONTRACTVERIFY</code> evaluation ====
@@ -311,7 +311,7 @@ defined in [[bip-0341.mediawiki|BIP-341]].
   # Amount checks
 
   if mode == CCV_MODE_CHECK_OUTPUT:
-    # default amount semantic
+    # default amount semantics
     if output_checked_deduct[index]:
       return fail()
 
@@ -323,7 +323,7 @@ defined in [[bip-0341.mediawiki|BIP-341]].
 
     output_checked_default[index] = True
   elif mode == CCV_MODE_CHECK_OUTPUT_DEDUCT_AMOUNT:
-    # 'deduct' amount semantic
+    # 'deduct' amount semantics
     if residual_input_amount < outputs[index].amount:
       return fail()
 


### PR DESCRIPTION
- Clarified `<pk>` replacement rule: now specifies "minimally encoded 0" instead of just "0".
- Fixed grammar in phrases (`semantic` → `semantics`, `value` → `values`).
- Corrected sentence structure ("allow to commit" → "allow to committing").
- Minor variable name fix in pseudocode (`input` → `inputs`).
