### PR TITLE
BIP328: Use Base58Check in ExtendedKey.deserialize and validate length

### DIFF
--- a/bip-0328/_xpub.py
+++ b/bip-0328/_xpub.py
@@ -133,7 +133,9 @@ class ExtendedKey(object):
 
         :param xpub: The Base58 check encoded xpub
         """
-        data = base58.decode(xpub)[:-4] # Decoded xpub without checksum
+        data = base58.decode_check(xpub)
+        if len(data) != 78:
+            raise ValueError("Invalid extended key length")
         return cls.from_bytes(data)
 
     @classmethod


### PR DESCRIPTION
- Replace raw Base58 decode and manual slice with base58.decode_check(xpub) to enforce checksum validation as required by BIP-32 and as implied by the method docstring.
- Add strict len(data) == 78 check before parsing to ensure the serialized extended key length matches the BIP-32 78-byte structure.
- This prevents accepting corrupted or truncated extended keys and aligns deserialization behavior with Base58Check semantics.