### PR TITLE
BIP327: remove unused Any import

### DIFF
--- a/bip-0327/reference.py
+++ b/bip-0327/reference.py
@@ -4,7 +4,7 @@
 # be used in production environments. The code is vulnerable to timing attacks,
 # for example.
 
-from typing import Any, List, Optional, Tuple, NewType, NamedTuple
+from typing import List, Optional, Tuple, NewType, NamedTuple
 import hashlib
 import secrets
 import time


### PR DESCRIPTION
The Any type from typing was imported in bip-0327/reference.py but never used. This likely originated from copying the import header from the BIP-0340 reference, where Any is used (e.g., in pretty(v: Any)), but in BIP-0327 there is no such usage. Removing it cleans up the imports without changing behavior.