### PR TITLE
BIP2: license section fixups

### DIFF
--- a/bip-0002.mediawiki
+++ b/bip-0002.mediawiki
@@ -372,7 +372,7 @@ In addition, it is recommended that literal code included in the BIP be dual-lic
 * BSL-1.0: [https://www.boost.org/LICENSE_1_0.txt Boost Software License, version 1.0]
 * CC-BY-4.0: [https://creativecommons.org/licenses/by/4.0/ Creative Commons Attribution 4.0 International]
 * CC-BY-SA-4.0: [https://creativecommons.org/licenses/by-sa/4.0/ Creative Commons Attribution-ShareAlike 4.0 International]
-* MIT: [https://opensource.org/licenses/MIT Expat/MIT/X11 license]
+* MIT: [https://opensource.org/licenses/MIT The MIT License]
 * AGPL-3.0+: [https://www.gnu.org/licenses/agpl-3.0.en.html GNU Affero General Public License (AGPL), version 3 or newer]
 * FDL-1.3: [https://www.gnu.org/licenses/fdl-1.3.en.html GNU Free Documentation License, version 1.3]
 * GPL-2.0+: [https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html GNU General Public License (GPL), version 2 or newer]

--- a/bip-0002.mediawiki
+++ b/bip-0002.mediawiki
@@ -359,8 +359,8 @@ In this case, only the acceptable license(s) should be listed in the License and
 
 ====Recommended licenses====
 
-* BSD-2-Clause: [https://opensource.org/licenses/BSD-2-Clause OSI-approved BSD 2-clause license]
-* BSD-3-Clause: [https://opensource.org/licenses/BSD-3-Clause OSI-approved BSD 3-clause license]
+* BSD-2-Clause: [https://opensource.org/license/BSD-2-Clause OSI-approved BSD 2-clause license]
+* BSD-3-Clause: [https://opensource.org/license/BSD-3-Clause OSI-approved BSD 3-clause license]
 * CC0-1.0: [https://creativecommons.org/publicdomain/zero/1.0/ Creative Commons CC0 1.0 Universal]
 * GNU-All-Permissive: [https://www.gnu.org/prep/maintain/html_node/License-Notices-for-Other-Files.html GNU All-Permissive License]
 
@@ -372,7 +372,7 @@ In addition, it is recommended that literal code included in the BIP be dual-lic
 * BSL-1.0: [https://www.boost.org/LICENSE_1_0.txt Boost Software License, version 1.0]
 * CC-BY-4.0: [https://creativecommons.org/licenses/by/4.0/ Creative Commons Attribution 4.0 International]
 * CC-BY-SA-4.0: [https://creativecommons.org/licenses/by-sa/4.0/ Creative Commons Attribution-ShareAlike 4.0 International]
-* MIT: [https://opensource.org/licenses/MIT The MIT License]
+* MIT: [https://opensource.org/license/MIT The MIT License]
 * AGPL-3.0+: [https://www.gnu.org/licenses/agpl-3.0.en.html GNU Affero General Public License (AGPL), version 3 or newer]
 * FDL-1.3: [https://www.gnu.org/licenses/fdl-1.3.en.html GNU Free Documentation License, version 1.3]
 * GPL-2.0+: [https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html GNU General Public License (GPL), version 2 or newer]


### PR DESCRIPTION
- Update MIT license name per https://opensource.org/license/MIT and https://spdx.org/licenses/MIT
- Fix up license URLs with 301 redirects
