### PR TITLE
BIP85: replace Base64 by Base85 in PWD BASE85 section

### DIFF
--- a/bip-0085.mediawiki
+++ b/bip-0085.mediawiki
@@ -292,11 +292,11 @@ The derivation path format is: <code>m/83696968'/707764'/{pwd_len}'/{index}'</co
 `20 <= pwd_len <= 86`
 
 [https://datatracker.ietf.org/doc/html/rfc4648 Base64] encode all 64 bytes of entropy.
-Remove any spaces or new lines inserted by Base64 encoding process. Slice base64 result string
+Remove any spaces or new lines inserted by Base64 encoding process. Slice Base64 result string
 on index 0 to `pwd_len`. This slice is the password. As `pwd_len` is limited to 86, passwords will not contain padding.
 
 Entropy calculation:<br>
-R = 64  (base64 - do not count padding)<br>
+R = 64  (Base64 - do not count padding)<br>
 L = pwd_len<br>
 Entropy = log2(R ** L)<br>
 
@@ -330,7 +330,7 @@ The derivation path format is: <code>m/83696968'/707785'/{pwd_len}'/{index}'</co
 `10 <= pwd_len <= 80`
 
 Base85 encode all 64 bytes of entropy.
-Remove any spaces or new lines inserted by Base85 encoding process. Slice base85 result string
+Remove any spaces or new lines inserted by Base85 encoding process. Slice Base85 result string
 on index 0 to `pwd_len`. This slice is the password. `pwd_len` is limited to 80 characters.
 
 Entropy calculation:<br>


### PR DESCRIPTION
Replace `Base64` by `Base85` encoder in the Pwd Base85 section, and use consistent capitalization.