### PR TITLE
BIP158: Replace ioutil.ReadFile with os.ReadFile

### DIFF
--- a/bip-0158/gentestvectors.go
+++ b/bip-0158/gentestvectors.go
@@ -13,7 +13,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -164,7 +163,7 @@ func main() {
 
 	writerFile = writer
 
-	cert, err := ioutil.ReadFile(defaultBtcdRPCCertFile)
+    cert, err := os.ReadFile(defaultBtcdRPCCertFile)
 	if err != nil {
 		fmt.Println("Couldn't read RPC cert: ", err.Error())
 		return


### PR DESCRIPTION
Go 1.16 deprecated most of io/ioutil; os.ReadFile is the direct replacement.