### PR TITLE
BIP-390: allow musig() under rawtr()

### DIFF
--- a/bip-0390.mediawiki
+++ b/bip-0390.mediawiki
@@ -35,8 +35,8 @@ and [[bip-0389.mediawiki|BIP-389]].
 
 ===<tt>musig(KEY, KEY, ..., KEY)</tt>===
 
-The <tt>musig(KEY, KEY, ..., KEY)</tt> expression can only be used inside of a <tt>tr()</tt>
-expression as a key expression. It additionally cannot be nested within another <tt>musig()</tt>
+The <tt>musig(KEY, KEY, ..., KEY)</tt> expression can only be used inside of a <tt>tr()</tt> or
+<tt>rawtr()</tt> expression as a key expression. It additionally cannot be nested within another <tt>musig()</tt>
 expression. Participant public keys may be repeated. The aggregate public key is produced
 by using the <tt>KeyAgg</tt> algorithm on all KEYs specified in the expression after performing all
 specified derivation. As with script expressions, KEY can contain child derivation specified by


### PR DESCRIPTION
musig() was previously specified as only usable under tr(), but the BIP-390 test vectors already include valid rawtr(musig(...)) descriptors and Bitcoin Core’s descriptor implementation accepts musig() as a generic KEY under both tr() and rawtr(). This change updates the wording to explicitly allow musig() inside rawtr(), aligning the specification with the existing test vectors and Core semantics without changing any behavior.