### PR TITLE
Remove BIP 174's claim that Combine is commutative

### DIFF
--- a/bip-0174.mediawiki
+++ b/bip-0174.mediawiki
@@ -908,7 +908,7 @@ For every type that a Combiner understands, it may refuse to combine PSBTs if it
 The Combiner does not need to know how to interpret scripts in order to combine PSBTs. It can do so without understanding scripts or the network serialization format.
 
 In general, the result of a Combiner combining two PSBTs from independent participants A and B should be functionally equivalent to a result obtained from processing the original PSBT by A and then B in a sequence.
-Or, for participants performing fA(psbt) and fB(psbt): Combine(fA(psbt), fB(psbt)) == fA(fB(psbt)) == fB(fA(psbt))
+Or, for participants performing fA(psbt) and fB(psbt): Combine(fA(psbt), fB(psbt)) == fB(fA(psbt))
 
 ===Input Finalizer===
 

--- a/bip-0174.mediawiki
+++ b/bip-0174.mediawiki
@@ -907,8 +907,13 @@ For every type that a Combiner understands, it may refuse to combine PSBTs if it
 
 The Combiner does not need to know how to interpret scripts in order to combine PSBTs. It can do so without understanding scripts or the network serialization format.
 
-In general, the result of a Combiner combining two PSBTs from independent participants A and B should be functionally equivalent to a result obtained from processing the original PSBT by A and then B in a sequence.
-Or, for participants performing fA(psbt) and fB(psbt): Combine(fA(psbt), fB(psbt)) == fB(fA(psbt))
+In general, the result of a Combiner combining two PSBTs with no conflicting fields from independent participants A and B should be functionally equivalent to a result obtained from processing the original PSBT by A and then B in a sequence.
+Or, for participants performing fA(psbt) and fB(psbt) where fA() and fB() only add unique fields to the PSBT: Combine(fA(psbt), fB(psbt)) == fA(fB(psbt)) == fB(fA(psbt))
+
+Combiners may be asked to combine PSBTs which have conflicting fields, i.e. each PSBT has a field with identical keys but differing values.
+As discussed in [[Handling Duplicated Keys]], the combiner may arbitrarily choose the value from one PSBT to use in the combined PSBT.
+Alternatively, the combiner may also refuse to combine the PSBTs.
+In this case, the previously discussed commutative property no longer holds.
 
 ===Input Finalizer===
 

--- a/bip-0174.mediawiki
+++ b/bip-0174.mediawiki
@@ -907,12 +907,13 @@ For every type that a Combiner understands, it may refuse to combine PSBTs if it
 
 The Combiner does not need to know how to interpret scripts in order to combine PSBTs. It can do so without understanding scripts or the network serialization format.
 
-In general, the result of a Combiner combining two PSBTs with no conflicting fields from independent participants A and B should be functionally equivalent to a result obtained from processing the original PSBT by A and then B in a sequence.
+In general, the result of a Combiner combining two PSBTs from independent participants A and B will be functionally equivalent to a result obtained from processing the original PSBT by A and then B in a sequence.
 Or, for participants performing fA(psbt) and fB(psbt) where fA() and fB() only add unique fields to the PSBT: Combine(fA(psbt), fB(psbt)) == fA(fB(psbt)) == fB(fA(psbt))
+Combining two PSBTs is commutative unless the PSBTs have conflicting fields, i.e., fields with duplicated keys but differing values.
 
-Combiners may be asked to combine PSBTs which have conflicting fields, i.e. each PSBT has a field with identical keys but differing values.
-As discussed in [[Handling Duplicated Keys]], the combiner may arbitrarily choose the value from one PSBT to use in the combined PSBT.
-Alternatively, the combiner may also refuse to combine the PSBTs.
+As discussed in [[Handling Duplicated Keys]], when a combiner is asked to combine PSBTs with conflicting fields,
+the combiner may arbitrarily choose the value for the combined PSBT from any of the original PSBTs.
+Alternatively, the combiner may refuse to combine PSBTs with conflicting content.
 In this case, the previously discussed commutative property no longer holds.
 
 ===Input Finalizer===


### PR DESCRIPTION
The BIP asserts that `fA(fB(psbt)) == fB(fA(psbt))`, however the explanatory text before this doesn't actually say this and even hints that the ordering does matter: "processing [..] A and then B *in a sequence*". It seems that the BIP text only supports the `Combine(fA(psbt), fB(psbt)) == fB(fA(psbt))` part, and that `fA(fB(psbt))` slipped in by accident?

In practice, Bitcoin Core's `combinepsbt` isn't commutative and gives precedence to latter PSBTs in the array. Here's a quick example demonstrating this:

```bash
PSBT_A="cHNidP8BADMCAAAAAa83fnb+Vw0gR7jZBeABQNh2dFx8F+MbmvHAM8N5+O07AAAAAAD/////AAAAAAAAAQUBUQA="
PSBT_B="cHNidP8BADMCAAAAAa83fnb+Vw0gR7jZBeABQNh2dFx8F+MbmvHAM8N5+O07AAAAAAD/////AAAAAAAAAQUBUgA="
$ bitcoin-cli decodepsbt $(bitcoin-cli combinepsbt [\"$PSBT_A\",\"$PSBT_B\"]) | jq -r .inputs[0].witness_script.asm
1
$ bitcoin-cli decodepsbt $(bitcoin-cli combinepsbt [\"$PSBT_B\",\"$PSBT_A\"]) | jq -r .inputs[0].witness_script.asm
2
````

And here's a related discussion about rust-bitcoin's `Psbt::combine()`, which isn't commutative either but documented as "*In accordance with BIP 174 this function is commutative*": https://github.com/rust-bitcoin/rust-bitcoin/issues/5486