### PR TITLE
BIP155: update status from Draft to Proposed

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -889,13 +889,13 @@ Those proposing changes should consider that ultimately consent may rest with th
 | Karl-Johan Alm
 | Standard
 | Withdrawn
-|-
+|- style="background-color: #ffffcf"
 | [[bip-0155.mediawiki|155]]
 | Peer Services
 | addrv2 message
 | Wladimir J. van der Laan
 | Standard
-| Draft
+| Proposed
 |- style="background-color: #ffcfcf"
 | [[bip-0156.mediawiki|156]]
 | Peer Services

--- a/bip-0155.mediawiki
+++ b/bip-0155.mediawiki
@@ -5,7 +5,7 @@
   Author: Wladimir J. van der Laan <laanwj@gmail.com>
   Comments-Summary: No comments yet.
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0155
-  Status: Draft
+  Status: Proposed
   Type: Standards Track
   Created: 2019-02-27
   License: BSD-2-Clause


### PR DESCRIPTION
BIP155 has been deployed in Bitcoin Core since a few years. It could also be Final, but I hesitate to do that because new networks may be added to the reserved network IDs table.

If BIP3 is activated, I think BIP155 would become Deployed.