### PR TITLE
BIPs 18 and 52: remove broken links

### DIFF
--- a/bip-0018.mediawiki
+++ b/bip-0018.mediawiki
@@ -123,10 +123,6 @@ If a majority of hashing power does not support the new validation rules, then r
 The first two bytes of hashScriptCheck specify the hash algorithm and length used to verify scriptCheck.
 This BIP only allows Bitcoin's Hash160 algorithm, but leaves open the possibility of a future BIP implementing others.
 
-==Reference Implementation==
-
-https://github.com/bitcoin/bips/blob/master/bip-0016.mediawiki
-
 ==See Also==
 
 * The [[bip-0013.mediawiki|Address format for Pay to Script Hash BIP]]

--- a/bip-0018.mediawiki
+++ b/bip-0018.mediawiki
@@ -125,7 +125,7 @@ This BIP only allows Bitcoin's Hash160 algorithm, but leaves open the possibilit
 
 ==Reference Implementation==
 
-https://github.com/gavinandresen/bitcoin-git/tree/pay_to_script_hash
+https://github.com/bitcoin/bips/blob/master/bip-0016.mediawiki
 
 ==See Also==
 

--- a/bip-0052.mediawiki
+++ b/bip-0052.mediawiki
@@ -47,8 +47,6 @@ mining rewards diminishes. oPoW is hardware-compatible with GPUs, FPGAs, and
 ASICs meaning that a transitional period of optical and traditional hardware
 mining in parallel on the network is feasible
 
-More information is available here: [https://www.powx.org/opow].
-
 == Abstract ==
 
 As Bitcoin gained utility and value over the preceding decade, the network incentivized the purchase of billions of dollars in mining equipment and electricity. With the growth of competition, home mining became unprofitable. Even the most sophisticated special-purpose hardware (ASIC miners) doesn’t cover its energy costs unless the miner also has direct access to very cheap electricity. This heavy reliance on energy makes it difficult for new miners to enter the market and leads to hashrate instability as miners shut off their machines when the price of Bitcoin falls. Additionally as the network stores ever more value, the percentage of world energy consumption that is associated with Bitcoin continues to grow, creating the potential for scaling failure and a general backlash. To ensure that Bitcoin can continue scaling and reach its full potential as a world currency and store of value, we propose a low-energy proof-of-work paradigm for Bitcoin. ''Optical proof of work (oPoW)'' is designed to decouple Bitcoin’s security from massive energy use and make bitcoin mining feasible outside of regions with low electricity costs. ''Optical proof-of-work'' is a modification of Hashcash that is most efficiently computed using a new class of photonic processors that has emerged as a leading solution for ultra-low energy computing over the last 5 years. oPoW shifts the operating expenses of mining (OPEX), to capital expenses (CAPEX)–i.e. electricity to hardware, without compromising the cryptographic or game-theoretical security of Hashcash. We provide an example implementation of oPoW, briefly discuss its cryptographic construction as well as the working principle of photonic processors. Additionally, we outline the potential benefits of oPoW to the bitcoin network, including geographic decentralization and democratization of mining as well as hashrate resilience to price fluctuations.
@@ -246,8 +244,6 @@ Note that in locations where mining is not profitable, hashrate is zero.
 <img src="bip-0052/sim2.png"></img>
 
 <img src="bip-0052/sim3.png"></img>
-
-An interactive version of this diagram can be found [https://www.powx.org/opow here].
 
 === Why does CAPEX to OPEX shift lead to lower energy consumption? ===
 


### PR DESCRIPTION
BIP 18: remove the outdated reference link to Gavin Andresen's pay_to_script_hash branch in the Bitcoin repository https://github.com/gavinandresen/bitcoin-git/tree/pay_to_script_hash

BIP 52: remove https://www.powx.org/opow - no alternative link found in google