### PR TITLE
BIP352: ECDSA verify compare x(R) modulo n to r

### DIFF
--- a/bip-0352/secp256k1.py
+++ b/bip-0352/secp256k1.py
@@ -373,7 +373,7 @@ class ECPubKey():
         u1 = z*w % SECP256K1_ORDER
         u2 = r*w % SECP256K1_ORDER
         R = SECP256K1.affine(SECP256K1.mul([(SECP256K1_G, u1), (self.p, u2)]))
-        if R is None or R[0] != r:
+        if R is None or (R[0] % SECP256K1_ORDER) != r:
             return False
         return True
 


### PR DESCRIPTION
The signer computes r = x(R) mod n, but the verifier compared the affine x-coordinate directly to r. This could incorrectly reject valid signatures when x(R) ≥ n (rare but possible). Update ECPubKey.verify_ecdsa to check (x(R) % n) == r, aligning verification with ECDSA as defined in SEC1/FIPS 186 and matching our signer’s behavior.