### PR TITLE
BIP-340: remove unused binascii import from reference.py

### DIFF
--- a/bip-0340/reference.py
+++ b/bip-0340/reference.py
@@ -1,6 +1,5 @@
 from typing import Tuple, Optional, Any
 import hashlib
-import binascii
 
 # Set DEBUG to True to get a detailed debug output including
 # intermediate values during key generation, signing, and


### PR DESCRIPTION
# PR Description
This PR removes an unused `import binascii` statement from the BIP-340 reference implementation.

- All test vectors pass (19/19 tests successful)
- No functional changes to the cryptographic operations
- The `binascii` module was imported but never used in the cod