### PR TITLE
BIP360: swap scriptPathControlBlocks[1] and [2] for three-leaf P2MR test vectors

### DIFF
--- a/bip-0360/ref-impl/common/tests/data/p2mr_construction.json
+++ b/bip-0360/ref-impl/common/tests/data/p2mr_construction.json
@@ -205,8 +205,8 @@
                 "bip350Address": "bc1zej7kd3hhar76k3an5jr0t8fgyc47s4lnp4rh8uk4afrlwasuur3qzgewqq",
                 "scriptPathControlBlocks": [
                     "c1ffe578e9ea769027e4f5a3de40732f75a88a6353a09d767ddeb66accef85e553",
-                    "c1ba982a91d4fc552163cb1c0da03676102d5b7a014304c01f0c77b2b8e888de1c2645a02e0aac1fe69d69755733a9b7621b694bb5b5cde2bbfc94066ed62b9817",
-                    "c19e31407bffa15fefbf5090b149d53959ecdf3f62b1246780238c24501d5ceaf62645a02e0aac1fe69d69755733a9b7621b694bb5b5cde2bbfc94066ed62b9817"
+                    "c19e31407bffa15fefbf5090b149d53959ecdf3f62b1246780238c24501d5ceaf62645a02e0aac1fe69d69755733a9b7621b694bb5b5cde2bbfc94066ed62b9817",
+                    "c1ba982a91d4fc552163cb1c0da03676102d5b7a014304c01f0c77b2b8e888de1c2645a02e0aac1fe69d69755733a9b7621b694bb5b5cde2bbfc94066ed62b9817"
                 ]
             }
         },
@@ -251,8 +251,8 @@
                 "bip350Address": "bc1z9a4jc5uhkmtgegvwpx3lq5tpv68layaf3pvz64wx7paatvejnhhsv52lcv",
                 "scriptPathControlBlocks": [
                     "c13cd369a528b326bc9d2133cbd2ac21451acb31681a410434672c8e34fe757e91",
-                    "c1737ed1fe30bc42b8022d717b44f0d93516617af64a64753b7a06bf16b26cd711f154e8e8e17c31d3462d7132589ed29353c6fafdb884c5a6e04ea938834f0d9d",
-                    "c1d7485025fceb78b9ed667db36ed8b8dc7b1f0b307ac167fa516fe4352b9f4ef7f154e8e8e17c31d3462d7132589ed29353c6fafdb884c5a6e04ea938834f0d9d"
+                    "c1d7485025fceb78b9ed667db36ed8b8dc7b1f0b307ac167fa516fe4352b9f4ef7f154e8e8e17c31d3462d7132589ed29353c6fafdb884c5a6e04ea938834f0d9d",
+                    "c1737ed1fe30bc42b8022d717b44f0d93516617af64a64753b7a06bf16b26cd711f154e8e8e17c31d3462d7132589ed29353c6fafdb884c5a6e04ea938834f0d9d"
                 ]
             }
         }


### PR DESCRIPTION
## Summary


## Problem

In a tree structured as [leaf0, [leaf1, leaf2]],
 the control block for spending
a leaf must contain the sibling 
hashes along the Merkle path, not the leaf's
own hash. The current test vectors have the control blocks for leaf1 and leaf2
swapped, causing them to include the spending leaf's own hash as the first path
element instead of its sibling's hash.

### Example:es 1 and 2 in the
three-lea
Intermediate leaf hashes (correct in the test vector):
```
leafHash[0] = 2645a02e0aac1fe69d69755733a9b7621b694bb5b5cde2bbfc94066ed62b9817
leafHash[1] = ba982a91d4fc552163cb1c0da03676102d5b7a014304c01f0c77b2b8e888de1c
leafHash[2] = 9e31407bffa15fefbf5090b149d53959ecdf3f62b1246780238c24501d5ceaf6
merkleRoot  = ccbd66c6f7e8fdab47b3a486f59d28262be857f30d4773f2d5ea47f7761ce0e2
Current (incorrect)ests/data/p2mr_construction. 
[1] = c1 ba982a91...de1c 2645a02e...9817   ← first path element is leafHash[1] itself!
[2] = c1 9e31407b...f6   2645a02e...9817   ← first path element is leafHash[2] itself!
```

Fix swapped 
```
scripto verify leaf1:kj = leafHash[1] = ba982a91...
ej = ba982a91...  (from control block, which IS leafHash[1])
→ tapBranchHash(ba982a91..., ba982a91...) = ccabeef4...  ← hashing with itself!
→ final root = 5037e24f... ≠ expected ccbd66c6...  ✗
```

### Fix

Swap1 and 2 in the
three-leaf P2MRand scriptPathControlBlocks[2]:
```
[1] = c1 9e31407b...f6   2645a02e...9817   ← sibling of leaf1 is leafHash[2], then leafHash[0]
[2] = c1 ba982a91...de1c 2645a02e...9817   ← sibling of leaf2 is leafHash[1], then leafHash[0]
```
Verification of correctedontrolBlocks
``` 
entries for leaffor leaf1:kj = leafHash[1] = ba982a91...  
ej = leafHash[2] = 9e31407b...  
→ tapBranchHash(9e31..., ba98...) = ffe578e9...  ← correct inner branch hash ✓. 
ej = leafHash[0] = 2645a02e...  
→ tapBranchHash(2645..., ffe5...) = ccbd66c6...  ← correct merkle root ✓
```
The same issue exists in P2MR test vectors `p2mr_threeand` is fixed identically.
