### PR TITLE
BIP 433: Add P2A BIP

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1345,6 +1345,13 @@ Those proposing changes should consider that ultimately consent may rest with th
 | Informational
 | Draft
 |-
+| [[bip-0433.mediawiki|433]]
+| Applications
+| Pay to Anchor (P2A)
+| Gregory Sanders
+| Informational
+| Draft
+|-
 | [[bip-0443.mediawiki|443]]
 | Consensus (soft fork)
 | OP_CHECKCONTRACTVERIFY

--- a/bip-0433.mediawiki
+++ b/bip-0433.mediawiki
@@ -1,0 +1,76 @@
+<pre>
+  BIP: 433
+  Layer: Applications
+  Title: Pay to Anchor (P2A)
+  Author: Gregory Sanders <gsanders87@gmail.com>
+  Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0433
+  Status: Draft
+  Type: Informational
+  Created: 2025-12-08
+  License: BSD-3-Clause
+  Post-History: 2024-06-27: https://github.com/bitcoin/bitcoin/pull/30352 Github PR
+                2024-10-10: https://bitcoinops.org/en/bitcoin-core-28-wallet-integration-guide/ wallet integration guide
+</pre>
+
+==Abstract==
+
+This document describes a new standard output script called Pay to Anchor (P2A) and prescribes making spending of this output type standard.
+
+This output is "keyless" meaning no signature or witness data at all are required to spend this output typea.
+
+==Motivation==
+
+The "anchor" output type is a commonly used pattern in Bitcoin layer 2 systems such as Lightning Network and beyond. This pattern allows transactions which are presigned far in advance to leave a "hook" for CPFP fee bumping later, when prevailing feerates for block inclusion are better known.
+
+When the wallet user is unconcerned by *who* is able to bump the transaction fees as long as someone does, this output type may confer a couple of advantages:
+
+1. Using an output type with minimal output and spending input footprint saves fees
+2. Keyless operation aids in interoperability of services like watchtowers as there is no privileged key material required for bumping
+
+with the drawback that selection of this output type could result in griefing if anti-pinning measures are not taken. If unsure, use in conjunction with [https://github.com/bitcoin/bips/blob/master/bip-0431.mediawiki TRUC transactions].
+
+===Specification===
+
+A P2A output is defined as one with the scriptPubKey
+
+<code>OP_1 <0x4e73></code><ref>Native segwit outputs are composed of a witness version and a witness program. A witness program must be at least two bytes long and the specific bytes cannot be zeros. The two bytes for the P2A witness program are chosen to spell "fees" in bech32m encoding.</ref>
+
+corresponding to the addresses <code>bc1pfeessrawgf</code> on Bitcoin mainnet, <code><tb1pfees9rn5nz</code> on public testnets, and <code>bcrt1pfeesnyr2tx</code> on regtest.
+
+P2A inputs are considered standard by Bitcoin Core for spending if no witness data is attached. This avoids meaningless witness padding. Consensus meaning is unchanged.
+
+====Implementation====
+
+* https://github.com/bitcoin/bitcoin/pull/30352
+
+====Related Work====
+
+There are a number of related but separate historical concepts:
+
+[https://github.com/bitcoin/bitcoin/pull/30239 Ephemeral Dust]: Relay policies allowing a single dust output as long as it is spent in a transaction package. As an implementation detail, dust threshold for P2A is set at 240 satoshis by default, other dust levels remain unchanged, and the dust-having transaction must be zero fee. Any output script type may have down to 0-value outputs.
+
+[https://bitcoinops.org/en/topics/ephemeral-anchors/ Ephemeral Anchors]: Historically the union of P2A output type and ephemeral dust. Keyed anchors along with ephemeral dust are also an accepted pattern and as such they remain separate concepts.
+
+[https://github.com/bitcoin/bips/blob/master/bip-0431.mediawiki TRUC transactions]: TRUC transactions bound the topology including child transaction size, which aids in anti-pinning for the P2A output, as anyone can attach a child transaction including an oversized, low feerate one. There is no ineherent dependency on this concept and P2A.
+
+====Backward Compatibility====
+
+Creation of P2A outputs has been considered standard since the deployment of Segwit softfork on the network.
+
+Transactions with P2A inputs were previously nonstandard, reserved as an upgrade hook.
+
+There are no known conflicts with previous usage.
+
+==Acknowledgements==
+
+Thanks to collaborators who helped focus the historical ideas into deployed ones:
+Suhas Daftuar,
+Gloria Zhao,
+Pieter Wuille,
+Jeremy Rubin,
+and Bastien Teinturier.
+
+==References and Rationale==
+
+<references/>
+


### PR DESCRIPTION
For interoperability with other schemes, it behooves me to write a BIP for this output type. It's already standard to spend in well over half the network.

h/t roasbeef for bothering me about this repeatedly