### PR TITLE
BIP321: add reference implementation, mention BIP21 replacement

### DIFF
--- a/bip-0321.mediawiki
+++ b/bip-0321.mediawiki
@@ -24,7 +24,7 @@ This BIP proposes a URI scheme for describing Bitcoin payment instructions.
 
 The purpose of this URI scheme is to enable users to easily make payments by simply clicking links on webpages or scanning QR Codes.
 
-This BIP is a modification of [[bip-0021.mediawiki|BIP 0021]] to add information about the modern usage of bitcoin: URIs (including standard query parameters and modern address types) as well as provide forward-looking guidance on how to incorporate new payment instructions. It further adds an optional extension to provide the payment initiator with proof of payment. BIP 21 was based on BIP 20, which was, in turn based on an earlier document by Nils Schneider.
+This BIP is a modification and intended replacement of [[bip-0021.mediawiki|BIP 0021]] to add information about the modern usage of bitcoin: URIs (including standard query parameters and modern address types) as well as provide forward-looking guidance on how to incorporate new payment instructions. It further adds an optional extension to provide the payment initiator with proof of payment. BIP 21 was based on BIP 20, which was, in turn based on an earlier document by Nils Schneider.
 
 == Specification ==
 


### PR DESCRIPTION
- Add Reference Implementation section, using the BIP author's suggested implementation in https://github.com/bitcoin/bips/pull/1911#issuecomment-3324867313
- Mention replacement in addition to modification with respect to BIP21, for consistency with the "Replaces: 21" header