### PR TITLE
BIP-346: correct TxFieldSelector index upper bound

### DIFF
--- a/bip-0346/ref-impl/src/main.rs
+++ b/bip-0346/ref-impl/src/main.rs
@@ -174,7 +174,7 @@ fn parse_inout_selection(
                 (current_input_idx as isize + rel) as usize
             };
 
-            if idx > nb_items {
+            if idx >= nb_items {
                 return Err("selected index out of bounds");
             }
             if let Some(last) = selected.last() {


### PR DESCRIPTION
Previously `parse_inout_selection` only rejected indices strictly greater than `nb_items`, allowing `idx == nb_items` to pass through and later cause a panic when indexing transaction inputs/outputs.

Tightened the bounds check in `parse_inout_selection` to treat `idx >= nb_items` as out of bounds, enforcing the intended `0..nb_items-1` index range for `TxFieldSelector` individual mode.