### PR TITLE
BIP-119: use self.stack[-1] in execute_bip_119

### DIFF
--- a/bip-0119.mediawiki
+++ b/bip-0119.mediawiki
@@ -72,7 +72,7 @@ def execute_bip_119(self):
             self.context.precomputed_ctv_data = self.context.tx.get_default_check_template_precomputed_data()
 
         # If the hashes do not match, return error
-        if stack[-1] != self.context.tx.get_default_check_template_hash(self.context.nIn, self.context.precomputed_ctv_data):
+        if self.stack[-1] != self.context.tx.get_default_check_template_hash(self.context.nIn, self.context.precomputed_ctv_data):
             return self.errors_with(errors.script_err_template_mismatch)
 
         return self.return_as_nop()


### PR DESCRIPTION
The pseudocode in bip-0119 used stack[-1] while the rest of execute_bip_119 consistently accessed the interpreter stack via self.stack.