### PR TITLE
fix: replace assert with return False in dleq_verify_proof

### DIFF
--- a/bip-0374/reference.py
+++ b/bip-0374/reference.py
@@ -82,7 +82,8 @@ def dleq_verify_proof(
 ) -> bool:
     if A.infinity or B.infinity or C.infinity or G.infinity:
         return False
-    assert len(proof) == 64
+    if len(proof) != 64:
+        return False
     e = int.from_bytes(proof[:32], "big")
     s = int.from_bytes(proof[32:], "big")
     if s >= GE.ORDER:


### PR DESCRIPTION
Replace assert with return False for proof length validation to ensure the function behaves consistently and doesn't crash when Python runs with optimization flags (-O).

This makes the validation consistent with other checks in the same function and improves robustness of the reference implementation.
Tests: All existing unit tests pass