### PR TITLE
bip174: Explain BIP2 status in Changelog

### DIFF
--- a/bip-0174.mediawiki
+++ b/bip-0174.mediawiki
@@ -587,7 +587,7 @@ able to be unserialized by an unserializer for the PSBT format.
 ** Introduce type registry auxiliary file
 ** Add changelog
 * '''1.4.1''' (2021-01-14):
-** Mark Final
+** Mark Final (Later updated to "Deployed" with adoption of BIP3)
 * '''1.4.0''' (2019-10-02):
 ** Add preimage fields
 * '''1.3.0''' (2019-10-02):

--- a/bip-0174/type-registry.mediawiki
+++ b/bip-0174/type-registry.mediawiki
@@ -9,47 +9,47 @@ This document collects the fields and types used in PSBTs of any version from al
 |-
 | Unsigned Transaction
 | <tt>PSBT_GLOBAL_UNSIGNED_TX = 0x00</tt>
-| [[bip-0174.mediawiki|174]]
+| [[../bip-0174.mediawiki|174]]
 |-
 | Extended Public Key
 | <tt>PSBT_GLOBAL_XPUB = 0x01</tt>
-| [[bip-0174.mediawiki|174]]
+| [[../bip-0174.mediawiki|174]]
 |-
 | Transaction Version
 | <tt>PSBT_GLOBAL_TX_VERSION = 0x02</tt>
-| [[bip-0370.mediawiki|370]]
+| [[../bip-0370.mediawiki|370]]
 |-
 | Fallback Locktime
 | <tt>PSBT_GLOBAL_FALLBACK_LOCKTIME = 0x03</tt>
-| [[bip-0370.mediawiki|370]]
+| [[../bip-0370.mediawiki|370]]
 |-
 | Input Count
 | <tt>PSBT_GLOBAL_INPUT_COUNT = 0x04</tt>
-| [[bip-0370.mediawiki|370]]
+| [[../bip-0370.mediawiki|370]]
 |-
 | Output Count
 | <tt>PSBT_GLOBAL_OUTPUT_COUNT = 0x05</tt>
-| [[bip-0370.mediawiki|370]]
+| [[../bip-0370.mediawiki|370]]
 |-
 | Transaction Modifiable Flags
 | <tt>PSBT_GLOBAL_TX_MODIFIABLE = 0x06</tt>
-| [[bip-0370.mediawiki|370]]
+| [[../bip-0370.mediawiki|370]]
 |-
 | Silent Payment Global ECDH Share
 | <tt>PSBT_GLOBAL_SP_ECDH_SHARE = 0x07</tt>
-| [[bip-0375.mediawiki|375]]
+| [[../bip-0375.mediawiki|375]]
 |-
 | Silent Payment Global DLEQ Proof
 | <tt>PSBT_GLOBAL_SP_DLEQ = 0x08</tt>
-| [[bip-0375.mediawiki|375]]
+| [[../bip-0375.mediawiki|375]]
 |-
 | PSBT Version Number
 | <tt>PSBT_GLOBAL_VERSION = 0xFB</tt>
-| [[bip-0174.mediawiki|174]]
+| [[../bip-0174.mediawiki|174]]
 |-
 | Proprietary Use Type
 | <tt>PSBT_GLOBAL_PROPRIETARY = 0xFC</tt>
-| [[bip-0174.mediawiki|174]]
+| [[../bip-0174.mediawiki|174]]
 |}
 
 ==Per-input Types==
@@ -61,135 +61,135 @@ This document collects the fields and types used in PSBTs of any version from al
 |-
 | Non-Witness UTXO
 | <tt>PSBT_IN_NON_WITNESS_UTXO = 0x00</tt>
-| [[bip-0174.mediawiki|174]]
+| [[../bip-0174.mediawiki|174]]
 |-
 | Witness UTXO
 | <tt>PSBT_IN_WITNESS_UTXO = 0x01</tt>
-| [[bip-0174.mediawiki|174]]
+| [[../bip-0174.mediawiki|174]]
 |-
 | Partial Signature
 | <tt>PSBT_IN_PARTIAL_SIG = 0x02</tt>
-| [[bip-0174.mediawiki|174]]
+| [[../bip-0174.mediawiki|174]]
 |-
 | Sighash Type
 | <tt>PSBT_IN_SIGHASH_TYPE = 0x03</tt>
-| [[bip-0174.mediawiki|174]]
+| [[../bip-0174.mediawiki|174]]
 |-
 | Redeem Script
 | <tt>PSBT_IN_REDEEM_SCRIPT = 0x04</tt>
-| [[bip-0174.mediawiki|174]]
+| [[../bip-0174.mediawiki|174]]
 |-
 | Witness Script
 | <tt>PSBT_IN_WITNESS_SCRIPT = 0x05</tt>
-| [[bip-0174.mediawiki|174]]
+| [[../bip-0174.mediawiki|174]]
 |-
 | BIP 32 Derivation Path
 | <tt>PSBT_IN_BIP32_DERIVATION = 0x06</tt>
