### PR TITLE
BIP111: update status from Proposed to Final

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -609,13 +609,13 @@ Those proposing changes should consider that ultimately consent may rest with th
 | Gavin Andresen
 | Standard
 | Rejected
-|- style="background-color: #ffffcf"
+|- style="background-color: #cfffcf"
 | [[bip-0111.mediawiki|111]]
 | Peer Services
 | NODE_BLOOM service bit
 | Matt Corallo, Peter Todd
 | Standard
-| Proposed
+| Final
 |- style="background-color: #cfffcf"
 | [[bip-0112.mediawiki|112]]
 | Consensus (soft fork)

--- a/bip-0111.mediawiki
+++ b/bip-0111.mediawiki
@@ -6,7 +6,7 @@
           Peter Todd <pete@petertodd.org>
   Comments-Summary: No comments yet.
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0111
-  Status: Proposed
+  Status: Final
   Type: Standards Track
   Created: 2015-08-20
   License: PD


### PR DESCRIPTION
The `NODE_BLOOM` service bit has been deployed in Bitcoin Core since https://github.com/bitcoin/bitcoin/pull/6579.