### PR TITLE
BIP3: license section updates

### DIFF
--- a/bip-0003.md
+++ b/bip-0003.md
@@ -424,12 +424,12 @@ acceptable license.
 In other words, a new BIP must specify an SPDX License Expression that is either "L" or equivalent to "L OR E" for some
 acceptable license L from the following list and another SPDX License Expression E.
 
-* BSD-2-Clause: [BSD 2-Clause License](https://opensource.org/licenses/BSD-2-Clause)
-* BSD-3-Clause: [BSD 3-Clause License](https://opensource.org/licenses/BSD-3-Clause)
+* BSD-2-Clause: [BSD 2-Clause License](https://opensource.org/license/BSD-2-Clause)
+* BSD-3-Clause: [BSD 3-Clause License](https://opensource.org/license/BSD-3-Clause)
 * CC0-1.0: [CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/)
 * FSFAP: [FSF All Permissive License](https://www.gnu.org/prep/maintain/html_node/License-Notices-for-Other-Files.html)
 * CC-BY-4.0: [Creative Commons Attribution 4.0 International](https://creativecommons.org/licenses/by/4.0/)
-* MIT: [Expat/MIT/X11 License](https://opensource.org/licenses/MIT)
+* MIT: [Expat/MIT/X11 License](https://opensource.org/license/MIT)
 * Apache-2.0: [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 * BSL-1.0: [Boost Software License 1.0](https://www.boost.org/LICENSE_1_0.txt)
 

--- a/bip-0003.md
+++ b/bip-0003.md
@@ -429,7 +429,7 @@ acceptable license L from the following list and another SPDX License Expression
 * CC0-1.0: [CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/)
 * FSFAP: [FSF All Permissive License](https://www.gnu.org/prep/maintain/html_node/License-Notices-for-Other-Files.html)
 * CC-BY-4.0: [Creative Commons Attribution 4.0 International](https://creativecommons.org/licenses/by/4.0/)
-* MIT: [Expat/MIT/X11 License](https://opensource.org/license/MIT)
+* MIT: [The MIT License](https://opensource.org/license/MIT)
 * MIT-0: [MIT No Attribution License](https://opensource.org/license/MIT-0)
 * Apache-2.0: [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 * BSL-1.0: [Boost Software License 1.0](https://www.boost.org/LICENSE_1_0.txt)

--- a/bip-0003.md
+++ b/bip-0003.md
@@ -430,6 +430,7 @@ acceptable license L from the following list and another SPDX License Expression
 * FSFAP: [FSF All Permissive License](https://www.gnu.org/prep/maintain/html_node/License-Notices-for-Other-Files.html)
 * CC-BY-4.0: [Creative Commons Attribution 4.0 International](https://creativecommons.org/licenses/by/4.0/)
 * MIT: [Expat/MIT/X11 License](https://opensource.org/license/MIT)
+* MIT-0: [MIT No Attribution License](https://opensource.org/license/MIT-0)
 * Apache-2.0: [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 * BSL-1.0: [Boost Software License 1.0](https://www.boost.org/LICENSE_1_0.txt)
 


### PR DESCRIPTION
Picks up #1931 and adds a commit to update the MIT license name. Changes:

- Fix up license URLs with 301 redirects
- Add MIT-0 License
- Update MIT license name per https://opensource.org/license/MIT and https://spdx.org/licenses/MIT
