### PR TITLE
fix: correct misleading ORDER_HALF comment in bip-0374

### DIFF
--- a/bip-0374/secp256k1.py
+++ b/bip-0374/secp256k1.py
@@ -164,10 +164,10 @@ class GE:
     * infinity: True
     """
 
-    # Order of the group (number of points on the curve, plus 1 for infinity)
+    # Order of the group (number of points on the curve, including infinity)
     ORDER = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
 
-    # Number of valid distinct x coordinates on the curve.
+    # Half the order, used for ECDSA low-S normalization
     ORDER_HALF = ORDER // 2
 
     def __init__(self, x=None, y=None):


### PR DESCRIPTION
The comment for ORDER_HALF incorrectly stated it represents "Number of valid distinct x coordinates on the curve". This is wrong - ORDER_HALF is simply half the group order, commonly used for ECDSA low-S signature normalization. The number of valid x coordinates on secp256k1 is approximately (p-1)/2 where p is the field size, which is a completely different value.

Also clarified the ORDER comment from "plus 1 for infinity" to "including infinity" for better accuracy.