-| [[bip-0174.mediawiki|174]]
+| [[../bip-0174.mediawiki|174]]
 |-
 | Finalized scriptSig
 | <tt>PSBT_IN_FINAL_SCRIPTSIG = 0x07</tt>
-| [[bip-0174.mediawiki|174]]
+| [[../bip-0174.mediawiki|174]]
 |-
 | Finalized scriptWitness
 | <tt>PSBT_IN_FINAL_SCRIPTWITNESS = 0x08</tt>
-| [[bip-0174.mediawiki|174]]
+| [[../bip-0174.mediawiki|174]]
 |-
 | Proof-of-reserves commitment
 | <tt>PSBT_IN_POR_COMMITMENT = 0x09</tt>
-| [[bip-0127.mediawiki|127]]
+| [[../bip-0127.mediawiki|127]]
 |-
 | RIPEMD160 preimage
 | <tt>PSBT_IN_RIPEMD160 = 0x0a</tt>
-| [[bip-0174.mediawiki|174]]
+| [[../bip-0174.mediawiki|174]]
 |-
 | SHA256 preimage
 | <tt>PSBT_IN_SHA256 = 0x0b</tt>
-| [[bip-0174.mediawiki|174]]
+| [[../bip-0174.mediawiki|174]]
 |-
 | HASH160 preimage
 | <tt>PSBT_IN_HASH160 = 0x0c</tt>
-| [[bip-0174.mediawiki|174]]
+| [[../bip-0174.mediawiki|174]]
 |-
 | HASH256 preimage
 | <tt>PSBT_IN_HASH256 = 0x0d</tt>
-| [[bip-0174.mediawiki|174]]
+| [[../bip-0174.mediawiki|174]]
 |-
 | Previous TXID
 | <tt>PSBT_IN_PREVIOUS_TXID = 0x0e</tt>
-| [[bip-0370.mediawiki|370]]
+| [[../bip-0370.mediawiki|370]]
 |-
 | Spent Output Index
 | <tt>PSBT_IN_OUTPUT_INDEX = 0x0f</tt>
-| [[bip-0370.mediawiki|370]]
+| [[../bip-0370.mediawiki|370]]
 |-
 | Sequence Number
 | <tt>PSBT_IN_SEQUENCE = 0x10</tt>
-| [[bip-0370.mediawiki|370]]
+| [[../bip-0370.mediawiki|370]]
 |-
 | Required Time-based Locktime
 | <tt>PSBT_IN_REQUIRED_TIME_LOCKTIME = 0x11</tt>
-| [[bip-0370.mediawiki|370]]
+| [[../bip-0370.mediawiki|370]]
 |-
 | Required Height-based Locktime
 | <tt>PSBT_IN_REQUIRED_HEIGHT_LOCKTIME = 0x12</tt>
-| [[bip-0370.mediawiki|370]]
+| [[../bip-0370.mediawiki|370]]
 |-
 | Taproot Key Spend Signature
 | <tt>PSBT_IN_TAP_KEY_SIG = 0x13</tt>
-| [[bip-0371.mediawiki|371]]
+| [[../bip-0371.mediawiki|371]]
 |-
 | Taproot Script Spend Signature
 | <tt>PSBT_IN_TAP_SCRIPT_SIG = 0x14</tt>
-| [[bip-0371.mediawiki|371]]
+| [[../bip-0371.mediawiki|371]]
 |-
 | Taproot Leaf Script
 | <tt>PSBT_IN_TAP_LEAF_SCRIPT = 0x15</tt>
-| [[bip-0371.mediawiki|371]]
+| [[../bip-0371.mediawiki|371]]
 |-
 | Taproot Key BIP 32 Derivation Path
 | <tt>PSBT_IN_TAP_BIP32_DERIVATION = 0x16</tt>
-| [[bip-0371.mediawiki|371]]
+| [[../bip-0371.mediawiki|371]]
 |-
 | Taproot Internal Key
 | <tt>PSBT_IN_TAP_INTERNAL_KEY = 0x17</tt>
-| [[bip-0371.mediawiki|371]]
+| [[../bip-0371.mediawiki|371]]
 |-
 | Taproot Merkle Root
 | <tt>PSBT_IN_TAP_MERKLE_ROOT = 0x18</tt>
-| [[bip-0371.mediawiki|371]]
+| [[../bip-0371.mediawiki|371]]
 |-
 | MuSig2 Participant Public Keys
 | <tt>PSBT_IN_MUSIG2_PARTICIPANT_PUBKEYS = 0x1a</tt>
-| [[bip-0373.mediawiki|373]]
+| [[../bip-0373.mediawiki|373]]
 |-
 | MuSig2 Public Nonce
 | <tt>PSBT_IN_MUSIG2_PUB_NONCE = 0x1b</tt>
