### PR TITLE
BIP352: remove unused import from reference.py

### DIFF
--- a/bip-0352/reference.py
+++ b/bip-0352/reference.py
@@ -7,7 +7,6 @@ import json
 from typing import List, Tuple, Dict, cast
 from sys import argv, exit
 from functools import reduce
-from itertools import permutations
 
 # local files
 from bech32m import convertbits, bech32_encode, decode, Encoding


### PR DESCRIPTION
Remove from itertools import permutations which is not used anywhere
Re-checked the codebase: no calls to permutations(...)