### PR TITLE
BIP327,353: Update to Final and Proposed instead of Active

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1077,7 +1077,7 @@ Those proposing changes should consider that ultimately consent may rest with th
 | MuSig2 for BIP340-compatible Multi-Signatures
 | Jonas Nick, Tim Ruffing, Elliott Jin
 | Informational
-| Active
+| Final
 |- style="background-color: #ffffcf"
 | [[bip-0328.mediawiki|328]]
 | Applications
@@ -1204,13 +1204,13 @@ Those proposing changes should consider that ultimately consent may rest with th
 | josibake, Ruben Somsen
 | Standard
 | Proposed
-|- style="background-color: #cfffcf"
+|- style="background-color: #ffffcf"
 | [[bip-0353.mediawiki|353]]
 | Applications
 | DNS Payment Instructions
 | Matt Corallo, Bastien Teinturier
 | Standard
-| Active
+| Proposed
 |- style="background-color: #cfffcf"
 | [[bip-0370.mediawiki|370]]
 | Applications

--- a/bip-0327.mediawiki
+++ b/bip-0327.mediawiki
@@ -5,7 +5,7 @@
           Tim Ruffing <crypto@timruffing.de>
           Elliott Jin <elliott.jin@gmail.com>
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0327
-  Status: Active
+  Status: Final
   Type: Informational
   Created: 2022-03-22
   License: BSD-3-Clause

--- a/bip-0353.mediawiki
+++ b/bip-0353.mediawiki
@@ -6,7 +6,7 @@
           Bastien Teinturier <bastien@acinq.fr>
   Comments-Summary: No comments yet.
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0353
-  Status: Active
+  Status: Proposed
   Type: Standards Track
   Created: 2024-02-10
   License: CC0-1.0


### PR DESCRIPTION
A BIP status of Active is only for Process BIPs.

- BIP 327 should be Final, not Active.
- BIP 353 has an open PR with test vector additions, should be Proposed.