-| [[bip-0373.mediawiki|373]]
+| [[../bip-0373.mediawiki|373]]
 |-
 | MuSig2 Participant Partial Signature
 | <tt>PSBT_IN_MUSIG2_PARTIAL_SIG = 0x1c</tt>
-| [[bip-0373.mediawiki|373]]
+| [[../bip-0373.mediawiki|373]]
 |-
 | Silent Payment Input ECDH Share
 | <tt>PSBT_IN_SP_ECDH_SHARE = 0x1d</tt>
-| [[bip-0375.mediawiki|375]]
+| [[../bip-0375.mediawiki|375]]
 |-
 | Silent Payment Input DLEQ Proof
 | <tt>PSBT_IN_SP_DLEQ = 0x1e</tt>
-| [[bip-0375.mediawiki|375]]
+| [[../bip-0375.mediawiki|375]]
 |-
 | Silent Payment Spend Key BIP 32 Derivation Path
 | <tt>PSBT_IN_SP_SPEND_BIP32_DERIVATION = 0x1f</tt>
-| [[bip-0376.mediawiki|376]]
+| [[../bip-0376.mediawiki|376]]
 |-
 | Silent Payment Tweak
 | <tt>PSBT_IN_SP_TWEAK = 0x20</tt>
-| [[bip-0376.mediawiki|376]]
+| [[../bip-0376.mediawiki|376]]
 |-
 | Proprietary Use Type
 | <tt>PSBT_IN_PROPRIETARY = 0xFC</tt>
-| [[bip-0174.mediawiki|174]]
+| [[../bip-0174.mediawiki|174]]
 |}
 
 
@@ -202,53 +202,53 @@ This document collects the fields and types used in PSBTs of any version from al
 |-
 | Redeem Script
 | <tt>PSBT_OUT_REDEEM_SCRIPT = 0x00</tt>
-| [[bip-0174.mediawiki|174]]
+| [[../bip-0174.mediawiki|174]]
 |-
 | Witness Script
 | <tt>PSBT_OUT_WITNESS_SCRIPT = 0x01</tt>
-| [[bip-0174.mediawiki|174]]
+| [[../bip-0174.mediawiki|174]]
 |-
 | BIP 32 Derivation Path
 | <tt>PSBT_OUT_BIP32_DERIVATION = 0x02</tt>
-| [[bip-0174.mediawiki|174]]
+| [[../bip-0174.mediawiki|174]]
 |-
 | Output Amount
 | <tt>PSBT_OUT_AMOUNT = 0x03</tt>
-| [[bip-0370.mediawiki|370]]
+| [[../bip-0370.mediawiki|370]]
 |-
 | Output Script
 | <tt>PSBT_OUT_SCRIPT = 0x04</tt>
-| [[bip-0370.mediawiki|370]], [[bip-0375.mediawiki|375]]
+| [[../bip-0370.mediawiki|370]], [[../bip-0375.mediawiki|375]]
 |-
 | Taproot Internal Key
 | <tt>PSBT_OUT_TAP_INTERNAL_KEY = 0x05</tt>
-| [[bip-0371.mediawiki|371]]
+| [[../bip-0371.mediawiki|371]]
 |-
 | Taproot Tree
 | <tt>PSBT_OUT_TAP_TREE = 0x06</tt>
-| [[bip-0371.mediawiki|371]]
+| [[../bip-0371.mediawiki|371]]
 |-
 | Taproot Key BIP 32 Derivation Path
 | <tt>PSBT_OUT_TAP_BIP32_DERIVATION = 0x07</tt>
-| [[bip-0371.mediawiki|371]]
+| [[../bip-0371.mediawiki|371]]
 |-
 | MuSig2 Participant Public Keys
 | <tt>PSBT_OUT_MUSIG2_PARTICIPANT_PUBKEYS = 0x08</tt>
-| [[bip-0373.mediawiki|373]]
+| [[../bip-0373.mediawiki|373]]
 |-
 | Silent Payment Data
 | <tt>PSBT_OUT_SP_V0_INFO = 0x09</tt>
-| [[bip-0375.mediawiki|375]]
+| [[../bip-0375.mediawiki|375]]
 |-
 | Silent Payment Label
 | <tt>PSBT_OUT_SP_V0_LABEL = 0x0a</tt>
-| [[bip-0375.mediawiki|375]]
+| [[../bip-0375.mediawiki|375]]
 |-
 | BIP 353 DNSSEC proof
 | <tt>PSBT_OUT_DNSSEC_PROOF = 0x35</tt>
-| [[bip-0353.mediawiki|353]]
+| [[../bip-0353.mediawiki|353]]
 |-
 | Proprietary Use Type
 | <tt>PSBT_OUT_PROPRIETARY = 0xFC</tt>
-| [[bip-0174.mediawiki|174]]
+| [[../bip-0174.mediawiki|174]]
 |}


### PR DESCRIPTION
Update the changelog in BIP174 to explain the mention of "Final" in contrast to the "Deployed" state.