### PR TITLE
BIP-352: warn against stopping scan due to wallet policy filtering

### DIFF
--- a/bip-0352.mediawiki
+++ b/bip-0352.mediawiki
@@ -357,7 +357,7 @@ If each of the checks in ''[[#scanning-silent-payment-eligible-transactions|Scan
 ****** Add ''P<sub>k</sub> + label'' to the wallet
 ****** Remove ''output'' from ''outputs_to_check'' and rescan ''outputs_to_check'' with ''k++''
 ***** If a label is not found, negate ''output'' and check a second time<ref name="negate_output">''' Why negate the output?''' Unfortunately taproot outputs are X-only, meaning we don't know what the correct Y coordinate is. This causes this specific calculation to fail 50% of the time, so we need to repeat it with the other Y coordinate by negating the output.</ref>
-*** If no matches are found, stop
+*** If no matches are found, stop<ref name="always_continue_scanning_after_match">'''WARNING:''' The decision to continue scanning (increment ''k'') must be based on whether a cryptographic match was found, not on whether the wallet considers the output spendable or relevant. A match that is later filtered by wallet policy (e.g. dust) must still trigger a rescan with ''k++''; stopping early may cause subsequent outputs for the same sender to be missed.</ref>
 
 ==== Spending ====
 


### PR DESCRIPTION
From the discussion in https://github.com/bitcoin/bips/pull/2106#issuecomment-3961384931, this PR adds a warning to the "if no matches are found, stop" scanning step. Without it, wallet developers may be tempted to apply policy filtering (e.g. dust) before deciding to continue, causing subsequent outputs for the same sender to be missed.