### PR TITLE
CI: migrate workflows to checkout v5

### DIFF
--- a/.github/workflows/github-action-checks.yml
+++ b/.github/workflows/github-action-checks.yml
@@ -5,18 +5,18 @@ jobs:
   Link-Format-Checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - run: scripts/link-format-chk.sh
   Build-Table-Checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - run: scripts/buildtable.pl >/tmp/table.mediawiki || exit 1
   Diff-Checks:
     name: "Diff Checks (fails until number assignment)"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 2
       - run: scripts/diffcheck.sh
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Check spelling
         uses: crate-ci/typos@master


### PR DESCRIPTION
Bumps checkout to v5 for future-proofing against Node 24 runner updates. Requires runner v2.327.1+. Workflows compile the same.

More info: https://github.com/actions/checkout/releases/tag/v5.0.0