### PR TITLE
BIP340: replace deprecated __next__() with built-in next() function

### DIFF
--- a/bip-0340/reference.py
+++ b/bip-0340/reference.py
@@ -148,7 +148,7 @@ def test_vectors() -> bool:
     all_passed = True
     with open(os.path.join(sys.path[0], 'test-vectors.csv'), newline='') as csvfile:
         reader = csv.reader(csvfile)
-        reader.__next__()
+        next(reader)
         for row in reader:
             (index, seckey_hex, pubkey_hex, aux_rand_hex, msg_hex, sig_hex, result_str, comment) = row
             pubkey = bytes.fromhex(pubkey_hex)


### PR DESCRIPTION
Use the built-in next() function instead of directly calling the private __next__() method on the CSV reader iterator;

This follows Python best practices and PEP 3114 recommendations. The functionality remains identical while improving code readability.