### PR TITLE
Remove unused import in bip-0328 reference script

### DIFF
--- a/bip-0328/reference.py
+++ b/bip-0328/reference.py
@@ -4,7 +4,6 @@ import json
 import os
 import sys
 
-from _base58 import xpub_to_pub_hex
 from _bip327 import cbytes, key_agg
 from _xpub import ExtendedKey
 


### PR DESCRIPTION
bip-0328/reference.py imported xpub_to_pub_hex, but the symbol is never used.