### PR TITLE
fix: handle empty matches and filenames with spaces properly

### DIFF
--- a/scripts/link-format-chk.sh
+++ b/scripts/link-format-chk.sh
@@ -7,9 +7,10 @@
 # Check wrong mediawiki link format
 
 ECODE=0
+shopt -s nullglob
 for fname in *.mediawiki; do
-    GRES=$(grep -n '](http' $fname)
-    if [ "$GRES" != "" ]; then
+    GRES=$(grep -n '](http' "$fname")
+    if [ -n "$GRES" ]; then
         if [ $ECODE -eq 0 ]; then
             >&2 echo "Github Mediawiki format writes link as [URL text], not as [text](url):"
         fi


### PR DESCRIPTION
made a few tweaks to make the script behave better:

* turned on `shopt -s nullglob` so the loop skips `*.mediawiki` when there are no files.
* put quotes around `$fname` in `grep` so filenames with spaces don’t break things.
* switched `if [ "$GRES" != "" ]` to `if [ -n "$GRES" ]` — just cleaner and more reliable.