### PR TITLE
style: move import statement to top of file

### DIFF
--- a/bip-0330/minisketch.py
+++ b/bip-0330/minisketch.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+import random
+
 ######## ENCODING and DECODING ########
 
 FIELD_BITS = 32
@@ -30,8 +32,6 @@ def sketch(shortids, capacity):
     return b''.join(elem.to_bytes(4, 'little') for elem in odd_sums)
 
 ######## DECODING only ########
-
-import random
 
 def inv(x):
     """Compute 1/x in GF(2^FIELD_BITS)"""


### PR DESCRIPTION
Moved 'import random' from the middle of the file to the beginning to follow Python coding conventions where all imports should be placed at the top of the file after the shebang line
