### PR TITLE
BIP-0388: fix typos and wording

### DIFF
--- a/bip-0388.mediawiki
+++ b/bip-0388.mediawiki
@@ -35,7 +35,7 @@ This BIP is licensed under the BSD 2-clause license.
 
 Unfortunately, descriptors are not a perfect match for the typical usage of hardware signing devices (often also called ''hardware wallets''). Most of them have some of the following limitations when compared to a general-purpose machine running Bitcoin Core:
 
-* they are embedded devices with limited RAM, and computational power;
+* they are embedded devices with limited RAM and computational power;
 * they cannot import additional private keys (that is, they can only sign with keys derived from a single seed via [[bip-0032.mediawiki|BIP-32]]);
 * they have limited storage, or they might not have persistent storage at all (''stateless design'').
 
@@ -74,7 +74,7 @@ It is out of scope for this document to guarantee that users do not reuse extend
 
 ==== UX issues ====
 
-Miniscript (and taproot trees) allow substantially more complex spending policies. It is a challenge to ensure that the user can practically verify such spending policies per the screen.
+Miniscript (and taproot trees) allow substantially more complex spending policies. It is a challenge to ensure that the user can practically verify such spending policies on the screen.
 
 We set two fundamental design goals:
 * Minimize the amount of information that is shown on screen - so that the user can actually validate it.
@@ -124,7 +124,7 @@ This section formally defines wallet policies, and how they relate to output scr
 
 === Formal definition ===
 
-A ''wallet policy'' is composed by a ''wallet descriptor template'', together with a vector of ''key information items''.
+A ''wallet policy'' is composed of a ''wallet descriptor template'', together with a vector of ''key information items''.
 
 ==== Wallet descriptor template ====
 
@@ -309,7 +309,7 @@ The following descriptor templates are invalid:
 * <tt>sh(multi(1,@0/**,@0/**))</tt>: Repeated keys with the same path expression
 * <tt>sh(multi(1,@0/<0;1>/*,@0/<1;2>/*))</tt>: Non-disjoint multipath expressions (<tt>@0/1/*</tt> appears twice)
 * <tt>sh(multi(1,@0/**,xpub6AHA9hZDN11k2ijHMeS5QqHx2KP9aMBRhTDqANMnwVtdyw2TDYRmF8PjpvwUFcL1Et8Hj59S3gTSMcUQ5gAqTz3Wd8EsMTmF3DChhqPQBnU/<0;1>/*))</tt>: Expression with a non-KP key present
-* <tt>pkh(@0/<0;1;2>/*)</tt>: Solved cardinality > 2
+* <tt>pkh(@0/<0;1;2>/*)</tt>: Allowed cardinality > 2
 * <tt>tr(musig(@0/**,@1/**))</tt>: Derivation before aggregation is not allowed in wallet policies (despite being allowed in [[bip-0390.mediawiki|BIP-390]])
 
 Remark: some of the examples of invalid descriptor templates may be valid via optional extensions.


### PR DESCRIPTION
- Fixed typo in invalid examples: "Solved cardinality" → "Allowed cardinality".
- Removed unnecessary comma in "limited RAM and computational power".
- Changed "per the screen" → "on the screen" for clarity.
- Corrected "composed by" → "composed of".
