### PR TITLE
BIP174: Deduplicate type definitions by introducing registry file

### DIFF
--- a/bip-0174.mediawiki
+++ b/bip-0174.mediawiki
@@ -288,7 +288,7 @@ Per-input types are defined as follows:
 | 0, 2
 |}
 
-The currently defined per-output <ref>'''Why do we need per-output data?''' Per-output data allows signers
+The per-output <ref>'''Why do we need per-output data?''' Per-output data allows signers
 to verify that the outputs are going to the intended recipient. The output data can also be use by signers to
 determine which outputs are change outputs and verify that the change is returning to the correct place.</ref> types are defined as follows:
 
@@ -302,7 +302,6 @@ determine which outputs are change outputs and verify that the change is returni
 ! Versions Requiring Inclusion
 ! Versions Requiring Exclusion
 ! Versions Allowing Inclusion
-! Parent BIP
 |-
 | Redeem Script
 | <tt>PSBT_OUT_REDEEM_SCRIPT = 0x00</tt>
@@ -313,7 +312,6 @@ determine which outputs are change outputs and verify that the change is returni
 |
 |
 | 0, 2
-| 174
 |-
 | Witness Script
 | <tt>PSBT_OUT_WITNESS_SCRIPT = 0x01</tt>
@@ -324,7 +322,6 @@ determine which outputs are change outputs and verify that the change is returni
 |
 |
 | 0, 2
-| 174
 |-
 | BIP 32 Derivation Path
 | <tt>PSBT_OUT_BIP32_DERIVATION = 0x02</tt>
@@ -335,110 +332,6 @@ determine which outputs are change outputs and verify that the change is returni
 |
 |
 | 0, 2
