### PR TITLE
Caution on tweaking in bip 327

### DIFF
--- a/bip-0327.mediawiki
+++ b/bip-0327.mediawiki
@@ -130,6 +130,8 @@ For example, we can imagine a scenario where a single entity creates a MuSig2 se
 In that case, duplicates may not result from a malicious signing device copying an individual public key of another signing device but from accidental initialization of two devices with the same seed.
 Since MuSig2 key aggregation would accept the duplicate keys and not error out, which would in turn reduce the security compared to the intended key setup, applications may reject duplicate individual public keys before passing them to MuSig2 key aggregation and ask the user to investigate.
 
+Implementers should further note that in case duplicate pubkeys exist in the set, production of a partial signature by the first of 2 (or more) duplicates will allow production of the other(s) partial signature(s), and thus allow complete production of a valid Schnorr signature. Even further, the same comment applies to multiple pubkeys that are not identical, but are related via a public tweak, such as that in BIP32 unhardened derivation.<ref> Note that such usage of MuSig2 makes little sense, almost always: you do not treat two keys that are different only by a public tweak, as if they are genuinely different authorizations from a security perspective. However the situation is somewhat worse than you might imagine, if you did this. See the attack described in [https://eprint.iacr.org/2025/692 the DahLIAS paper], Appendix A.2. An attacker compromising only network connections, and not secret keys, can complete a MuSig2 session using two keys related by a public tweak, after just seeing one signature from the honest counterparty, i.e. they do not need to steal a key. Obviously this is not an attack of the normal type, and is thus not covered, nor discussed in MuSig2 itself, but in case of designing a deployment or protocol using such a construction for any reason, note that it fails to provide security against such attacks. This same comment applies to a multiplicative tweak like ''K<sub>2</sub> = c * K<sub>1</sub>'', not only to additive tweaks like ''K<sub>2</sub> = K<sub>1</sub> + t*G''.</ref>
+
 === Nonce Generation ===
 
 '''IMPORTANT''': ''NonceGen'' must have access to a high-quality random generator to draw an unbiased, uniformly random value ''rand' ''.
@@ -549,7 +551,7 @@ which have been obtained via tweaking another secret key with tweaks known to th
 then the adversary could, after having seen the ''pubnonce'',
 influence whether ''sk<sub>1</sub>'' or ''sk<sub>2</sub>'' is provided to ''Sign''.
 This degree of freedom may allow the adversary to perform a generalized birthday attack and thereby forge a signature
-(see [https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2022-October/021000.html bitcoin-dev mailing list post] and [https://github.com/jonasnick/musig2-tweaking writeup] for details).
+(see [https://gnusha.org/pi/bitcoindev/576db60c-b05b-5b9a-75e5-9610f3e04eda@gmail.com/ bitcoin-dev mailing list post] and [https://github.com/jonasnick/musig2-tweaking writeup] for details).
 
 Checking ''pk'' against ''IndividualPubkey(sk)'' is a simple way to ensure
 that the secret key provided to ''Sign'' is fully determined already when ''NonceGen'' is invoked.
@@ -782,8 +784,13 @@ An exception to this rule is <code>MAJOR</code> version zero (0.y.z) which is fo
 The <code>MINOR</code> version is incremented whenever the inputs or the output of an algorithm changes in a backward-compatible way or new backward-compatible functionality is added.
 The <code>PATCH</code> version is incremented for other changes that are noteworthy (bug fixes, test vectors, important clarifications, etc.).
 
+<<<<<<< HEAD
 * '''1.0.3''' (2026-01-05):
 ** Fix minor bugs in the specification of ''DeterministicSign''.
+=======
+* '''1.0.3''' (2025-09-22):
+** Additional notes to warn against use of input keys related by public tweaks.
+>>>>>>> f3980c0 (Update bip-0327.mediawiki)
 * '''1.0.2''' (2024-07-22):
 ** Fix minor bug in the specification of ''DeterministicSign'' and add small improvement to a ''PartialSigAgg'' test vector.
 * '''1.0.1''' (2024-05-14):
@@ -829,4 +836,4 @@ The <code>PATCH</code> version is incremented for other changes that are notewor
 
 == Acknowledgements ==
 
-We thank Brandon Black, Riccardo Casatta, Sivaram Dhakshinamoorthy, Lloyd Fournier, Russell O'Connor, and Pieter Wuille for their contributions to this document.
+We thank Brandon Black, Riccardo Casatta, Adam Gibson, Sivaram Dhakshinamoorthy, Lloyd Fournier, Russell O'Connor, and Pieter Wuille for their contributions to this document.


### PR DESCRIPTION
The BIP is quite difficult to parse in terms of understanding the functionality and safety of tweaking keys.

In particular, while it is a terrible idea for more than one reason, constructing a MuSig2 aggregated key using related (bip32 unhardened) individual keys in the list is very specifically insecure, but that is not noted.

It's admittedly debatable whether you ever have to specify that a certain kind of stupid behaviour is to be warned against, but my justification is:

1. The BIP is very explicitly "supporting tweaking" right from the Abstract. It isn't immediately clear that this means tweaking the ouput, not the input. Perhaps a minor note early on would help with that.

2. Pre- this patch, in the section I'm editing, the document again explicitly says it supports tweaking, and this time, in relation to the *input* keys. It then goes on to explain the background of the attack outlined on the mailing list (I updated to a gnusha link: https://gnusha.org/pi/bitcoindev/576db60c-b05b-5b9a-75e5-9610f3e04eda@gmail.com/ ), which is much more "in scope" in the sense that the honest signer behaviour isn't stupid, but at the same time, the conditions of that attack are quite obscure.

3. While the behaviour is stupid, it's not inconceivable, and it sits within perhaps the most likely/common usage pattern of MuSig2: multisig for better cold storage/savings security. Multiple keys controlled by the same signer, using multiple hardware devices for redundant security. As noted by Jonas Nick in an earlier email convo we had, there is at least one reason such stupid behaviour might be considered: less backup (and/or laziness). I admit that a large majority would have the common sense to not reuse the same wallet seed across devices, but in case anyone did it, they are exposed in a specific way that is very unobvious.

4. To generalize the above, for me the BIP is not sufficiently explicit that the design of the MuSig2 algorithm does not address the possibility of related input keys at all (and it would be easy as an engineer consumer to assume that related keys would be safe, if they didn't look at the mathematical formulas too much).

If you want a concrete description of the attack, here you go (see Appendix A.2 of [DahLIAS](https://eprint.iacr.org/2025/692) for what I mean by "multipliers:"):

2 devices set up with one secret key each, where the keys are on the same branch so that sk1 = sk2 + t for "public" t (handwave).

The network is compromised by the attacker. It exchanges messages with device 1 (sk1); receives nonces, maliciously calculates the response nonces (with the multipliers), receives a partial sig for sk1 and can complete the signing protocol just from knowing t.

The higher-level idea here is (I'm cribbing from an earlier email I wrote):

> ... which I think nicely illustrates something that occurred to me earlier: there's a question of "what is authorization?" being raised here. In a single key signature, there is a single authorizing event, so we never worry too much about the "semantics" of the action of signing. It's one action, and it's all or nothing: you authorize, or you don't.

> In multi-signing it's not atomic. The semantics of individual signing events are something decided on by the operator(s) of the protocol. I might want to say "I authorize if and only if 3 different hardware devices sign" (or 3 people or whatever). How does the security definition represent this? I believe the rationale for applying EUF-CMA as in the paper is "we take a maximally pessimistic approach and assume that all except honest are the adversary, then we demand the adversary produce a signature without authorizing events from the honest signer" on the basis that, if the honest signer did authorize, then there is no security failure (the honest signer wanted it!) - but that's exactly the point I'm questioning.

> So it's back to the slightly confusion position of "that this is possible is worrying, but all the obvious ways of exploiting it as a weakness reduce to an already fundamentally insecure multisig setup (using calculable tweaks of existing keys), and the base security model does not include this" ("capture", perhaps).

> Whimsically I wonder if this can be seen as analogous to EUF style security vs SUF style security: for most purposes you don't need strong unforgeability but it can cause implementation headaches if you don't have it (MtGox,  hehe).