### PR TITLE
bip-0069: Fix Python 3 compatibility by replacing deprecated cmp para…

### DIFF
--- a/bip-0069/bip-0069_examples.py
+++ b/bip-0069/bip-0069_examples.py
@@ -32,7 +32,8 @@ def input_cmp(input_tuple1, input_tuple2):
 		raise ValueError('Matching previous transaction hash and previous transaction output index for two distinct inputs. Invalid!')
 
 def sort_inputs(input_tuples):
-	return sorted(input_tuples, cmp=input_cmp)
+	from functools import cmp_to_key
+	return sorted(input_tuples, key=cmp_to_key(input_cmp))
 
 def print_inputs(ordered_input_tuples):
 	index = 0
@@ -52,7 +53,8 @@ def output_cmp(output_tuple1, output_tuple2):
 	return bytearr_cmp(output_tuple1[1], output_tuple2[1])
 
 def sort_outputs(output_tuples):
-	return sorted(output_tuples, cmp=output_cmp)
+	from functools import cmp_to_key
+	return sorted(output_tuples, key=cmp_to_key(output_cmp))
 
 def print_outputs(ordered_output_tuples):
 	index = 0


### PR DESCRIPTION
Replace deprecated `cmp` parameter in sorted() calls with `key=cmp_to_key()` to fix Python 3 compatibility. The `cmp` parameter was removed in Python 3.0.

- Use functools.cmp_to_key() as the official migration path
- Maintains identical sorting behavior across Python versions
- Fixes: TypeError: 'cmp' is an invalid keyword argument for sorted()