### PR TITLE
BIP-322: add clarifications and more test vectors

### DIFF
--- a/bip-0322.mediawiki
+++ b/bip-0322.mediawiki
@@ -185,33 +185,8 @@ This document is licensed under the Creative Commons CC0 1.0 Universal license.
 
 == Test vectors ==
 
-=== Message hashing ===
+Basic test vectors for message hashing, transaction hashes and "simple" variant test cases can be found in [[bip-0322/basic-test-vectors.json|<code>basic-test-vectors.json</code>]].
 
-Message hashes are BIP340-tagged hashes of a message, i.e. sha256_tag(m), where tag = <code>BIP0322-signed-message</code>, and m is the message as is without length prefix or null terminator:
+Generated test vectors for more "simple" and "full" variant test cases can be found in [[bip-0322/generated-test-vectors.json|<code>generated-test-vectors.json</code>]].
 
-* Message = "" (empty string): <code>c90c269c4f8fcbe6880f72a721ddfbf1914268a794cbb21cfafee13770ae19f1</code>
-* Message = "Hello World": <code>f0eb03b1a75ac6d9847f55c624a99169b5dccba2a31f5b23bea77ba270de0a7a</code>
-
-=== Message signing ===
-
-Given below parameters:
-
-* private key <code>L3VFeEujGtevx9w18HD1fhRbCH67Az2dpCymeRE1SoPK6XQtaN2k</code>
-* corresponding address <code>bc1q9vza2e8x573nczrlzms0wvx3gsqjx7vavgkx0l</code>
-
-Produce signatures:
-
-* Message = "" (empty string): <code>AkcwRAIgM2gBAQqvZX15ZiysmKmQpDrG83avLIT492QBzLnQIxYCIBaTpOaD20qRlEylyxFSeEA2ba9YOixpX8z46TSDtS40ASECx/EgAxlkQpQ9hYjgGu6EBCPMVPwVIVJqO4XCsMvViHI=</code> or <code>AkgwRQIhAPkJ1Q4oYS0htvyuSFHLxRQpFAY56b70UvE7Dxazen0ZAiAtZfFz1S6T6I23MWI2lK/pcNTWncuyL8UL+oMdydVgzAEhAsfxIAMZZEKUPYWI4BruhAQjzFT8FSFSajuFwrDL1Yhy</code>
-* Message = "Hello World": <code>AkcwRAIgZRfIY3p7/DoVTty6YZbWS71bc5Vct9p9Fia83eRmw2QCICK/ENGfwLtptFluMGs2KsqoNSk89pO7F29zJLUx9a/sASECx/EgAxlkQpQ9hYjgGu6EBCPMVPwVIVJqO4XCsMvViHI=</code> or <code>AkgwRQIhAOzyynlqt93lOKJr+wmmxIens//zPzl9tqIOua93wO6MAiBi5n5EyAcPScOjf1lAqIUIQtr3zKNeavYabHyR8eGhowEhAsfxIAMZZEKUPYWI4BruhAQjzFT8FSFSajuFwrDL1Yhy</code>
-
-=== Transaction Hashes ===
-
-to_spend:
-
-* Message = "" (empty string): <code>c5680aa69bb8d860bf82d4e9cd3504b55dde018de765a91bb566283c545a99a7</code>
-* Message = "Hello World": <code>b79d196740ad5217771c1098fc4a4b51e0535c32236c71f1ea4d61a2d603352b</code>
-
-to_sign:
-
-* Message = "" (empty string): <code>1e9654e951a5ba44c8604c4de6c67fd78a27e81dcadcfe1edf638ba3aaebaed6</code>
-* Message = "Hello World": <code>88737ae86f2077145f93cc4b153ae9a1cb8d56afa511988c149c5c8c9d93bddf</code>
+They were generated using [https://github.com/guggero/btcd/blob/f0d8719873ac70412dd813ef6e81358864c4eaa3/btcutil/bip322/bip322_test.go#L910 this code].

--- a/bip-0322.mediawiki
+++ b/bip-0322.mediawiki
@@ -96,6 +96,7 @@ The <code>to_sign</code> transaction is:
     vin[0].prevout.hash = to_spend.txid
     vin[0].prevout.n = 0
     vin[0].nSequence = 0 or (FULL format only) as appropriate (for time locks)
+    vin[0].scriptSig = [] or (FULL format only) as appropriate (for non segwit-native transactions)
     vin[0].scriptWitness = message_signature
     vout[0].nValue = 0
     vout[0].scriptPubKey = OP_RETURN

--- a/bip-0322.mediawiki
+++ b/bip-0322.mediawiki
@@ -27,6 +27,32 @@ Ultimately no message signing protocol can actually prove control of funds, both
 
 This BIP specifies three formats for signing messages: ''legacy'', ''simple'' and ''full''. Additionally, a variant of the ''full'' format can be used to demonstrate control over a set of UTXOs.
 
+{| class="wikitable"
+|- style="font-weight:bold;"
+!
+! Compatible script types
+! Signature format
+|-
+| Legacy
+| <code>P2PKH</code>, <code>P2SH-P2WPKH</code><sup>1</sup>, <code>P2WPKH</code><sup>1</sup>
+| compact, public key recoverable ECDSA signature, base64-encoded
+|-
+| Simple
+| <code>P2WPKH</code>, <code>P2WSH</code><sup>2</sup>, <code>P2TR</code><sup>2</sup> <br/>
+| witness stack, consensus encoded and base64-encoded
+|-
+| Full
+| <code>all</code>
+| full <code>to_sign</code> transaction, consensus and base64-encoded
+|-
+| Full (PoF)
+| <code>all</code>
+| full <code>to_sign</code> transaction, consensus and base64-encoded
+|}
+
+<sup>1</sup>: Possible on a technical level but should NOT be used anymore in the context of this BIP.<br/>
+<sup>2</sup>: Excluding time lock scripts.
+
 === Legacy ===
 
 New proofs should use the new format for all invoice address formats, including P2PKH.

--- a/bip-0322/basic-test-vectors.json
+++ b/bip-0322/basic-test-vectors.json
@@ -1,0 +1,104 @@
+{
+  "tx_hashes": [
+    {
+      "message": "",
+      "address": "bc1q9vza2e8x573nczrlzms0wvx3gsqjx7vavgkx0l",
+      "message_hash": "c90c269c4f8fcbe6880f72a721ddfbf1914268a794cbb21cfafee13770ae19f1",
+      "to_spend_tx_hash": "c5680aa69bb8d860bf82d4e9cd3504b55dde018de765a91bb566283c545a99a7",
+      "to_sign_tx_hash": "1e9654e951a5ba44c8604c4de6c67fd78a27e81dcadcfe1edf638ba3aaebaed6"
+    },
+    {
+      "message": "Hello World",
+      "address": "bc1q9vza2e8x573nczrlzms0wvx3gsqjx7vavgkx0l",
+      "message_hash": "f0eb03b1a75ac6d9847f55c624a99169b5dccba2a31f5b23bea77ba270de0a7a",
+      "to_spend_tx_hash": "b79d196740ad5217771c1098fc4a4b51e0535c32236c71f1ea4d61a2d603352b",
+      "to_sign_tx_hash": "88737ae86f2077145f93cc4b153ae9a1cb8d56afa511988c149c5c8c9d93bddf"
+    }
+  ],
+  "simple": [
+    {
+      "message": "",
+      "private_keys": [
+        "L3VFeEujGtevx9w18HD1fhRbCH67Az2dpCymeRE1SoPK6XQtaN2k"
+      ],
+      "address": "bc1q9vza2e8x573nczrlzms0wvx3gsqjx7vavgkx0l",
+      "type": "p2wpkh",
+      "witness_script": "",
+      "bip322_signatures": [
+        "AkcwRAIgM2gBAQqvZX15ZiysmKmQpDrG83avLIT492QBzLnQIxYCIBaTpOaD20qRlEylyxFSeEA2ba9YOixpX8z46TSDtS40ASECx/EgAxlkQpQ9hYjgGu6EBCPMVPwVIVJqO4XCsMvViHI=",
+        "AkgwRQIhAPkJ1Q4oYS0htvyuSFHLxRQpFAY56b70UvE7Dxazen0ZAiAtZfFz1S6T6I23MWI2lK/pcNTWncuyL8UL+oMdydVgzAEhAsfxIAMZZEKUPYWI4BruhAQjzFT8FSFSajuFwrDL1Yhy"
+      ]
+    },
+    {
+      "message": "Hello World",
+      "private_keys": [
+        "L3VFeEujGtevx9w18HD1fhRbCH67Az2dpCymeRE1SoPK6XQtaN2k"
+      ],
+      "address": "bc1q9vza2e8x573nczrlzms0wvx3gsqjx7vavgkx0l",
+      "type": "p2wpkh",
+      "witness_script": "",
+      "bip322_signatures": [
+        "AkcwRAIgZRfIY3p7/DoVTty6YZbWS71bc5Vct9p9Fia83eRmw2QCICK/ENGfwLtptFluMGs2KsqoNSk89pO7F29zJLUx9a/sASECx/EgAxlkQpQ9hYjgGu6EBCPMVPwVIVJqO4XCsMvViHI=",
+        "AkgwRQIhAOzyynlqt93lOKJr+wmmxIens//zPzl9tqIOua93wO6MAiBi5n5EyAcPScOjf1lAqIUIQtr3zKNeavYabHyR8eGhowEhAsfxIAMZZEKUPYWI4BruhAQjzFT8FSFSajuFwrDL1Yhy"
+      ]
+    },
+    {
+      "message": "This will be a p2wsh 3-of-3 multisig BIP 322 signed message",
+      "private_keys": [
+        "L4DksdGZ4KQJfcLHD5Dv25fu8Rxyv7hHi2RjZR4TYzr8c6h9VNrp",
+        "KzSRqnCVwjzY8id2X5oHEJWXkSHwKUYaAXusjwgkES8BuQPJnPNu",
+        "L1zt9Rw7HrU7jaguMbVzhiX8ffuVkmMis5wLHddXYuHWYf8u8uRj"
+      ],
+      "address": "bc1qp0ahvfh83088w49k405szqgg4f3pptr7p2g06tdxfjcd40z4lh4q95lsz9",
+      "type": "p2wsh-multisig-3of3",
+      "witness_script": "5321027568b11f122ff8a7bc1c57e5c7642055bc618967b2f7bfe8e11fe99903c94dd321020a8bdf79cfa421d9655e9282800f115ff1d9db1e721ceb4248a3fcfec7faa67c21030c529e0ea40a00975d202624e39915daf7bdd2b71f31aa08596838781ce5f33a53ae",
+      "bip322_signatures": [
+        "BQBHMEQCIFX9aaqPJWq2Ff2kpen5bFDTid+ehgUOpHV0LfjncXy4AiA3GNicF7aKPzdpa9PCpmaYQs3pHd+qbvvhXdxOCKCAMAFIMEUCIQD/ELXg6CNYyUQijCg96JtgvgjZb9dsl1Ctof4QAeyTcQIgVM/1AAblFl/DCt6A1gJg+T/i2qU5SQD09+chFJzolRwBSDBFAiEAlqRfSFyWNVQhvaCnmeV5tyneiCWMTcFbuujoD/pFa3wCIGnZjfQb8NolSYq9asV+ZeBSkCGHJcqnaV4JYS5MYPEGAWlTIQJ1aLEfEi/4p7wcV+XHZCBVvGGJZ7L3v+jhH+mZA8lN0yECCovfec+kIdllXpKCgA8RX/HZ2x5yHOtCSKP8/sf6pnwhAwxSng6kCgCXXSAmJOOZFdr3vdK3HzGqCFloOHgc5fM6U64="
+      ]
+    }
+  ],
+  "error": [
+    {
+      "description": "invalid base64 encoding",
+      "message": "",
+      "address": "bc1q9vza2e8x573nczrlzms0wvx3gsqjx7vavgkx0l",
+      "signature": "not-valid-base64!!!",
+      "error_substr": "base64"
+    },
+    {
+      "description": "empty signature",
+      "message": "",
+      "address": "bc1q9vza2e8x573nczrlzms0wvx3gsqjx7vavgkx0l",
+      "signature": "",
+      "error_substr": "unknown format"
+    },
+    {
+      "description": "wrong message for valid simple p2wpkh signature (empty message was signed)",
+      "message": "Wrong message that was not signed",
+      "address": "bc1q9vza2e8x573nczrlzms0wvx3gsqjx7vavgkx0l",
+      "signature": "AkcwRAIgM2gBAQqvZX15ZiysmKmQpDrG83avLIT492QBzLnQIxYCIBaTpOaD20qRlEylyxFSeEA2ba9YOixpX8z46TSDtS40ASECx/EgAxlkQpQ9hYjgGu6EBCPMVPwVIVJqO4XCsMvViHI=",
+      "error_substr": "invalid signature"
+    },
+    {
+      "description": "wrong address for valid simple p2wpkh signature (signed for different address)",
+      "message": "",
+      "address": "bc1qp0ahvfh83088w49k405szqgg4f3pptr7p2g06tdxfjcd40z4lh4q95lsz9",
+      "signature": "AkcwRAIgM2gBAQqvZX15ZiysmKmQpDrG83avLIT492QBzLnQIxYCIBaTpOaD20qRlEylyxFSeEA2ba9YOixpX8z46TSDtS40ASECx/EgAxlkQpQ9hYjgGu6EBCPMVPwVIVJqO4XCsMvViHI=",
+      "error_substr": "invalid signature"
+    },
+    {
+      "description": "empty witness stack (single zero byte)",
+      "message": "",
+      "address": "bc1q9vza2e8x573nczrlzms0wvx3gsqjx7vavgkx0l",
+      "signature": "AA==",
+      "error_substr": "invalid signature"
+    },
+    {
+      "description": "wrong message for valid simple p2wsh 3-of-3 multisig signature",
+      "message": "This is not the message that was signed",
+      "address": "bc1qp0ahvfh83088w49k405szqgg4f3pptr7p2g06tdxfjcd40z4lh4q95lsz9",
+      "signature": "BQBHMEQCIFX9aaqPJWq2Ff2kpen5bFDTid+ehgUOpHV0LfjncXy4AiA3GNicF7aKPzdpa9PCpmaYQs3pHd+qbvvhXdxOCKCAMAFIMEUCIQD/ELXg6CNYyUQijCg96JtgvgjZb9dsl1Ctof4QAeyTcQIgVM/1AAblFl/DCt6A1gJg+T/i2qU5SQD09+chFJzolRwBSDBFAiEAlqRfSFyWNVQhvaCnmeV5tyneiCWMTcFbuujoD/pFa3wCIGnZjfQb8NolSYq9asV+ZeBSkCGHJcqnaV4JYS5MYPEGAWlTIQJ1aLEfEi/4p7wcV+XHZCBVvGGJZ7L3v+jhH+mZA8lN0yECCovfec+kIdllXpKCgA8RX/HZ2x5yHOtCSKP8/sf6pnwhAwxSng6kCgCXXSAmJOOZFdr3vdK3HzGqCFloOHgc5fM6U64=",
+      "error_substr": "invalid signature"
+    }
+  ]
+}

--- a/bip-0322/generated-test-vectors.json
+++ b/bip-0322/generated-test-vectors.json
@@ -1,0 +1,350 @@
+{
+  "simple": [
+    {
+      "message": "ESHJI7MWUL64AXHBI42L3UR4QA",
+      "private_keys": [
+        "L1W6mc2yYRcDCkhwhFASvvacvp6Pm4u29dxK9RJHVorXqLciTdq4"
+      ],
+      "address": "bc1qkntwc3c4dzxh9xh6875l03fn3vkk023jgak3u7",
+      "type": "p2wpkh",
+      "witness_script": "",
+      "bip322_signatures": [
+        "AkcwRAIgCYHF/vn67iZX5WBimh84kqD6pTME6eNCMGhfFnnwCNECIAF3nMCk/RfLit+uv8a8FgfQIw0f0ASE21GSz7rX17PsASEDTA2vM8bOtUFgvenSDUmvkq7aWNwoTB0CMiM6carHY1s="
+      ]
+    },
+    {
+      "message": "TPIZPITUIHEUHO5ACOL6W6MBVD",
+      "private_keys": [
+        "L1rPtXzPkeCuXArPk5QKfaU4PCx16S2zCXnYtFSMGHiDkQyWw5fv"
+      ],
+      "address": "bc1p9cyuceaazr8cz46mvgkzl94wy397mwpqsrk84su37t72jvkg6wzqv52nfp",
+      "type": "p2tr",
+      "witness_script": "",
+      "bip322_signatures": [
+        "AUBay6NwR4LEYedkTG+vE9F7C0RTOCB5NH6ZAqf+3hudjHIkOzSZk1jW/5Kt0wRKX3llJ25os+0qktdou4/Y8516"
+      ]
+    },
+    {
+      "message": "GDU6AXT64O5ZS4AHHXK5JETYRM",
+      "private_keys": [
+        "KyjdoWRGFoNm2SQa1RuKyRKDVyqvLfvLgpv4zkAFZFB7MpA8cEXk",
+        "L25Vj2oJuVZknqqDzTpZgiwYUEAzfFnSNbpQB78NoYhLjGdJepXx"
+      ],
+      "address": "bc1qa8xp82hejuydq8d9yc44s662ras5ncr98gxz3n53s6vklwgrczrqc4fqtn",
+      "type": "p2wsh-multisig-2of2",
+      "witness_script": "52210271f8856d15f7b363ffc6ecf07ff7f6767d66ad0f19b9f8cd35f79b17dd8d6aa32102bc32a9df90529550f64c5a8c3f2ecc95726ba869779e4400828e750df89122a952ae",
+      "bip322_signatures": [
+        "BABIMEUCIQCLKarc4DfTq5bmqPVjRZ/qBvRPy886P2dM1tDK/92WIgIgN7y495rkp5FPcpjohhl8Knmo9rf63tPLGIVo8PKE81ABSDBFAiEAz2U1cppenj2Kbg8DkS3wXMmAN4jvZvsP/PdcCI1akogCIFlrCbW2+GbMRkvObV2utVdHYBxIJhM6DJlv1NIwViXBAUdSIQJx+IVtFfezY//G7PB/9/Z2fWatDxm5+M0195sX3Y1qoyECvDKp35BSlVD2TFqMPy7MlXJrqGl3nkQAgo51DfiRIqlSrg=="
+      ]
+    },
+    {
+      "message": "BSAWAJZ2EQJD2TYPE7XJM4C7UT",
+      "private_keys": [
+        "KyjwDY9kKijtTPixxoe8DqkWmWp172fWTo6uHU6RS8j2tGhuAvT4",
+        "Kybt9Gv8G9UkaWJZ4znqS5MXyfsfoZwiio8oHG5V9TUSRW6Sae5X",
+        "L1iyj3m9NtdtpyC34X8Dh7ScnxiGtT1RnhsRWLfSz1VmRoNgJ9Sf"
+      ],
+      "address": "bc1qel33n4j8luylanep3rhfdkkwsvz2pjvjvle4ttt4v8v74ur74fuqjrp0uw",
+      "type": "p2wsh-multisig-3of3",
+      "witness_script": "53210264bdbc6daff47cb5146fd0949b605687fa433e941afe2bdb778bca656a81892a21031df0008bc3f4536806148841c962e76e7b35fede3d5a9214e403cdeed7947255210218513455f7baa7874c97fd4dfa34a5ad5c4a9b756d239a5326043c9e45b0bcee53ae",
+      "bip322_signatures": [
+        "BQBHMEQCIFT0+Kbu1NAAJvWikhuw20MSB3LHCbMHgcNlMI2y38CnAiBKzu+vWiUofSZ6z7efpiAg9NhnAFgzrLJ7NVw4yY9I0gFHMEQCIFB1YEnj+Rvy18vUU7CADhSgoC9DyTqKH35q+uND4ZXEAiA9ISDpX9EA5gUvkTPBVQpEO+6pET87I4XhckdBmbZWwAFHMEQCIC8vcyfV3kOLDUI+ZaqFnS7psT11aFt+CW+jU2We7VYXAiA3zPurejZx5jSrUE/q9FI+B/idy8zRHAFmxo511LMjqwFpUyECZL28ba/0fLUUb9CUm2BWh/pDPpQa/ivbd4vKZWqBiSohAx3wAIvD9FNoBhSIQcli5257Nf7ePVqSFOQDze7XlHJVIQIYUTRV97qnh0yX/U36NKWtXEqbdW0jmlMmBDyeRbC87lOu"
+      ]
+    }
+  ],
+  "full": [
+    {
+      "message": "GI2SVNWVCWTEEIMFZFFZYAQNSA",
+      "private_keys": [
+        "L2m4Wo96ZaFFd7cGFiv6SnCr1ntYEa6PVbfg6Z6gFCMW76ysZ6AT"
+      ],
+      "address": "164P4mbDkPcyvRnFGAZd1ThjxSj7Fbsywz",
+      "type": "p2pkh",
+      "witness_script": "",
+      "tx_version": 2,
+      "lock_time": 2016,
+      "sequence": 2016,
+      "bip322_signatures": [
+        "AgAAAAGEmHuloQANVIqnpMegGLNFKwAGE0Urv0a/uMiHnJ+FQwAAAABrSDBFAiEAr8VdqPCZU/oVqKKj2WwHfeCX/lzp+Rfk8d59cS9xdGECIAar0nievDdeVstmIgjfM7kzMepL6HrecBuJtgEitFxBASECzgU8WF30ffzpbdClcw/0NBkTCkuRbiEzr+CTXePjiPfgBwAAAQAAAAAAAAAAAWrgBwAA"
+      ]
+    },
+    {
+      "message": "YGIAANMREUXLFRI4HIEOCE4T23",
+      "private_keys": [
+        "KyAbLfXdznrXRfeaCQTXPzqT5k12FHwKBLKE8fk8KZ9ye7nQf1TA"
+      ],
+      "address": "bc1qkwzsslep5elkuat4608v7tpntpr3d9n7w5cwwq",
+      "type": "p2wpkh",
+      "witness_script": "",
+      "tx_version": 2,
+      "lock_time": 2016,
+      "sequence": 2016,
+      "bip322_signatures": [
+        "AgAAAAABAaVatLF3wpACTG5XowFYPJPv65lgTlZypjUV9d1DNduCAAAAAADgBwAAAQAAAAAAAAAAAWoCRzBEAiB+SJdR6bVLpv5+kK8pOXSUDS24rU53YkTQEvelQJ22uwIgEfqM8eYTupu4LtA0Tz7z1LIbhpP2PrUxWEt9osnrxFEBIQMasC7JaIHbbAUt1kU81yx7S4QHScnEDBs4GsdHDPMPSuAHAAA="
+      ]
+    },
+    {
+      "message": "K276VUM3MXP56DGNVICQR5XWRT",
+      "private_keys": [
+        "KyU8wJ8ARQruQikto4GksjPKmgh8pKF5GsZVB78JPbYgPDQSQzgw"
+      ],
+      "address": "bc1psmjelwjtg7lz26jhd4kkf35v0xp3u7ffc6p4n4869s0hxkrrrtkqkpqvmg",
+      "type": "p2tr",
+      "witness_script": "",
+      "tx_version": 2,
+      "lock_time": 2016,
+      "sequence": 2016,
+      "bip322_signatures": [
+        "AgAAAAABAY+B3hhlrps+S2YaxSvL3HxZKdfT+8XCCtZ4KQc5N+AaAAAAAADgBwAAAQAAAAAAAAAAAWoBQEHQoT3HfPKw4WNiQySblfcRX2gnha/mrpFxUoYlkJxuQFXNN3sS+XbJsNAoXRlvQitk0tVEFpsUGRcCdZ7bWPHgBwAA"
+      ]
+    },
+    {
+      "message": "5WCQVNSZADVB2U447BH2A44Y4X",
+      "private_keys": [
+        "L1YoVzY3hdJZozYKnVaJARiqK78NMmmdSv7fg17b4CDALhS3J5Uz"
+      ],
+      "address": "bc1peeyux4l3g6wmq23hsl6hytndlu89emtvqrw0k222hgnfvys8yw8sehzpun",
+      "type": "p2tr-time-lock",
+      "witness_script": "6320ad87d784e921d02bf0b89a41f8eded6a5d8409f3b4bfb935fc0e0f4e519c42206702e007b27520d798ac1b476ad095809ea0cfcd49eaf9b3257fe716c8b506834d223597a0d03e68ac",
+      "tx_version": 2,
+      "lock_time": 2016,
+      "sequence": 2016,
+      "bip322_signatures": [
+        "AgAAAAABARTMGFokvM/viA990Uz2acpongloH+NqLgjm1grzw7C1AAAAAADgBwAAAQAAAAAAAAAAAWoEQAl8+ry6NBWeMu08ZpB9fJVnTiWQJy1i5LOfmtDr8DLWVvSUyKAwNQK7EyIPJlQhATz/7cw3Oywj0+dF0NHS9mMAS2MgrYfXhOkh0CvwuJpB+O3tal2ECfO0v7k1/A4PTlGcQiBnAuAHsnUg15isG0dq0JWAnqDPzUnq+bMlf+cWyLUGg00iNZeg0D5orCHB15isG0dq0JWAnqDPzUnq+bMlf+cWyLUGg00iNZeg0D7gBwAA"
+      ]
+    },
+    {
+      "message": "OQXDXSR5SN5N7WRXSPTI462HKH",
+      "private_keys": [
+        "KyS1o2pNNmd5bfw4cnhVZLJus7CFLgbYBKB3GY2KQKuWKT8remsc"
+      ],
+      "address": "37HVPoc7ZsU5C9Z2VKcCkSLzEknYXCzm3s",
+      "type": "p2sh-p2wkh",
+      "witness_script": "",
+      "tx_version": 2,
+      "lock_time": 2016,
+      "sequence": 2016,
+      "bip322_signatures": [
+        "AgAAAAABAbtjBsUTHnoyuNG4NGbx6cI1Z01QLlfGHJX/WIRCAU6/AAAAABcWABTGXFmsgRqCkic6D+eE4AKm1iyVhuAHAAABAAAAAAAAAAABagJHMEQCIBp/IMJTnnhI6YrHJwIQbfucoizq0esZ35QRxtpXuk7fAiAGx6kSd9BuPDY+R0sHTJU0ZFtScJI8ASojEHwrClKxDQEhAl3boe/68fHvtuYzRkaS3GOSxnUTJwejjrubm+czK+Yi4AcAAA=="
+      ]
+    },
+    {
+      "message": "TOJXD6LSM3XO5OQ4QBQSL56I22",
+      "private_keys": [
+        "L4XDovzsRB17tPmPobeseJN9fxTuduEvkRYxs3iPnX5ZEkc16J7N"
+      ],
+      "address": "bc1q9dtw8dz93e7w6v5w8tra2et0vhz3wct3hpvl4tk5vrac9xz8szwqtvf0e2",
+      "type": "p2wsh-time-lock",
+      "witness_script": "632103ad87d784e921d02bf0b89a41f8eded6a5d8409f3b4bfb935fc0e0f4e519c42206702e007b275210324db2009cbb2f151c13fc0e2463050d2349f2d69c114392a4164328a4b0f9ab868ac",
+      "tx_version": 2,
+      "lock_time": 2016,
+      "sequence": 2016,
+      "bip322_signatures": [
+        "AgAAAAABARVzK6W+9P3uKAmwv5xuqaftTkpGVj+1VWPgnqAVBFPyAAAAAADgBwAAAQAAAAAAAAAAAWoDSDBFAiEA82QBQkW16bqrm2mfKOLubqM2XHM+042kNMIor103anACICxp8esh++3RqSzqeefA+nlZoejw4pJJeubRTC9d6kZaAQBNYyEDrYfXhOkh0CvwuJpB+O3tal2ECfO0v7k1/A4PTlGcQiBnAuAHsnUhAyTbIAnLsvFRwT/A4kYwUNI0ny1pwRQ5KkFkMopLD5q4aKzgBwAA"
+      ]
+    },
+    {
+      "message": "5P7EW4XUVZ6PJX5HY4MW5FK5PB",
+      "private_keys": [
+        "KzwYgVTF98GMqVjMK2tPFsmhchCXmzLkyFMe7ffoAZDWpN6qYy7d",
+        "Kx6S7bhsPP4nHga9nG3DrhQx7phhjNqe3hAneFDbJXRE62ZkzAxh"
+      ],
+      "address": "bc1qfqj9nyjyt48mnu3d5pl98t280l2w0ccpfd2r2mee3fwfxar5sehszuz26t",
+      "type": "p2wsh-multisig-2of2",
+      "witness_script": "522103d6235806d1078a5a954637ee163ee191412d0243243d7ed644c1d9dcd193ad442102bc4f73a93645811dc767f0d8f77cda0ec681e2eb689ee67861055c8c5aec8c1f52ae",
+      "tx_version": 2,
+      "lock_time": 2016,
+      "sequence": 2016,
+      "bip322_signatures": [
+        "AgAAAAABAcE9Xti5qyNVQrVVDtYUznEvVIDEbkXUF3n3CQI5bzKRAAAAAADgBwAAAQAAAAAAAAAAAWoEAEcwRAIgSwczcWxkT+Tk8wvTdorKXE3Hfemk6mtcKXC2yGSXp2ACIEIa5UwomMwpoPLyowZ/e550yHRPTyIIbYDaYT1kF9szAUgwRQIhAPpw4wkAFjKT1mvhOSfmHlYFtRgQ87hfbOfjnjJnQ2PuAiA7uR/iEFqgQfLLZIEsRIImvMPP/gMfchFpj4Qx5aRSpQFHUiED1iNYBtEHilqVRjfuFj7hkUEtAkMkPX7WRMHZ3NGTrUQhArxPc6k2RYEdx2fw2Pd82g7GgeLraJ7meGEFXIxa7IwfUq7gBwAA"
+      ]
+    },
+    {
+      "message": "QDZMAZBL27JFGRNCIXL25DXBSH",
+      "private_keys": [
+        "L1xYMTew8iFqTmXTQruRSBwjLph1BwuezxSLnVALwcW79D6KTjYP",
+        "KxHZVrs6Y7VmVtdY65noGD8N8HJEZ2cRHnGv2GWWR54gmA5JAiWe",
+        "L1Y8bAM735QEtq25mcu9jJkaNFXwbtGZ1RRQLVzaq6CBNkL7dPoG"
+      ],
+      "address": "bc1q9nrqkah76dcr2yvw40wkr2af439ccyl5xay0md3awkkk00zges4qdt3sx7",
+      "type": "p2wsh-multisig-3of3",
+      "witness_script": "5321031bfb695323b58953840f3cb38abcb45728c98e52ba242ae6109725c4946985f221026bfc91c8110a5d2dd245100f2214c1eef70a8bb641299861610cbad28656a67821025a62b87556e506e794c547e8276d1a6e2629780a565db35fcb7c3f9435a36bbc53ae",
+      "tx_version": 2,
+      "lock_time": 2016,
+      "sequence": 2016,
+      "bip322_signatures": [
+        "AgAAAAABAer7c1QlVJDuAbqiJjI4BDfc9mBGcO7bMHZbQkfJkv5xAAAAAADgBwAAAQAAAAAAAAAAAWoFAEcwRAIgSOxqpGJcIsTlpitk5ZYjL39Oz19Nju75iEIAZJakhxoCIAGdJoVeVRnYtALtXneYlvi+c1cM/g1VB9KuVPAbG2sEAUgwRQIhANqm0LEFk63YpHgNdhiOxvqrr+CfuTYDiBWd2qSX4eCZAiAEkN5Cei/Nu8hf344x16B07RoLmp5QkanvbWw+RYG0iAFIMEUCIQDNtva8FSjrEKwDIuRbtWf/1l5sPfPDfjCNiq4qN2b83gIgDUhfk7LFcc300VDuTgS7sapPpq7DeiEfy3bzgz6bGCoBaVMhAxv7aVMjtYlThA88s4q8tFcoyY5SuiQq5hCXJcSUaYXyIQJr/JHIEQpdLdJFEA8iFMHu9wqLtkEpmGFhDLrShlameCECWmK4dVblBueUxUfoJ20abiYpeApWXbNfy3w/lDWja7xTruAHAAA="
+      ]
+    }
+  ],
+  "error": [
+    {
+      "description": "wrong message for p2wpkh simple signature",
+      "message": "OVKTTPEFKLUOTAOJSPCKIHCQZW",
+      "address": "bc1qkntwc3c4dzxh9xh6875l03fn3vkk023jgak3u7",
+      "signature": "AkcwRAIgCYHF/vn67iZX5WBimh84kqD6pTME6eNCMGhfFnnwCNECIAF3nMCk/RfLit+uv8a8FgfQIw0f0ASE21GSz7rX17PsASEDTA2vM8bOtUFgvenSDUmvkq7aWNwoTB0CMiM6carHY1s=",
+      "error_substr": "invalid signature"
+    },
+    {
+      "description": "wrong signer for p2wpkh simple signature",
+      "message": "ESHJI7MWUL64AXHBI42L3UR4QA",
+      "address": "bc1qx3f9s3scavc92s3g2fhwzqzn7qucd37ez03jpf",
+      "signature": "AkcwRAIgCYHF/vn67iZX5WBimh84kqD6pTME6eNCMGhfFnnwCNECIAF3nMCk/RfLit+uv8a8FgfQIw0f0ASE21GSz7rX17PsASEDTA2vM8bOtUFgvenSDUmvkq7aWNwoTB0CMiM6carHY1s=",
+      "error_substr": "invalid signature"
+    },
+    {
+      "description": "wrong message for p2tr simple signature",
+      "message": "IHUVDIXOZV7EE7RU6CP7JUS57N",
+      "address": "bc1p9cyuceaazr8cz46mvgkzl94wy397mwpqsrk84su37t72jvkg6wzqv52nfp",
+      "signature": "AUBay6NwR4LEYedkTG+vE9F7C0RTOCB5NH6ZAqf+3hudjHIkOzSZk1jW/5Kt0wRKX3llJ25os+0qktdou4/Y8516",
+      "error_substr": "invalid signature"
+    },
+    {
+      "description": "wrong signer for p2tr simple signature",
+      "message": "TPIZPITUIHEUHO5ACOL6W6MBVD",
+      "address": "bc1pr72av8sh7qc2ssxs8w0hlj0cl82g2q2dvypngzgsrmd4plml84ksmfyv0q",
+      "signature": "AUBay6NwR4LEYedkTG+vE9F7C0RTOCB5NH6ZAqf+3hudjHIkOzSZk1jW/5Kt0wRKX3llJ25os+0qktdou4/Y8516",
+      "error_substr": "invalid signature"
+    },
+    {
+      "description": "wrong message for p2wsh-multisig-2of2 simple signature",
+      "message": "RPZ3MU56TLYDP4J7XLACULFXEJ",
+      "address": "bc1qa8xp82hejuydq8d9yc44s662ras5ncr98gxz3n53s6vklwgrczrqc4fqtn",
+      "signature": "BABIMEUCIQCLKarc4DfTq5bmqPVjRZ/qBvRPy886P2dM1tDK/92WIgIgN7y495rkp5FPcpjohhl8Knmo9rf63tPLGIVo8PKE81ABSDBFAiEAz2U1cppenj2Kbg8DkS3wXMmAN4jvZvsP/PdcCI1akogCIFlrCbW2+GbMRkvObV2utVdHYBxIJhM6DJlv1NIwViXBAUdSIQJx+IVtFfezY//G7PB/9/Z2fWatDxm5+M0195sX3Y1qoyECvDKp35BSlVD2TFqMPy7MlXJrqGl3nkQAgo51DfiRIqlSrg==",
+      "error_substr": "invalid signature"
+    },
+    {
+      "description": "wrong signer for p2wsh-multisig-2of2 simple signature",
+      "message": "GDU6AXT64O5ZS4AHHXK5JETYRM",
+      "address": "bc1qcfden7aelf249fdvq7qjkdus5fehgfvnlx8u6fs8ll08jjejfw6qslr6nd",
+      "signature": "BABIMEUCIQCLKarc4DfTq5bmqPVjRZ/qBvRPy886P2dM1tDK/92WIgIgN7y495rkp5FPcpjohhl8Knmo9rf63tPLGIVo8PKE81ABSDBFAiEAz2U1cppenj2Kbg8DkS3wXMmAN4jvZvsP/PdcCI1akogCIFlrCbW2+GbMRkvObV2utVdHYBxIJhM6DJlv1NIwViXBAUdSIQJx+IVtFfezY//G7PB/9/Z2fWatDxm5+M0195sX3Y1qoyECvDKp35BSlVD2TFqMPy7MlXJrqGl3nkQAgo51DfiRIqlSrg==",
+      "error_substr": "invalid signature"
+    },
+    {
+      "description": "wrong message for p2wsh-multisig-3of3 simple signature",
+      "message": "QT6D4KWLZBL3T5S6NOLAV765K2",
+      "address": "bc1qel33n4j8luylanep3rhfdkkwsvz2pjvjvle4ttt4v8v74ur74fuqjrp0uw",
+      "signature": "BQBHMEQCIFT0+Kbu1NAAJvWikhuw20MSB3LHCbMHgcNlMI2y38CnAiBKzu+vWiUofSZ6z7efpiAg9NhnAFgzrLJ7NVw4yY9I0gFHMEQCIFB1YEnj+Rvy18vUU7CADhSgoC9DyTqKH35q+uND4ZXEAiA9ISDpX9EA5gUvkTPBVQpEO+6pET87I4XhckdBmbZWwAFHMEQCIC8vcyfV3kOLDUI+ZaqFnS7psT11aFt+CW+jU2We7VYXAiA3zPurejZx5jSrUE/q9FI+B/idy8zRHAFmxo511LMjqwFpUyECZL28ba/0fLUUb9CUm2BWh/pDPpQa/ivbd4vKZWqBiSohAx3wAIvD9FNoBhSIQcli5257Nf7ePVqSFOQDze7XlHJVIQIYUTRV97qnh0yX/U36NKWtXEqbdW0jmlMmBDyeRbC87lOu",
+      "error_substr": "invalid signature"
+    },
+    {
+      "description": "wrong signer for p2wsh-multisig-3of3 simple signature",
+      "message": "BSAWAJZ2EQJD2TYPE7XJM4C7UT",
+      "address": "bc1qkz7vg09c9krg56dcfeg0pfy4643vwtccvtel7946whaz6r8y9gyqhvdgcp",
+      "signature": "BQBHMEQCIFT0+Kbu1NAAJvWikhuw20MSB3LHCbMHgcNlMI2y38CnAiBKzu+vWiUofSZ6z7efpiAg9NhnAFgzrLJ7NVw4yY9I0gFHMEQCIFB1YEnj+Rvy18vUU7CADhSgoC9DyTqKH35q+uND4ZXEAiA9ISDpX9EA5gUvkTPBVQpEO+6pET87I4XhckdBmbZWwAFHMEQCIC8vcyfV3kOLDUI+ZaqFnS7psT11aFt+CW+jU2We7VYXAiA3zPurejZx5jSrUE/q9FI+B/idy8zRHAFmxo511LMjqwFpUyECZL28ba/0fLUUb9CUm2BWh/pDPpQa/ivbd4vKZWqBiSohAx3wAIvD9FNoBhSIQcli5257Nf7ePVqSFOQDze7XlHJVIQIYUTRV97qnh0yX/U36NKWtXEqbdW0jmlMmBDyeRbC87lOu",
+      "error_substr": "invalid signature"
+    },
+    {
+      "description": "wrong message for p2pkh full signature",
+      "message": "745NRH7L6UQCEPPXTQOGU56EDU",
+      "address": "164P4mbDkPcyvRnFGAZd1ThjxSj7Fbsywz",
+      "signature": "AgAAAAGEmHuloQANVIqnpMegGLNFKwAGE0Urv0a/uMiHnJ+FQwAAAABrSDBFAiEAr8VdqPCZU/oVqKKj2WwHfeCX/lzp+Rfk8d59cS9xdGECIAar0nievDdeVstmIgjfM7kzMepL6HrecBuJtgEitFxBASECzgU8WF30ffzpbdClcw/0NBkTCkuRbiEzr+CTXePjiPfgBwAAAQAAAAAAAAAAAWrgBwAA",
+      "error_substr": "invalid signature"
+    },
+    {
+      "description": "wrong signer for p2pkh full signature",
+      "message": "GI2SVNWVCWTEEIMFZFFZYAQNSA",
+      "address": "1GZvNdLeGpGaRnbymmnmtA8MFPqxPDVjvH",
+      "signature": "AgAAAAGEmHuloQANVIqnpMegGLNFKwAGE0Urv0a/uMiHnJ+FQwAAAABrSDBFAiEAr8VdqPCZU/oVqKKj2WwHfeCX/lzp+Rfk8d59cS9xdGECIAar0nievDdeVstmIgjfM7kzMepL6HrecBuJtgEitFxBASECzgU8WF30ffzpbdClcw/0NBkTCkuRbiEzr+CTXePjiPfgBwAAAQAAAAAAAAAAAWrgBwAA",
+      "error_substr": "invalid signature"
+    },
+    {
+      "description": "wrong message for p2wpkh full signature",
+      "message": "VSNPXEH7QRARGTKFSEHRDRNMJ3",
+      "address": "bc1qkwzsslep5elkuat4608v7tpntpr3d9n7w5cwwq",
+      "signature": "AgAAAAABAaVatLF3wpACTG5XowFYPJPv65lgTlZypjUV9d1DNduCAAAAAADgBwAAAQAAAAAAAAAAAWoCRzBEAiB+SJdR6bVLpv5+kK8pOXSUDS24rU53YkTQEvelQJ22uwIgEfqM8eYTupu4LtA0Tz7z1LIbhpP2PrUxWEt9osnrxFEBIQMasC7JaIHbbAUt1kU81yx7S4QHScnEDBs4GsdHDPMPSuAHAAA=",
+      "error_substr": "invalid signature"
+    },
+    {
+      "description": "wrong signer for p2wpkh full signature",
+      "message": "YGIAANMREUXLFRI4HIEOCE4T23",
+      "address": "bc1q50kxspq60j437r8z0m68zazrpk4dwt29pkngjf",
+      "signature": "AgAAAAABAaVatLF3wpACTG5XowFYPJPv65lgTlZypjUV9d1DNduCAAAAAADgBwAAAQAAAAAAAAAAAWoCRzBEAiB+SJdR6bVLpv5+kK8pOXSUDS24rU53YkTQEvelQJ22uwIgEfqM8eYTupu4LtA0Tz7z1LIbhpP2PrUxWEt9osnrxFEBIQMasC7JaIHbbAUt1kU81yx7S4QHScnEDBs4GsdHDPMPSuAHAAA=",
+      "error_substr": "invalid signature"
+    },
+    {
+      "description": "wrong message for p2tr full signature",
+      "message": "OGCYVFNJIZJRCOG565FNS3X5RH",
+      "address": "bc1psmjelwjtg7lz26jhd4kkf35v0xp3u7ffc6p4n4869s0hxkrrrtkqkpqvmg",
+      "signature": "AgAAAAABAY+B3hhlrps+S2YaxSvL3HxZKdfT+8XCCtZ4KQc5N+AaAAAAAADgBwAAAQAAAAAAAAAAAWoBQEHQoT3HfPKw4WNiQySblfcRX2gnha/mrpFxUoYlkJxuQFXNN3sS+XbJsNAoXRlvQitk0tVEFpsUGRcCdZ7bWPHgBwAA",
+      "error_substr": "invalid signature"
+    },
+    {
+      "description": "wrong signer for p2tr full signature",
+      "message": "K276VUM3MXP56DGNVICQR5XWRT",
+      "address": "bc1pwt2tn6fvwnr36nf4f4cvzxxr6wztg3rrvmht7tvj28k7mudad24q2gq7su",
+      "signature": "AgAAAAABAY+B3hhlrps+S2YaxSvL3HxZKdfT+8XCCtZ4KQc5N+AaAAAAAADgBwAAAQAAAAAAAAAAAWoBQEHQoT3HfPKw4WNiQySblfcRX2gnha/mrpFxUoYlkJxuQFXNN3sS+XbJsNAoXRlvQitk0tVEFpsUGRcCdZ7bWPHgBwAA",
+      "error_substr": "invalid signature"
+    },
+    {
+      "description": "wrong message for p2tr-time-lock full signature",
+      "message": "S63435UWIE57USYNHTS4OP56RU",
+      "address": "bc1peeyux4l3g6wmq23hsl6hytndlu89emtvqrw0k222hgnfvys8yw8sehzpun",
+      "signature": "AgAAAAABARTMGFokvM/viA990Uz2acpongloH+NqLgjm1grzw7C1AAAAAADgBwAAAQAAAAAAAAAAAWoEQAl8+ry6NBWeMu08ZpB9fJVnTiWQJy1i5LOfmtDr8DLWVvSUyKAwNQK7EyIPJlQhATz/7cw3Oywj0+dF0NHS9mMAS2MgrYfXhOkh0CvwuJpB+O3tal2ECfO0v7k1/A4PTlGcQiBnAuAHsnUg15isG0dq0JWAnqDPzUnq+bMlf+cWyLUGg00iNZeg0D5orCHB15isG0dq0JWAnqDPzUnq+bMlf+cWyLUGg00iNZeg0D7gBwAA",
+      "error_substr": "invalid signature"
+    },
+    {
+      "description": "wrong signer for p2tr-time-lock full signature",
+      "message": "5WCQVNSZADVB2U447BH2A44Y4X",
+      "address": "bc1pjnyr02p39jwlzvpsg0r4lhjspyylpntdqjy250j9lnsn8t26y0yqk5yads",
+      "signature": "AgAAAAABARTMGFokvM/viA990Uz2acpongloH+NqLgjm1grzw7C1AAAAAADgBwAAAQAAAAAAAAAAAWoEQAl8+ry6NBWeMu08ZpB9fJVnTiWQJy1i5LOfmtDr8DLWVvSUyKAwNQK7EyIPJlQhATz/7cw3Oywj0+dF0NHS9mMAS2MgrYfXhOkh0CvwuJpB+O3tal2ECfO0v7k1/A4PTlGcQiBnAuAHsnUg15isG0dq0JWAnqDPzUnq+bMlf+cWyLUGg00iNZeg0D5orCHB15isG0dq0JWAnqDPzUnq+bMlf+cWyLUGg00iNZeg0D7gBwAA",
+      "error_substr": "invalid signature"
+    },
+    {
+      "description": "wrong message for p2sh-p2wkh full signature",
+      "message": "TB6S2JNNDFW4IDDB672R7VCHK6",
+      "address": "37HVPoc7ZsU5C9Z2VKcCkSLzEknYXCzm3s",
+      "signature": "AgAAAAABAbtjBsUTHnoyuNG4NGbx6cI1Z01QLlfGHJX/WIRCAU6/AAAAABcWABTGXFmsgRqCkic6D+eE4AKm1iyVhuAHAAABAAAAAAAAAAABagJHMEQCIBp/IMJTnnhI6YrHJwIQbfucoizq0esZ35QRxtpXuk7fAiAGx6kSd9BuPDY+R0sHTJU0ZFtScJI8ASojEHwrClKxDQEhAl3boe/68fHvtuYzRkaS3GOSxnUTJwejjrubm+czK+Yi4AcAAA==",
+      "error_substr": "invalid signature"
+    },
+    {
+      "description": "wrong signer for p2sh-p2wkh full signature",
+      "message": "OQXDXSR5SN5N7WRXSPTI462HKH",
+      "address": "3Lzvqx3CwgQ3JEzQNyA1UUdYcMJ4FFNLrx",
+      "signature": "AgAAAAABAbtjBsUTHnoyuNG4NGbx6cI1Z01QLlfGHJX/WIRCAU6/AAAAABcWABTGXFmsgRqCkic6D+eE4AKm1iyVhuAHAAABAAAAAAAAAAABagJHMEQCIBp/IMJTnnhI6YrHJwIQbfucoizq0esZ35QRxtpXuk7fAiAGx6kSd9BuPDY+R0sHTJU0ZFtScJI8ASojEHwrClKxDQEhAl3boe/68fHvtuYzRkaS3GOSxnUTJwejjrubm+czK+Yi4AcAAA==",
+      "error_substr": "invalid signature"
+    },
+    {
+      "description": "wrong message for p2wsh-time-lock full signature",
+      "message": "YPD57Q4WGIZ2HFH7FIYYN7DFAO",
+      "address": "bc1q9dtw8dz93e7w6v5w8tra2et0vhz3wct3hpvl4tk5vrac9xz8szwqtvf0e2",
+      "signature": "AgAAAAABARVzK6W+9P3uKAmwv5xuqaftTkpGVj+1VWPgnqAVBFPyAAAAAADgBwAAAQAAAAAAAAAAAWoDSDBFAiEA82QBQkW16bqrm2mfKOLubqM2XHM+042kNMIor103anACICxp8esh++3RqSzqeefA+nlZoejw4pJJeubRTC9d6kZaAQBNYyEDrYfXhOkh0CvwuJpB+O3tal2ECfO0v7k1/A4PTlGcQiBnAuAHsnUhAyTbIAnLsvFRwT/A4kYwUNI0ny1pwRQ5KkFkMopLD5q4aKzgBwAA",
+      "error_substr": "invalid signature"
+    },
+    {
+      "description": "wrong signer for p2wsh-time-lock full signature",
+      "message": "TOJXD6LSM3XO5OQ4QBQSL56I22",
+      "address": "bc1q6qd404g7r3yuv8746favwel3rd2evgwkng9fu7hkr5djwnaffmfql906cu",
+      "signature": "AgAAAAABARVzK6W+9P3uKAmwv5xuqaftTkpGVj+1VWPgnqAVBFPyAAAAAADgBwAAAQAAAAAAAAAAAWoDSDBFAiEA82QBQkW16bqrm2mfKOLubqM2XHM+042kNMIor103anACICxp8esh++3RqSzqeefA+nlZoejw4pJJeubRTC9d6kZaAQBNYyEDrYfXhOkh0CvwuJpB+O3tal2ECfO0v7k1/A4PTlGcQiBnAuAHsnUhAyTbIAnLsvFRwT/A4kYwUNI0ny1pwRQ5KkFkMopLD5q4aKzgBwAA",
+      "error_substr": "invalid signature"
+    },
+    {
+      "description": "wrong message for p2wsh-multisig-2of2 full signature",
+      "message": "BDWJUGVTIJ5ED36ZORNU4ZYZQI",
+      "address": "bc1qfqj9nyjyt48mnu3d5pl98t280l2w0ccpfd2r2mee3fwfxar5sehszuz26t",
+      "signature": "AgAAAAABAcE9Xti5qyNVQrVVDtYUznEvVIDEbkXUF3n3CQI5bzKRAAAAAADgBwAAAQAAAAAAAAAAAWoEAEcwRAIgSwczcWxkT+Tk8wvTdorKXE3Hfemk6mtcKXC2yGSXp2ACIEIa5UwomMwpoPLyowZ/e550yHRPTyIIbYDaYT1kF9szAUgwRQIhAPpw4wkAFjKT1mvhOSfmHlYFtRgQ87hfbOfjnjJnQ2PuAiA7uR/iEFqgQfLLZIEsRIImvMPP/gMfchFpj4Qx5aRSpQFHUiED1iNYBtEHilqVRjfuFj7hkUEtAkMkPX7WRMHZ3NGTrUQhArxPc6k2RYEdx2fw2Pd82g7GgeLraJ7meGEFXIxa7IwfUq7gBwAA",
+      "error_substr": "invalid signature"
+    },
+    {
+      "description": "wrong signer for p2wsh-multisig-2of2 full signature",
+      "message": "5P7EW4XUVZ6PJX5HY4MW5FK5PB",
+      "address": "bc1qdd2sh7ejv460se0gfswaz9fve8adafyg3l9f8s0xya72dwve2jxqvarq63",
+      "signature": "AgAAAAABAcE9Xti5qyNVQrVVDtYUznEvVIDEbkXUF3n3CQI5bzKRAAAAAADgBwAAAQAAAAAAAAAAAWoEAEcwRAIgSwczcWxkT+Tk8wvTdorKXE3Hfemk6mtcKXC2yGSXp2ACIEIa5UwomMwpoPLyowZ/e550yHRPTyIIbYDaYT1kF9szAUgwRQIhAPpw4wkAFjKT1mvhOSfmHlYFtRgQ87hfbOfjnjJnQ2PuAiA7uR/iEFqgQfLLZIEsRIImvMPP/gMfchFpj4Qx5aRSpQFHUiED1iNYBtEHilqVRjfuFj7hkUEtAkMkPX7WRMHZ3NGTrUQhArxPc6k2RYEdx2fw2Pd82g7GgeLraJ7meGEFXIxa7IwfUq7gBwAA",
+      "error_substr": "invalid signature"
+    },
+    {
+      "description": "wrong message for p2wsh-multisig-3of3 full signature",
+      "message": "JCQSZPX52267XRXVXDYHSZBZSR",
+      "address": "bc1q9nrqkah76dcr2yvw40wkr2af439ccyl5xay0md3awkkk00zges4qdt3sx7",
+      "signature": "AgAAAAABAer7c1QlVJDuAbqiJjI4BDfc9mBGcO7bMHZbQkfJkv5xAAAAAADgBwAAAQAAAAAAAAAAAWoFAEcwRAIgSOxqpGJcIsTlpitk5ZYjL39Oz19Nju75iEIAZJakhxoCIAGdJoVeVRnYtALtXneYlvi+c1cM/g1VB9KuVPAbG2sEAUgwRQIhANqm0LEFk63YpHgNdhiOxvqrr+CfuTYDiBWd2qSX4eCZAiAEkN5Cei/Nu8hf344x16B07RoLmp5QkanvbWw+RYG0iAFIMEUCIQDNtva8FSjrEKwDIuRbtWf/1l5sPfPDfjCNiq4qN2b83gIgDUhfk7LFcc300VDuTgS7sapPpq7DeiEfy3bzgz6bGCoBaVMhAxv7aVMjtYlThA88s4q8tFcoyY5SuiQq5hCXJcSUaYXyIQJr/JHIEQpdLdJFEA8iFMHu9wqLtkEpmGFhDLrShlameCECWmK4dVblBueUxUfoJ20abiYpeApWXbNfy3w/lDWja7xTruAHAAA=",
+      "error_substr": "invalid signature"
+    },
+    {
+      "description": "wrong signer for p2wsh-multisig-3of3 full signature",
+      "message": "QDZMAZBL27JFGRNCIXL25DXBSH",
+      "address": "bc1q9pzvuxjwwc63hzntqx0c3ftarjhxvud7ellrk7ywev7vxapjm02sd48ghw",
+      "signature": "AgAAAAABAer7c1QlVJDuAbqiJjI4BDfc9mBGcO7bMHZbQkfJkv5xAAAAAADgBwAAAQAAAAAAAAAAAWoFAEcwRAIgSOxqpGJcIsTlpitk5ZYjL39Oz19Nju75iEIAZJakhxoCIAGdJoVeVRnYtALtXneYlvi+c1cM/g1VB9KuVPAbG2sEAUgwRQIhANqm0LEFk63YpHgNdhiOxvqrr+CfuTYDiBWd2qSX4eCZAiAEkN5Cei/Nu8hf344x16B07RoLmp5QkanvbWw+RYG0iAFIMEUCIQDNtva8FSjrEKwDIuRbtWf/1l5sPfPDfjCNiq4qN2b83gIgDUhfk7LFcc300VDuTgS7sapPpq7DeiEfy3bzgz6bGCoBaVMhAxv7aVMjtYlThA88s4q8tFcoyY5SuiQq5hCXJcSUaYXyIQJr/JHIEQpdLdJFEA8iFMHu9wqLtkEpmGFhDLrShlameCECWmK4dVblBueUxUfoJ20abiYpeApWXbNfy3w/lDWja7xTruAHAAA=",
+      "error_substr": "invalid signature"
+    }
+  ]
+}


### PR DESCRIPTION
While implementing [a Golang implementation of BIP-322](https://github.com/btcsuite/btcd/pull/2521), I noticed a couple of things that weren't super clear.

I also added more test vectors for both the "simple" and "full" variants.