### PR TITLE
bip388: Update Changelog

### DIFF
--- a/bip-0388.mediawiki
+++ b/bip-0388.mediawiki
@@ -8,6 +8,7 @@
   Assigned: 2023-12-26
   License: BSD-2-Clause
   Discussion: 2022-05-10: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2022-May/020423.html
+  Version: 1.1.0
 </pre>
 
 == Abstract ==
@@ -332,12 +333,12 @@ Wallet policies are implemented in
 For development and testing purposes, we provide a [[bip-0388/wallet_policies.py|Python 3.7 reference implementation]] of simple classes to handle wallet policies, and the conversion to/from output script descriptors.
 The reference implementation is for demonstration purposes only and not to be used in production environments.
 
-== Change Log ==
+== Changelog ==
 
 * '''1.1.0''' (2024-11):
 ** Added support for <tt>musig</tt> key placeholders in descriptor templates.
-* '''1.0.0''' (2024-05):
-** Initial version.
+* '''1.0.0''' (2024-05-12):
+** Initial version, advance to Proposed (later updated to Complete per BIP3 adoption).
 * '''0.0.1''' (2022-11-16):
 ** First draft.
 

--- a/bip-0388.mediawiki
+++ b/bip-0388.mediawiki
@@ -5,7 +5,7 @@
   Authors: Salvatore Ingala <salvatoshi@protonmail.com>
   Status: Complete
   Type: Specification
-  Assigned: 2022-11-16
+  Assigned: 2023-12-26
   License: BSD-2-Clause
   Discussion: 2022-05-10: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2022-May/020423.html
 </pre>
@@ -338,6 +338,8 @@ The reference implementation is for demonstration purposes only and not to be us
 ** Added support for <tt>musig</tt> key placeholders in descriptor templates.
 * '''1.0.0''' (2024-05):
 ** Initial version.
+* '''0.0.1''' (2022-11-16):
+** First draft.
 
 == Footnotes ==
 


### PR DESCRIPTION
This aligns the section title of the Changelog with the proposed best practice from BIP3 (previously "Change Log"), corrects the date in the Assigned header, and adds the missing Version header.

This PR only touches metadata and doesn’t change any of the payload content of the document.

cc: @salvatoshi as Owner to keep you in the loop.