### PR TITLE
bip54: add coinbase locktime and sequence to GBT

### DIFF
--- a/bip-0022.mediawiki
+++ b/bip-0022.mediawiki
@@ -244,3 +244,4 @@ Why should "sigops" be provided for transactions?
 
 ==See Also==
 * [[bip-0023.mediawiki|BIP 23: getblocktemplate - Pooled Mining]]
+* [[bip-0054.md#getblocktemplate-changes|BIP 54: getblocktemplate changes]]

--- a/bip-0054.md
+++ b/bip-0054.md
@@ -153,11 +153,33 @@ that include 64-byte transactions.
 The coinbase transaction is usually crafted by mining pool software. To the best of the authors'
 knowledge, there does not exist an open source reference broadly in use today for such software.
 We encourage mining pools to update their software to craft coinbase transactions that are
-forward-compatible with the changes proposed in this BIP.
+forward-compatible with the changes proposed in this BIP. This can be done by using the new
+`getblocktemplate` fields described below, once node software supports it.
+
+## getblocktemplate changes
+
+The template Object of the `getblocktemplate` JSON-RPC call ([bip-0022][BIP22]) is extended with
+the following keys:
+
+| Key | Required | Type | Description |
+|-----|----------|------|-------------|
+| `coinbase_locktime` | Yes | Number | coinbase `nLockTime` value |
+| `coinbase_sequence` | Yes | Number | coinbase `nSequence` value |
+
+Types are JSON types as defined in [bip-0022][BIP22].
+
+The `coinbase_locktime` field specifies the exact value that MUST be used for the coinbase
+transaction's `nLockTime` field.
+
+The `coinbase_sequence` field specifies a value that SHOULD be used for the coinbase transaction
+input's `nSequence` field. If a different value is used, it MUST NOT be `0xffffffff`[^13].
+
 
 ## Reference implementation
 
 An implementation of BIP54 for Bitcoin Core is available [here][inquisition-implem].
+
+The `getblocktemplate` extension is implemented in [bitcoin/bitcoin#34419][GBT implem].
 
 ## Test vectors
 
@@ -225,6 +247,11 @@ notably of Bitcoin Core but also of all other implementations the authors are aw
 where [bip-0034][BIP34] violations have been manually inspected (see [here][Core validation.cpp
 BIP34]). Without the guarantee given by enforcing the timelock on coinbase transactions, this would
 have to be perpetuated for the Consensus Cleanup.
+[^13]: **Why SHOULD for `coinbase_sequence`?**
+  The only consensus constraint on `nSequence` is to disallow `0xffffffff`.
+  The server could communicate this via a bit mask, but for simplicity it
+  provides the entire `nSequence` value. Clients SHOULD use this value, so
+  that future soft forks can safely add additional constraints.
 
 [BIP30]: https://github.com/bitcoin/bips/blob/master/bip-0030.mediawiki
 [BIP-XXXX]: https://github.com/TheBlueMatt/bips/blob/7f9670b643b7c943a0cc6d2197d3eabe661050c2/bip-XXXX.mediawiki
@@ -250,3 +277,5 @@ have to be perpetuated for the Consensus Cleanup.
 [inquisition-implem]: https://github.com/darosior/bitcoin/tree/2509_inquisition_consensus_cleanup
 [Core 30.0]: https://bitcoincore.org/en/releases/30.0
 [Core validation.cpp BIP34]: https://github.com/bitcoin/bitcoin/blob/390e7d61bd531505bb3d13f38316c282b85ed1dd/src/validation.cpp#L2401-L2459
+[BIP22]: https://github.com/bitcoin/bips/blob/master/bip-0022.mediawiki
+[GBT implem]: https://github.com/bitcoin/bitcoin/pull/34419


### PR DESCRIPTION
[BIP54](https://github.com/bitcoin/bips/blob/master/bip-0054.md) proposes constraining the coinbase transaction `nLockTime` and `nSequence` fields.

Bitcoin Core's internal mining code has been doing this since v30.0 (see https://github.com/bitcoin/bitcoin/pull/32155), but currently the fields are only communicated to IPC clients (i.e. Stratum v2, see e.g. https://github.com/bitcoin/bitcoin/pull/33819).

This PR extends BIP54 with the following BIP22 fields (`getblocktemplate` RPC):

- `lock_time`
- `sequence`

Setting these fields makes miners forward compatible with BIP54, if it's ever activated, but is _not_ the same as version bit signaling.

Reference implementation: https://github.com/bitcoin/bitcoin/pull/34419

Mailinglist post: https://groups.google.com/g/bitcoindev/c/znBz5MA7_Bo/m/CY2uMIenAgAJ

The BIP22 "See Also" section is updated to link to these changes. 