-| 174
-|-
-| Output Amount
-| <tt>PSBT_OUT_AMOUNT = 0x03</tt>
-| None
-| No key data
-| <tt><64-bit int amount></tt>
-| 64 bit signed little endian integer representing the output's amount in satoshis.
-| 2
-| 0
-| 2
-| [[bip-0370.mediawiki|370]]
-|-
-| Output Script
-| <tt>PSBT_OUT_SCRIPT = 0x04</tt>
-| None
-| No key data
-| <tt><bytes script></tt>
-| The script for this output, also known as the scriptPubKey. Must be omitted in PSBTv0. Must be provided in PSBTv2 if not sending to a BIP352 silent payment address, otherwise may be omitted.
-|
-| 0
-| 2
-| [[bip-0370.mediawiki|370]], [[bip-0375.mediawiki|375]]
-|-
-| Taproot Internal Key
-| <tt>PSBT_OUT_TAP_INTERNAL_KEY = 0x05</tt>
-| None
-| No key data
-| <tt><32 byte xonlypubkey></tt>
-| The X-only pubkey used as the internal key in this output.
-|
-|
-| 0, 2
-| [[bip-0371.mediawiki|371]]
-|-
-| Taproot Tree
-| <tt>PSBT_OUT_TAP_TREE = 0x06</tt>
-| None
-| No key data
-| <tt>{<8-bit uint depth> <8-bit uint leaf version> <compact size uint scriptlen> <bytes script>}*</tt>
-| One or more tuples representing the depth, leaf version, and script for a leaf in the Taproot tree, allowing the entire tree to be reconstructed. The tuples must be in depth first search order so that the tree is correctly reconstructed. Each tuple is an 8-bit unsigned integer representing the depth in the Taproot tree for this script, an 8-bit unsigned integer representing the leaf version, the length of the script as a compact size unsigned integer, and the script itself.
-|
-|
-| 0, 2
-| [[bip-0371.mediawiki|371]]
-|-
-| Taproot Key BIP 32 Derivation Path
-| <tt>PSBT_OUT_TAP_BIP32_DERIVATION = 0x07</tt>
-| <tt><32 byte xonlypubkey></tt>
-| A 32 byte X-only public key involved in this output. It may be the output key, the internal key, or a key present in a leaf script.
-| <tt><compact size uint number of hashes> <32 byte leaf hash>* <4 byte fingerprint> <32-bit little endian uint path element>*</tt>
-| A compact size unsigned integer representing the number of leaf hashes, followed by a list of leaf hashes, followed by the 4 byte master key fingerprint concatenated with the derivation path of the public key. The derivation path is represented as 32-bit little endian unsigned integer indexes concatenated with each other. Public keys are those needed to spend this output. The leaf hashes are of the leaves which involve this public key. The internal key does not have leaf hashes, so can be indicated with a <tt>hashes len</tt> of 0. Finalizers should remove this field after <tt>PSBT_IN_FINAL_SCRIPTWITNESS</tt> is constructed.
-|
-|
-| 0, 2
-| [[bip-0371.mediawiki|371]]
-|-
-| MuSig2 Participant Public Keys
-| <tt>PSBT_OUT_MUSIG2_PARTICIPANT_PUBKEYS = 0x08</tt>
-| <tt><33 byte aggregate pubkey (compressed)></tt>
-| The MuSig2 compressed aggregate public key from the <tt>KeyAgg</tt> algorithm. This key may or may not
-be in the script directly. It may instead be a parent public key from which the public keys in the
-script were derived.
-| <tt><33 byte participant pubkey (compressed)>*</tt>
-| A list of the compressed public keys of the participants in the MuSig2 aggregate key in the order
-required for aggregation. If sorting was done, then the keys must be in the sorted order.
-|
-|
-| 0, 2
-| [[bip-0373.mediawiki|373]]
-|-
-| Silent Payment Data
-| <tt>PSBT_OUT_SP_V0_INFO = 0x09</tt>
-| None
-| No key data
-| <tt><33 byte scan key> <33 byte spend key></tt>
-| The scan and spend public keys from the silent payments address.
-|
-| 0
-| 2
-| [[bip-0375.mediawiki|375]]
-|-
-| Silent Payment Label
-| <tt>PSBT_OUT_SP_V0_LABEL = 0x0a</tt>
-| None
-| No key data
-| <tt><32-bit little endian uint label></tt>
-| The label to use to compute the spend key of the silent payments address to verify change.
-|
-| 0
-| 2
-| [[bip-0375.mediawiki|375]]
-|-
-| BIP 353 DNSSEC proof
-| <tt>PSBT_OUT_DNSSEC_PROOF = 0x35</tt>
-| None
-| No key data
-| <tt><1-byte-length-prefixed BIP 353 human-readable name><RFC 9102-formatted AuthenticationChain DNSSEC Proof></tt>
-| A BIP 353 human-readable name (without the ₿ prefix), prefixed by a 1-byte length.
-Followed by an [[https://www.rfc-editor.org/rfc/rfc9102.html#name-dnssec-authentication-chain|RFC 9102 DNSSEC <tt>AuthenticationChain</tt>]] (i.e. a series of DNS Resource Records in no particular order) providing a DNSSEC proof to a BIP 353 DNS TXT record.
-|
-|
-| 0, 2
-| [[bip-0353.mediawiki|353]]
 |-
 | Proprietary Use Type
 | <tt>PSBT_OUT_PROPRIETARY = 0xFC</tt>
@@ -449,7 +342,6 @@ Followed by an [[https://www.rfc-editor.org/rfc/rfc9102.html#name-dnssec-authent
 |
 |
 | 0, 2
-| 174
 |}
 
 Types can be skipped when they are unnecessary. For example, if an input is a witness

--- a/bip-0174.mediawiki
+++ b/bip-0174.mediawiki
@@ -134,7 +134,7 @@ The global types are defined as follows:
 | 0, 2
 |}
 
-The currently defined per-input types are defined as follows:
+Per-input types are defined as follows:
 
 {|
 ! Name
@@ -146,7 +146,6 @@ The currently defined per-input types are defined as follows:
 ! Versions Requiring Inclusion
 ! Versions Requiring Exclusion
 ! Versions Allowing Inclusion
-! Parent BIP
 |-
 | Non-Witness UTXO
 | <tt>PSBT_IN_NON_WITNESS_UTXO = 0x00</tt>
@@ -157,7 +156,6 @@ The currently defined per-input types are defined as follows:
 |
 |
 | 0, 2
-| 174
 |-
 | Witness UTXO
 | <tt>PSBT_IN_WITNESS_UTXO = 0x01</tt>
@@ -168,7 +166,6 @@ The currently defined per-input types are defined as follows:
 |
 |
 | 0, 2
-| 174
 |-
 | Partial Signature
 | <tt>PSBT_IN_PARTIAL_SIG = 0x02</tt>
@@ -179,7 +176,6 @@ The currently defined per-input types are defined as follows:
 |
 |
 | 0, 2
-| 174
 |-
 | Sighash Type
 | <tt>PSBT_IN_SIGHASH_TYPE = 0x03</tt>
@@ -190,7 +186,6 @@ The currently defined per-input types are defined as follows:
 |
 |
 | 0, 2
-| 174
 |-
 | Redeem Script
 | <tt>PSBT_IN_REDEEM_SCRIPT = 0x04</tt>
@@ -201,7 +196,6 @@ The currently defined per-input types are defined as follows:
 |
 |
 | 0, 2
-| 174
 |-
 | Witness Script
 | <tt>PSBT_IN_WITNESS_SCRIPT = 0x05</tt>
@@ -212,7 +206,6 @@ The currently defined per-input types are defined as follows:
 |
 |
 | 0, 2
-| 174
 |-
 | BIP 32 Derivation Path
 | <tt>PSBT_IN_BIP32_DERIVATION = 0x06</tt>
@@ -223,7 +216,6 @@ The currently defined per-input types are defined as follows:
 |
 |
 | 0, 2
-| 174
 |-
 | Finalized scriptSig
 | <tt>PSBT_IN_FINAL_SCRIPTSIG = 0x07</tt>
@@ -234,7 +226,6 @@ The currently defined per-input types are defined as follows:
 |
 |
 | 0, 2
-| 174
 |-
 | Finalized scriptWitness
 | <tt>PSBT_IN_FINAL_SCRIPTWITNESS = 0x08</tt>
@@ -245,18 +236,6 @@ The currently defined per-input types are defined as follows:
 |
 |
 | 0, 2
-| 174
-|-
-| Proof-of-reserves commitment
-| <tt>PSBT_IN_POR_COMMITMENT = 0x09</tt>
-| None
-| No key data
-| <tt><bytes porCommitment></tt>
-| The UTF-8 encoded commitment message string for the proof-of-reserves.  See [[bip-0127.mediawiki|BIP 127]] for more information.
-|
-|
-| 0, 2
-| [[bip-0127.mediawiki|127]]
 |-
 | RIPEMD160 preimage
 | <tt>PSBT_IN_RIPEMD160 = 0x0a</tt>
@@ -267,7 +246,6 @@ The currently defined per-input types are defined as follows:
 |
 |
 | 0, 2
-| 174
 |-
 | SHA256 preimage
 | <tt>PSBT_IN_SHA256 = 0x0b</tt>
@@ -278,7 +256,6 @@ The currently defined per-input types are defined as follows:
 |
 |
 | 0, 2
-| 174
 |-
 | HASH160 preimage
 | <tt>PSBT_IN_HASH160 = 0x0c</tt>
@@ -289,7 +266,6 @@ The currently defined per-input types are defined as follows:
 |
 |
 | 0, 2
-| 174
 |-
 | HASH256 preimage
 | <tt>PSBT_IN_HASH256 = 0x0d</tt>
@@ -300,218 +276,6 @@ The currently defined per-input types are defined as follows:
 |
 |
 | 0, 2
-| 174
-|-
-| Previous TXID
-| <tt>PSBT_IN_PREVIOUS_TXID = 0x0e</tt>
-| None
-| No key data
-| <tt><32 byte txid></tt>
-| 32 byte txid in standard byte order, not display byte order, of the previous transaction whose output at PSBT_IN_OUTPUT_INDEX is being spent.
-| 2
-| 0
-| 2
-| [[bip-0370.mediawiki|370]]
-|-
-| Spent Output Index
-| <tt>PSBT_IN_OUTPUT_INDEX = 0x0f</tt>
-| None
-| No key data
-| <tt><32-bit little endian uint index></tt>
-| 32 bit little endian integer representing the index of the output being spent in the transaction with the txid of PSBT_IN_PREVIOUS_TXID.
-| 2
-| 0
-| 2
-| [[bip-0370.mediawiki|370]]
-|-
-| Sequence Number
-| <tt>PSBT_IN_SEQUENCE = 0x10</tt>
-| None
-| No key data
-| <tt><32-bit little endian uint sequence></tt>
-| The 32 bit unsigned little endian integer for the sequence number of this input. If omitted, the sequence number is assumed to be the final sequence number (0xffffffff).
-|
-| 0
-| 2
-| [[bip-0370.mediawiki|370]]
-|-
-| Required Time-based Locktime
-| <tt>PSBT_IN_REQUIRED_TIME_LOCKTIME = 0x11</tt>
-| None
-| No key data
-| <tt><32-bit little endian uint locktime></tt>
-| 32 bit unsigned little endian integer greater than or equal to 500000000 representing the minimum Unix timestamp that this input requires to be set as the transaction's lock time.
-|
-| 0
-| 2
-| [[bip-0370.mediawiki|370]]
-|-
-| Required Height-based Locktime
-| <tt>PSBT_IN_REQUIRED_HEIGHT_LOCKTIME = 0x12</tt>
-| None
-| No key data
-| <tt><32-bit uint locktime></tt>
-| 32 bit unsigned little endian integer less than 500000000 representing the minimum block height that this input requires to be set as the transaction's lock time.
-|
-| 0
-| 2
-| [[bip-0370.mediawiki|370]]
-|-
-| Taproot Key Spend Signature
-| <tt>PSBT_IN_TAP_KEY_SIG = 0x13</tt>
-| None
-| No key data
-| <tt><64 or 65 byte signature></tt>
-| The 64 or 65 byte Schnorr signature for key path spending a Taproot output. Finalizers should remove this field after <tt>PSBT_IN_FINAL_SCRIPTWITNESS</tt> is constructed.
-|
-|
-| 0, 2
-| [[bip-0371.mediawiki|371]]
-|-
-| Taproot Script Spend Signature
-| <tt>PSBT_IN_TAP_SCRIPT_SIG = 0x14</tt>
-| <tt><32 byte xonlypubkey> <leafhash></tt>
-| A 32 byte X-only public key involved in a leaf script concatenated with the 32 byte hash of the leaf it is part of.
-| <tt><64 or 65 byte signature></tt>
-| The 64 or 65 byte Schnorr signature for this pubkey and leaf combination. Finalizers should remove this field after <tt>PSBT_IN_FINAL_SCRIPTWITNESS</tt> is constructed.
-|
-|
-| 0, 2
-| [[bip-0371.mediawiki|371]]
-|-
-| Taproot Leaf Script
-| <tt>PSBT_IN_TAP_LEAF_SCRIPT = 0x15</tt>
-| <tt><bytes control block></tt>
-| The control block for this leaf as specified in BIP 341. The control block contains the merkle tree path to this leaf.
-| <tt><bytes script> <8-bit uint leaf version></tt>
-| The script for this leaf as would be provided in the witness stack followed by the single byte leaf version. Note that the leaves included in this field should be those that the signers of this input are expected to be able to sign for. Finalizers should remove this field after <tt>PSBT_IN_FINAL_SCRIPTWITNESS</tt> is constructed.
-|
-|
-| 0, 2
-| [[bip-0371.mediawiki|371]]
-|-
-| Taproot Key BIP 32 Derivation Path
-| <tt>PSBT_IN_TAP_BIP32_DERIVATION = 0x16</tt>
-| <tt><32 byte xonlypubkey></tt>
-| A 32 byte X-only public key involved in this input. It may be the output key, the internal key, or a key present in a leaf script.
-| <tt><compact size uint number of hashes> <32 byte leaf hash>* <4 byte fingerprint> <32-bit little endian uint path element>*</tt>
-| A compact size unsigned integer representing the number of leaf hashes, followed by a list of leaf hashes, followed by the 4 byte master key fingerprint concatenated with the derivation path of the public key. The derivation path is represented as 32-bit little endian unsigned integer indexes concatenated with each other. Public keys are those needed to spend this output. The leaf hashes are of the leaves which involve this public key. The internal key does not have leaf hashes, so can be indicated with a <tt>hashes len</tt> of 0. Finalizers should remove this field after <tt>PSBT_IN_FINAL_SCRIPTWITNESS</tt> is constructed.
-|
-|
-| 0, 2
-| [[bip-0371.mediawiki|371]]
-|-
-| Taproot Internal Key
-| <tt>PSBT_IN_TAP_INTERNAL_KEY = 0x17</tt>
-| None
-| No key data
-| <tt><32 byte xonlypubkey></tt>
-| The X-only pubkey used as the internal key in this output. Finalizers should remove this field after <tt>PSBT_IN_FINAL_SCRIPTWITNESS</tt> is constructed.
-|
-|
-| 0, 2
-| [[bip-0371.mediawiki|371]]
-|-
-| Taproot Merkle Root
-| <tt>PSBT_IN_TAP_MERKLE_ROOT = 0x18</tt>
-| None
-| No key data
-| <tt><32-byte hash></tt>
-| The 32 byte Merkle root hash. Finalizers should remove this field after <tt>PSBT_IN_FINAL_SCRIPTWITNESS</tt> is constructed.
-|
-|
-| 0, 2
-| [[bip-0371.mediawiki|371]]
-|-
-| MuSig2 Participant Public Keys
-| <tt>PSBT_IN_MUSIG2_PARTICIPANT_PUBKEYS = 0x1a</tt>
-| <33 byte aggregate pubkey (compressed)>
-| The MuSig2 aggregate public key (compressed) from the <tt>KeyAgg</tt> algorithm. This key may or may not
-be in the script directly (as x-only). It may instead be a parent public key from which the public keys in the
-script were derived.
-| <tt><33 byte participant pubkey (compressed)>*</tt>
-| A list of the compressed public keys of the participants in the MuSig2 aggregate key in the order
-required for aggregation. If sorting was done, then the keys must be in the sorted order.
-|
-|
-| 0, 2
-| [[bip-0373.mediawiki|373]]
-|-
-| MuSig2 Public Nonce
-| <tt>PSBT_IN_MUSIG2_PUB_NONCE = 0x1b</tt>
-| <tt><33 byte participant pubkey (compressed)> <33 byte aggregate pubkey (compressed)> <32 byte hash or omitted></tt>
-| The compressed public key of the participant providing this nonce, followed by the compressed aggregate public
-key the participant is providing the nonce for, followed by the BIP 341 tapleaf hash of
-the Taproot leaf script that will be signed. If the aggregate key is the taproot internal key or the
-taproot output key, then the tapleaf hash must be omitted. The compressed participant public key must be
-the key found in the script and not the aggregate public key that it was derived from, if it was
-derived from an aggregate key.
-| <tt><66 byte public nonce></tt>
-| The public nonce produced by the <tt>NonceGen</tt> algorithm.
-|
-|
-| 0, 2
-| [[bip-0373.mediawiki|373]]
-|-
-| MuSig2 Participant Partial Signature
-| <tt>PSBT_IN_MUSIG2_PARTIAL_SIG = 0x1c</tt>
-| <tt><33 byte participant pubkey (compressed)> <33 byte aggregate pubkey (compressed)> <32 byte hash or omitted></tt>
-| The compressed public key of the participant providing this partial signature, followed by the
-compressed public key the participant is providing the signature for, followed by the BIP 341 tapleaf hash
-of the Taproot leaf script that will be signed. If the aggregate key is the Taproot internal key or
-the Taproot output key, then the tapleaf hash must be omitted. Note that the compressed participant public key must be
-be the key found in the script and not the aggregate public key that it was derived from, if it was
-derived from an aggregate key.
-| <tt><32 byte partial signature></tt>
-| The partial signature produced by the <tt>Sign</tt> algorithm.
-|
-|
-| 0, 2
-| [[bip-0373.mediawiki|373]]
-|-
-| Silent Payment Input ECDH Share
-| <tt>PSBT_IN_SP_ECDH_SHARE = 0x1d</tt>
-| <tt><33 byte scan key></tt>
-| The scan key that this ECDH share is for.
-| <tt><33 byte share></tt>
-| An ECDH share for a scan key. The ECDH shared is computed with ''a * B_scan'', where ''a'' is the private key of the corresponding prevout public key, and ''B_scan'' is the scan key of a recipient.
-|
-| 0
-| 2
-| [[bip-0375.mediawiki|375]]
-|-
-| Silent Payment Input DLEQ Proof
-| <tt>PSBT_IN_SP_DLEQ = 0x1e</tt>
-| <tt><33 byte scan key></tt>
-| The scan key that this proof covers.
-| <tt><64-byte proof></tt>
-| A BIP374 DLEQ proof computed for the matching ECDH share.
-|
-| 0
-| 2
-| [[bip-0375.mediawiki|375]]
-|-
-| Silent Payment Spend Key BIP 32 Derivation Path
-| <tt>PSBT_IN_SP_SPEND_BIP32_DERIVATION = 0x1f</tt>
-| <tt><33-byte spend key></tt>
-| The 33-byte spend public key used to derive the key locking this input.
-| <tt><4-byte fingerprint> <32-bit little endian uint path element>*</tt>
-| The master key fingerprint as defined by BIP 32 concatenated with the derivation path of the spend public key. The derivation path is represented as indexed 32-bit unsigned integers concatenated with each other. Input Finalizers should remove this field after <tt>PSBT_IN_FINAL_SCRIPTWITNESS</tt> is constructed.
-|
-| 0
-| 2
-| [[bip-0376.mediawiki|376]]
-|-
-| Silent Payment Tweak
-| <tt>PSBT_IN_SP_TWEAK = 0x20</tt>
-| None
-| No key data
-| <tt><32-byte tweak></tt>
-| A 32-byte raw tweak. Input Finalizers should remove this field after <tt>PSBT_IN_FINAL_SCRIPTWITNESS</tt> is constructed.
-|
-| 0
-| 2
-| [[bip-0376.mediawiki|376]]
 |-
 | Proprietary Use Type
 | <tt>PSBT_IN_PROPRIETARY = 0xFC</tt>
@@ -522,7 +286,6 @@ derived from an aggregate key.
 |
 |
 | 0, 2
-| 174
 |}
 
 The currently defined per-output <ref>'''Why do we need per-output data?''' Per-output data allows signers

--- a/bip-0174.mediawiki
+++ b/bip-0174.mediawiki
@@ -80,7 +80,7 @@ this will cause any non-PSBT unserializer to fail to properly unserialize the PS
 as a normal transaction. Likewise, since the 5 byte header is fixed, no transaction
 in the non-PSBT format will be able to be unserialized by a PSBT unserializer.</ref>. This integer must be serialized in most significant byte order.
 
-The currently defined global types are as follows:
+The global types are defined as follows:
 
 {|
 ! Name
@@ -92,7 +92,6 @@ The currently defined global types are as follows:
 ! Versions Requiring Inclusion
 ! Versions Requiring Exclusion
 ! Versions Allowing Inclusion
-! Parent BIP
 |-
 | Unsigned Transaction
 | <tt>PSBT_GLOBAL_UNSIGNED_TX = 0x00</tt>
@@ -103,7 +102,6 @@ The currently defined global types are as follows:
 | 0
 | 2
 | 0
-| 174
 |-
 | Extended Public Key
 | <tt>PSBT_GLOBAL_XPUB = 0x01</tt>
@@ -114,84 +112,6 @@ The currently defined global types are as follows:
 |
 |
 | 0, 2
-| 174
-|-
-| Transaction Version
-| <tt>PSBT_GLOBAL_TX_VERSION = 0x02</tt>
-| None
-| No key data
-| <tt><32-bit little endian int version></tt>
-| The 32-bit little endian signed integer representing the version number of the transaction being created. Note that this is not the same as the PSBT version number specified by the PSBT_GLOBAL_VERSION field.
-| 2
-| 0
-| 2
-| [[bip-0370.mediawiki|370]]
-|-
-| Fallback Locktime
-| <tt>PSBT_GLOBAL_FALLBACK_LOCKTIME = 0x03</tt>
-| None
-| No key data
-| <tt><32-bit little endian uint locktime></tt>
-| The 32-bit little endian unsigned integer representing the transaction locktime to use if no inputs specify a required locktime.
-|
-| 0
-| 2
-| [[bip-0370.mediawiki|370]]
-|-
-| Input Count
-| <tt>PSBT_GLOBAL_INPUT_COUNT = 0x04</tt>
-| None
-| No key data
-| <tt><compact size uint input count></tt>
-| Compact size unsigned integer representing the number of inputs in this PSBT.
-| 2
-| 0
-| 2
-| [[bip-0370.mediawiki|370]]
-|-
-| Output Count
-| <tt>PSBT_GLOBAL_OUTPUT_COUNT = 0x05</tt>
-| None
-| No key data
-| <tt><compact size uint input count></tt>
-| Compact size unsigned integer representing the number of outputs in this PSBT.
-| 2
-| 0
-| 2
-| [[bip-0370.mediawiki|370]]
-|-
-| Transaction Modifiable Flags
-| <tt>PSBT_GLOBAL_TX_MODIFIABLE = 0x06</tt>
-| None
-| No key data
-| <tt><8-bit uint flags></tt>
-| An 8 bit little endian unsigned integer as a bitfield for various transaction modification flags. Bit 0 is the Inputs Modifiable Flag and indicates whether inputs can be modified. Bit 1 is the Outputs Modifiable Flag and indicates whether outputs can be modified. Bit 2 is the Has SIGHASH_SINGLE flag and indicates whether the transaction has a SIGHASH_SINGLE signature who's input and output pairing must be preserved. Bit 2 essentially indicates that the Constructor must iterate the inputs to determine whether and how to add an input.
-|
-| 0
-| 2
-| [[bip-0370.mediawiki|370]]
-|-
-| Silent Payment Global ECDH Share
-| <tt>PSBT_GLOBAL_SP_ECDH_SHARE = 0x07</tt>
-| <tt><33 byte scan key></tt>
-| The scan key that this ECDH share is for.
-| <tt><33 byte share></tt>
-| An ECDH share for a scan key. The ECDH shared is computed with ''a * B_scan'', where ''a'' is the sum of all private keys of all eligible inputs, and ''B_scan'' is the scan key of a recipient.
-|
-| 0
-| 2
-| [[bip-0375.mediawiki|375]]
-|-
-| Silent Payment Global DLEQ Proof
-| <tt>PSBT_GLOBAL_SP_DLEQ = 0x08</tt>
-| <tt><33 byte scan key></tt>
-| The scan key that this proof covers.
-| <tt><64-byte proof></tt>
-| A BIP374 DLEQ proof computed for the matching ECDH share.
-|
-| 0
-| 2
-| [[bip-0375.mediawiki|375]]
 |-
 | PSBT Version Number
 | <tt>PSBT_GLOBAL_VERSION = 0xFB</tt>
@@ -202,7 +122,6 @@ The currently defined global types are as follows:
 | 2
 |
 | 0, 2
-| 174
 |-
 | Proprietary Use Type
 | <tt>PSBT_GLOBAL_PROPRIETARY = 0xFC</tt>
@@ -213,7 +132,6 @@ The currently defined global types are as follows:
 |
 |
 | 0, 2
-| 174
 |}
 
 The currently defined per-input types are defined as follows:
@@ -782,6 +700,8 @@ specified format for that type, the PSBT must be considered invalid. For example
 key that has no data except for the type specifier must only have the type specifier in
 the key.
 
+Additional types may be defined by other BIPs. They should be added to the accompanying [[bip-0174/type-registry.mediawiki|type registry tables]] to ease coordination.
+
 ===Handling Duplicated Keys===
 
 Keys within each scope should never be duplicated; all keys in the format are unique. PSBTs containing duplicate keys are invalid. However implementers
@@ -976,9 +896,9 @@ If an updater is updating a PSBT and needs to add a field that is only available
 
 ===Procedure For New Fields===
 
-New fields should first be proposed on the bitcoin-dev mailing list.
-If a field requires significant description as to its usage, it should be accompanied by a separate BIP.
-The field must be added to the field listing tables in the Specification section.
+New fields should first be proposed on the bitcoin-dev mailing list,
+and their usage should then be defined in a separate BIP.
+New fields must be added to the [[bip-0174/type-registry.mediawiki|type registry tables]].
 Although some PSBT version 0 implementations encode types as uint8_t rather than compact size,
 it is still safe to add >0xFD fields to PSBT 0, because these old parsers ignore
 unknown fields, and <keytype> is prefixed by its length.
@@ -986,8 +906,8 @@ unknown fields, and <keytype> is prefixed by its length.
 ===Procedure For New Versions===
 
 New PSBT versions must be described in a separate BIP.
-The BIP may reference this BIP and any components of PSBT version 0 that are retained in the new version.
-Any new fields described in the new version must be added to the field listing tables in the Specification section.
+Such new BIPs may reference this BIP and any components of PSBT version 0 that are retained in the new version.
+Any new fields described in a new version must be added to the [[bip-0174/type-registry.mediawiki|type registry tables]].
 
 ==Compatibility==
 

--- a/bip-0174.mediawiki
+++ b/bip-0174.mediawiki
@@ -9,6 +9,7 @@
   Type: Specification
   Assigned: 2017-07-12
   License: BSD-2-Clause
+  Version: 1.4.2
 </pre>
 
 ==Introduction==
@@ -579,6 +580,25 @@ able to be unserialized by an unserializer for the PSBT format.
 ===2-of-3 Multisig Workflow===
 
 <img src="bip-0174/multisig-workflow.svg" align="middle"></img>
+
+==Changelog==
+
+* '''1.4.2''' (2026-04-08):
+** Introduce type registry auxiliary file
+** Add changelog
+* '''1.4.1''' (2021-01-14):
+** Mark Final
+* '''1.4.0''' (2019-10-02):
+** Add preimage fields
+* '''1.3.0''' (2019-10-02):
+** Add proprietary fields
+* '''1.2.0''' (2019-08-01):
+** Types are compact size unsigned ints
+** Add global PSBT version field
+* '''1.1.0''' (2019-05-13):
+** Add global xpub field
+* '''1.0.0''' (2018-07-11):
+** Mark Proposed
 
 ==Test Vectors==
 

--- a/bip-0174/type-registry.mediawiki
+++ b/bip-0174/type-registry.mediawiki
@@ -1,0 +1,53 @@
+This document collects the fields and types used in PSBTs of any version from all BIPs that define PSBT fields to help coordinate and prevent key collisions.
+
+==Global Types==
+
+{|
+! Name
+! <tt><keytype></tt>
+! Parent BIP
+|-
+| Unsigned Transaction
+| <tt>PSBT_GLOBAL_UNSIGNED_TX = 0x00</tt>
+| [[bip-0174.mediawiki|174]]
+|-
+| Extended Public Key
+| <tt>PSBT_GLOBAL_XPUB = 0x01</tt>
+| [[bip-0174.mediawiki|174]]
+|-
+| Transaction Version
+| <tt>PSBT_GLOBAL_TX_VERSION = 0x02</tt>
+| [[bip-0370.mediawiki|370]]
+|-
+| Fallback Locktime
+| <tt>PSBT_GLOBAL_FALLBACK_LOCKTIME = 0x03</tt>
+| [[bip-0370.mediawiki|370]]
+|-
+| Input Count
+| <tt>PSBT_GLOBAL_INPUT_COUNT = 0x04</tt>
+| [[bip-0370.mediawiki|370]]
+|-
+| Output Count
+| <tt>PSBT_GLOBAL_OUTPUT_COUNT = 0x05</tt>
+| [[bip-0370.mediawiki|370]]
+|-
+| Transaction Modifiable Flags
+| <tt>PSBT_GLOBAL_TX_MODIFIABLE = 0x06</tt>
+| [[bip-0370.mediawiki|370]]
+|-
+| Silent Payment Global ECDH Share
+| <tt>PSBT_GLOBAL_SP_ECDH_SHARE = 0x07</tt>
+| [[bip-0375.mediawiki|375]]
+|-
+| Silent Payment Global DLEQ Proof
+| <tt>PSBT_GLOBAL_SP_DLEQ = 0x08</tt>
+| [[bip-0375.mediawiki|375]]
+|-
+| PSBT Version Number
+| <tt>PSBT_GLOBAL_VERSION = 0xFB</tt>
+| [[bip-0174.mediawiki|174]]
+|-
+| Proprietary Use Type
+| <tt>PSBT_GLOBAL_PROPRIETARY = 0xFC</tt>
+| [[bip-0174.mediawiki|174]]
+|}

--- a/bip-0174/type-registry.mediawiki
+++ b/bip-0174/type-registry.mediawiki
@@ -191,3 +191,64 @@ This document collects the fields and types used in PSBTs of any version from al
 | <tt>PSBT_IN_PROPRIETARY = 0xFC</tt>
 | [[bip-0174.mediawiki|174]]
 |}
+
+
+==Per-output types==
+
+{|
+! Name
+! <tt><keytype></tt>
+! Parent BIP
+|-
+| Redeem Script
+| <tt>PSBT_OUT_REDEEM_SCRIPT = 0x00</tt>
+| [[bip-0174.mediawiki|174]]
+|-
+| Witness Script
+| <tt>PSBT_OUT_WITNESS_SCRIPT = 0x01</tt>
+| [[bip-0174.mediawiki|174]]
+|-
+| BIP 32 Derivation Path
+| <tt>PSBT_OUT_BIP32_DERIVATION = 0x02</tt>
+| [[bip-0174.mediawiki|174]]
+|-
+| Output Amount
+| <tt>PSBT_OUT_AMOUNT = 0x03</tt>
+| [[bip-0370.mediawiki|370]]
+|-
+| Output Script
+| <tt>PSBT_OUT_SCRIPT = 0x04</tt>
+| [[bip-0370.mediawiki|370]], [[bip-0375.mediawiki|375]]
+|-
+| Taproot Internal Key
+| <tt>PSBT_OUT_TAP_INTERNAL_KEY = 0x05</tt>
+| [[bip-0371.mediawiki|371]]
+|-
+| Taproot Tree
+| <tt>PSBT_OUT_TAP_TREE = 0x06</tt>
+| [[bip-0371.mediawiki|371]]
+|-
+| Taproot Key BIP 32 Derivation Path
+| <tt>PSBT_OUT_TAP_BIP32_DERIVATION = 0x07</tt>
+| [[bip-0371.mediawiki|371]]
+|-
+| MuSig2 Participant Public Keys
+| <tt>PSBT_OUT_MUSIG2_PARTICIPANT_PUBKEYS = 0x08</tt>
+| [[bip-0373.mediawiki|373]]
+|-
+| Silent Payment Data
+| <tt>PSBT_OUT_SP_V0_INFO = 0x09</tt>
+| [[bip-0375.mediawiki|375]]
+|-
+| Silent Payment Label
+| <tt>PSBT_OUT_SP_V0_LABEL = 0x0a</tt>
+| [[bip-0375.mediawiki|375]]
+|-
+| BIP 353 DNSSEC proof
+| <tt>PSBT_OUT_DNSSEC_PROOF = 0x35</tt>
+| [[bip-0353.mediawiki|353]]
+|-
+| Proprietary Use Type
+| <tt>PSBT_OUT_PROPRIETARY = 0xFC</tt>
+| [[bip-0174.mediawiki|174]]
+|}

--- a/bip-0174/type-registry.mediawiki
+++ b/bip-0174/type-registry.mediawiki
@@ -51,3 +51,143 @@ This document collects the fields and types used in PSBTs of any version from al
 | <tt>PSBT_GLOBAL_PROPRIETARY = 0xFC</tt>
 | [[bip-0174.mediawiki|174]]
 |}
