### PR TITLE
Fix BIP3 link in BIP360, touch up BIP3 reference in BIP347

### DIFF
--- a/bip-0347.mediawiki
+++ b/bip-0347.mediawiki
@@ -167,7 +167,7 @@ A full test suite with additional vectors can be found at the Bitcoin [https://g
 ==Changelog==
 
 * __1.0.0__ (2026-03-01) - Marked as complete.
-* __0.3.1__ (2026-01-23) - Made compliant with BIP 003, use cases added. 
+* __0.3.1__ (2026-01-23) - Made compliant with [[bip-0003.md|BIP 3]], use cases added.
 * __0.3.0__ (2024-05-06) - Merged to BIP repo
 * __0.2.0__ (2024-04-24) - Assigned BIP number
 * __0.1.0__ (2023-12-11) - Initial draft posted

--- a/bip-0360.mediawiki
+++ b/bip-0360.mediawiki
@@ -401,7 +401,7 @@ To help implementers understand updates to this BIP, we keep a list of substanti
 
 * __0.11.0__  (2026-02-10) - Rename BIP from Pay-to-Tapscript-Hash (P2TSH) to Pay-to-Merkle-Root (P2MR)
 * __0.10.3__  (2026-02-06) - Rename tapscript-native output type to script tree output type.
-* __0.10.2__  (2026-01-23) - Fix bug in verification, minor review comments and adopt [[bip-0003.mediawiki|BIP 003]] conventions.
+* __0.10.2__  (2026-01-23) - Fix bug in verification, minor review comments and adopt [[bip-0003.md|BIP 3]] conventions.
 * __0.10.1__  (2026-01-21) - Terminology and clarity improvements, addressed feedback from reviews.
 * __0.10.0__  (2025-09-17) - Rewrote BIP for clarity and renamed from P2QRH to P2TSH
 * __0.9.0__  (2025-07-20) - Changed the Witness Version from 3 to 2.


### PR DESCRIPTION
Two BIPs added a changelog entry on 2026-01-23 referencing the updated BIP Process meta-BIP (BIP 3) with the wrong form:

- **bip-0360.mediawiki:404** rendered `[[bip-0003.mediawiki|BIP 003]]`, but the actual file in this repository is `bip-0003.md` (no MediaWiki variant exists). The wiki link therefore fails to resolve — readers of the bip-0360 changelog landed on a 404.
- **bip-0347.mediawiki:170** wrote the same reference as bare text `BIP 003` with no link at all, so readers of bip-0347 had no way to navigate to BIP 3.

Both entries were added on the same day (2026-01-23) with the same mistaken "BIP 003" (three-digit zero-pad) display text.

## Fix

Rewrite both entries to use the canonical form `[[bip-0003.md|BIP 3]]`:

- `bip-0003.md` matches the actual filename.
- `BIP 3` matches the display text convention the README already uses at line 40 (`[[bip-0003.md|3]]`). "BIP 003" with the three-digit zero-pad appears nowhere else in this repository for any BIP.

## Verification

- `ls bip-0003.*` → `bip-0003.md` + `bip-0003/` (image asset directory). No `bip-0003.mediawiki` file exists.
- Enumerated all 205 unique `bip-XXXX.{mediawiki,md}` filename references across every `.mediawiki` / `.md` file in the repository; `bip-0003.mediawiki` was the **only** one that does not resolve to an existing file.
- Confirmed the README (line 40) links via `bip-0003.md`, establishing the correct form.
