### PR TITLE
BIP-119: Fix missing self. prefix on stack reference in pseudocode

### DIFF
--- a/bip-0119.mediawiki
+++ b/bip-0119.mediawiki
@@ -71,7 +71,7 @@ def execute_bip_119(self):
             self.context.precomputed_ctv_data = self.context.tx.get_default_check_template_precomputed_data()
 
         # If the hashes do not match, return error
-        if stack[-1] != self.context.tx.get_default_check_template_hash(self.context.nIn, self.context.precomputed_ctv_data):
+        if self.stack[-1] != self.context.tx.get_default_check_template_hash(self.context.nIn, self.context.precomputed_ctv_data):
             return self.errors_with(errors.script_err_template_mismatch)
 
         return self.return_as_nop()


### PR DESCRIPTION
## Summary

In the `execute_bip_119` pseudocode, the hash comparison references `stack[-1]` instead of `self.stack[-1]`, inconsistent with all other stack references in the function:

```python
# Correct:
if len(self.stack) < 1:
if len(self.stack[-1]) == 32:

# Incorrect — missing self.:
if stack[-1] != self.context.tx.get_default_check_template_hash(...)
```

In Python, `stack[-1]` would reference an undefined local variable, while `self.stack[-1]` correctly accesses the interpreter's stack. The C++ reference implementation uses `stack.back()` consistently and is not affected.