### PR TITLE
docs: bip-0115 — fix duplicated mainnet line to testnet in Deployment

### DIFF
--- a/bip-0115.mediawiki
+++ b/bip-0115.mediawiki
@@ -42,7 +42,7 @@ This BIP will be deployed by "version bits" [[bip-0009.mediawiki|BIP9]] with the
 
 For Bitcoin '''mainnet''', the BIP9 '''starttime''' will be TBD (Epoch timestamp TBD) and BIP9 '''timeout''' will be TBD (Epoch timestamp TBD).
 
-For Bitcoin '''mainnet''', the BIP9 '''starttime''' will be TBD (Epoch timestamp TBD) and BIP9 '''timeout''' will be TBD (Epoch timestamp TBD).
+For Bitcoin '''testnet''', the BIP9 '''starttime''' will be TBD (Epoch timestamp TBD) and BIP9 '''timeout''' will be TBD (Epoch timestamp TBD).
 
 ==Motivation==
 


### PR DESCRIPTION
Correct the Deployment section in bip-0115.mediawiki by changing the second “mainnet” entry to “testnet”; documentation-only, no behavior changes.