### PR TITLE
fix: remove trailing semicolon in bitcoin_utils.py

### DIFF
--- a/bip-0352/bitcoin_utils.py
+++ b/bip-0352/bitcoin_utils.py
@@ -33,7 +33,7 @@ def deser_txid(txid: str):
 
 def deser_compact_size(f: BytesIO):
     view = f.getbuffer()
-    nbytes = view.nbytes;
+    nbytes = view.nbytes
     view.release()
     if (nbytes == 0):
         return 0 # end of stream


### PR DESCRIPTION
Remove unnecessary trailing semicolon from variable assignment in `bip-0352/bitcoin_utils.py` to comply with Python PEP 8 style guidelines. This is the only semicolon in the file and appears to be an inadvertent style inconsistency