### PR TITLE
BIP345: fix broken links

### DIFF
--- a/bip-0345.mediawiki
+++ b/bip-0345.mediawiki
@@ -393,7 +393,7 @@ unauthorized recovery transaction is limited.
 
 == Implementation ==
 
-A sample implementation is available on bitcoin-inquisition [https://github.com/jamesob/bitcoin/tree/2023-01-opvault here], with an associated [https://github.com/bitcoin-inquisition/bitcoin/pull/21 pull request].
+A sample implementation is available on bitcoin-inquisition [https://github.com/jamesob/bitcoin/tree/2023-02-opvault-inq here], with an associated [https://github.com/bitcoin-inquisition/bitcoin/pull/21 pull request].
 
 
 == Applications ==


### PR DESCRIPTION
- Updated MES16 paper link to crypto.news mirror
- Fixed outdated bitcoin-inquisition repo link
