### PR TITLE
BIP-158: replace deprecated io/ioutil with os.ReadFile

### DIFF
--- a/bip-0158/gentestvectors.go
+++ b/bip-0158/gentestvectors.go
@@ -13,7 +13,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -164,7 +163,7 @@ func main() {
 
 	writerFile = writer
 
-	cert, err := ioutil.ReadFile(defaultBtcdRPCCertFile)
+	cert, err := os.ReadFile(defaultBtcdRPCCertFile)
 	if err != nil {
 		fmt.Println("Couldn't read RPC cert: ", err.Error())
 		return


### PR DESCRIPTION
Update bip-0158/gentestvectors.go to use os.ReadFile instead of the deprecated io/ioutil package. The ioutil package has been deprecated since Go 1.16, with its functionality moved to the io and os packages.