+
+==Per-input Types==
+
+{|
+! Name
+! <tt><keytype></tt>
+! Parent BIP
+|-
+| Non-Witness UTXO
+| <tt>PSBT_IN_NON_WITNESS_UTXO = 0x00</tt>
+| [[bip-0174.mediawiki|174]]
+|-
+| Witness UTXO
+| <tt>PSBT_IN_WITNESS_UTXO = 0x01</tt>
+| [[bip-0174.mediawiki|174]]
+|-
+| Partial Signature
+| <tt>PSBT_IN_PARTIAL_SIG = 0x02</tt>
+| [[bip-0174.mediawiki|174]]
+|-
+| Sighash Type
+| <tt>PSBT_IN_SIGHASH_TYPE = 0x03</tt>
+| [[bip-0174.mediawiki|174]]
+|-
+| Redeem Script
+| <tt>PSBT_IN_REDEEM_SCRIPT = 0x04</tt>
+| [[bip-0174.mediawiki|174]]
+|-
+| Witness Script
+| <tt>PSBT_IN_WITNESS_SCRIPT = 0x05</tt>
+| [[bip-0174.mediawiki|174]]
+|-
+| BIP 32 Derivation Path
+| <tt>PSBT_IN_BIP32_DERIVATION = 0x06</tt>
+| [[bip-0174.mediawiki|174]]
+|-
+| Finalized scriptSig
+| <tt>PSBT_IN_FINAL_SCRIPTSIG = 0x07</tt>
+| [[bip-0174.mediawiki|174]]
+|-
+| Finalized scriptWitness
+| <tt>PSBT_IN_FINAL_SCRIPTWITNESS = 0x08</tt>
+| [[bip-0174.mediawiki|174]]
+|-
+| Proof-of-reserves commitment
+| <tt>PSBT_IN_POR_COMMITMENT = 0x09</tt>
+| [[bip-0127.mediawiki|127]]
+|-
+| RIPEMD160 preimage
+| <tt>PSBT_IN_RIPEMD160 = 0x0a</tt>
+| [[bip-0174.mediawiki|174]]
+|-
+| SHA256 preimage
+| <tt>PSBT_IN_SHA256 = 0x0b</tt>
+| [[bip-0174.mediawiki|174]]
+|-
+| HASH160 preimage
+| <tt>PSBT_IN_HASH160 = 0x0c</tt>
+| [[bip-0174.mediawiki|174]]
+|-
+| HASH256 preimage
+| <tt>PSBT_IN_HASH256 = 0x0d</tt>
+| [[bip-0174.mediawiki|174]]
+|-
+| Previous TXID
+| <tt>PSBT_IN_PREVIOUS_TXID = 0x0e</tt>
+| [[bip-0370.mediawiki|370]]
+|-
+| Spent Output Index
+| <tt>PSBT_IN_OUTPUT_INDEX = 0x0f</tt>
+| [[bip-0370.mediawiki|370]]
+|-
+| Sequence Number
+| <tt>PSBT_IN_SEQUENCE = 0x10</tt>
+| [[bip-0370.mediawiki|370]]
+|-
+| Required Time-based Locktime
+| <tt>PSBT_IN_REQUIRED_TIME_LOCKTIME = 0x11</tt>
+| [[bip-0370.mediawiki|370]]
+|-
+| Required Height-based Locktime
+| <tt>PSBT_IN_REQUIRED_HEIGHT_LOCKTIME = 0x12</tt>
+| [[bip-0370.mediawiki|370]]
+|-
+| Taproot Key Spend Signature
+| <tt>PSBT_IN_TAP_KEY_SIG = 0x13</tt>
+| [[bip-0371.mediawiki|371]]
+|-
+| Taproot Script Spend Signature
+| <tt>PSBT_IN_TAP_SCRIPT_SIG = 0x14</tt>
+| [[bip-0371.mediawiki|371]]
+|-
+| Taproot Leaf Script
+| <tt>PSBT_IN_TAP_LEAF_SCRIPT = 0x15</tt>
+| [[bip-0371.mediawiki|371]]
+|-
+| Taproot Key BIP 32 Derivation Path
+| <tt>PSBT_IN_TAP_BIP32_DERIVATION = 0x16</tt>
+| [[bip-0371.mediawiki|371]]
+|-
+| Taproot Internal Key
+| <tt>PSBT_IN_TAP_INTERNAL_KEY = 0x17</tt>
+| [[bip-0371.mediawiki|371]]
+|-
+| Taproot Merkle Root
+| <tt>PSBT_IN_TAP_MERKLE_ROOT = 0x18</tt>
+| [[bip-0371.mediawiki|371]]
+|-
+| MuSig2 Participant Public Keys
+| <tt>PSBT_IN_MUSIG2_PARTICIPANT_PUBKEYS = 0x1a</tt>
+| [[bip-0373.mediawiki|373]]
+|-
+| MuSig2 Public Nonce
+| <tt>PSBT_IN_MUSIG2_PUB_NONCE = 0x1b</tt>
+| [[bip-0373.mediawiki|373]]
+|-
+| MuSig2 Participant Partial Signature
+| <tt>PSBT_IN_MUSIG2_PARTIAL_SIG = 0x1c</tt>
+| [[bip-0373.mediawiki|373]]
+|-
+| Silent Payment Input ECDH Share
+| <tt>PSBT_IN_SP_ECDH_SHARE = 0x1d</tt>
+| [[bip-0375.mediawiki|375]]
+|-
+| Silent Payment Input DLEQ Proof
+| <tt>PSBT_IN_SP_DLEQ = 0x1e</tt>
+| [[bip-0375.mediawiki|375]]
+|-
+| Silent Payment Spend Key BIP 32 Derivation Path
+| <tt>PSBT_IN_SP_SPEND_BIP32_DERIVATION = 0x1f</tt>
+| [[bip-0376.mediawiki|376]]
+|-
+| Silent Payment Tweak
+| <tt>PSBT_IN_SP_TWEAK = 0x20</tt>
+| [[bip-0376.mediawiki|376]]
+|-
+| Proprietary Use Type
+| <tt>PSBT_IN_PROPRIETARY = 0xFC</tt>
+| [[bip-0174.mediawiki|174]]
+|}


### PR DESCRIPTION
So far, each BIP defining new PSBT types or fields has included the new definitions both in its own BIP text and then replicated them in BIP174. This violates the Single Source of Truth paradigm and presents an obvious vector for mismatching information across BIPs.
This PR proposes to make each BIP the sole authoritative source for the PSBT fields and types it introduces and extracts only the Name, `keytype`, and "Parent BIP" columns from BIP174 to a registry file that tracks all existing definitions to prevent clashes.

This PR builds on BIP376’s #2089 which is anticipated to be published soon, and will be rebased thereafter.