### PR TITLE
fix(wallet_policies): use descriptor instead of desc to prevent NameError

### DIFF
--- a/bip-0388/wallet_policies.py
+++ b/bip-0388/wallet_policies.py
@@ -138,7 +138,7 @@ class WalletPolicy(object):
             for op_pos_start in find_all(descriptor, op + "("):
 
                 # ignore if not a whole word (otherwise "sortedmulti" would be found inside "multi")
-                if op_pos_start > 0 and 'a' <= desc[op_pos_start - 1] <= 'z':
+                if op_pos_start > 0 and 'a' <= descriptor[op_pos_start - 1] <= 'z':
                     continue
 
                 if op in operators_key_all_but_first:


### PR DESCRIPTION
Replace unintended reference to local variable name desc with the correct method parameter descriptor in from_descriptor. The previous code raised a NameError when scanning operators because desc is not defined in that scope. This change aligns with the rest of the method, which consistently uses descriptor, and allows the example in main to run without error.