### PR TITLE
bip174: update changelog for semver/consistency

### DIFF
--- a/bip-0174.mediawiki
+++ b/bip-0174.mediawiki
@@ -9,7 +9,7 @@
   Type: Specification
   Assigned: 2017-07-12
   License: BSD-2-Clause
-  Version: 1.4.2
+  Version: 1.6.0
 </pre>
 
 ==Introduction==
@@ -583,10 +583,10 @@ able to be unserialized by an unserializer for the PSBT format.
 
 ==Changelog==
 
-* '''1.4.2''' (2026-04-08):
+* '''1.6.0''' (2026-04-08):
 ** Introduce type registry auxiliary file
 ** Add changelog
-* '''1.4.1''' (2021-01-14):
+* '''1.5.0''' (2021-01-14):
 ** Mark Final
 * '''1.4.0''' (2019-10-02):
 ** Add preimage fields


### PR DESCRIPTION
following up on https://github.com/bitcoin/bips/pull/2135#discussion_r3088781483.

Per https://semver.org/:

Given a version number MAJOR.MINOR.PATCH, increment the:

    MAJOR version when you make incompatible API changes
    MINOR version when you add functionality in a backward compatible manner
    PATCH version when you make backward compatible bug fixes

Per https://keepachangelog.com/en/1.0.0/:

```
Changelogs are for humans.

Should you ever rewrite a changelog?

Sure. There are always good reasons to improve a changelog.
```