### PR TITLE
scripts: remove unused FILES variable in link-format-chk.sh

### DIFF
--- a/scripts/link-format-chk.sh
+++ b/scripts/link-format-chk.sh
@@ -7,7 +7,6 @@
 # Check wrong mediawiki link format
 
 ECODE=0
-FILES=""
 for fname in *.mediawiki; do
     GRES=$(grep -n '](http' $fname)
     if [ "$GRES" != "" ]; then


### PR DESCRIPTION
Remove unused FILES variable that was declared but never referenced in the script.