### PR TITLE
BIP-0329: Add spscan label type for labelling silent payments wallets

### DIFF
--- a/bip-0329.mediawiki
+++ b/bip-0329.mediawiki
@@ -52,10 +52,10 @@ Each JSON object must contain 3 or 4 key/value pairs, defined as follows:
 ! Description
 |-
 | <tt>type</tt>
-| One of <tt>tx</tt>, <tt>addr</tt>, <tt>pubkey</tt>, <tt>input</tt>, <tt>output</tt> or <tt>xpub</tt>
+| One of <tt>tx</tt>, <tt>addr</tt>, <tt>pubkey</tt>, <tt>input</tt>, <tt>output</tt>, <tt>xpub</tt> or <tt>spscan</tt>
 |-
 | <tt>ref</tt>
-| Reference to the transaction, address, public key, input, output or extended public key
+| Reference to the transaction, address, public key, input, output, extended public key or silent payments scan key expression
 |-
 | <tt>label</tt>
 | The label applied to the reference
@@ -98,6 +98,10 @@ The reference is defined for each <tt>type</tt> as follows:
 | <tt>xpub</tt>
 | Extended public key as defined by BIP32
 | <tt>xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8Nq...</tt>
+|-
+| <tt>spscan</tt>
+| Key expression for the single argument form of a silent payments output descriptor as defined by BIP392
+| <tt>spscan1q5zs2pg9q5zs2pg9q5zs2pg9q5zs2pg9q5zs2pg9q5...</tt>
 |}
 
 Each JSON object must contain both <tt>type</tt> and <tt>ref</tt> properties. The <tt>label</tt>, <tt>origin</tt> and <tt>spendable</tt> properties are optional. If the <tt>label</tt> or <tt>spendable</tt> properties are omitted, the importing wallet should not alter these values. The <tt>spendable</tt> property should only appear where type is <tt>output</tt>.
@@ -131,6 +135,7 @@ The following fragment represents a wallet label export:
 { "type": "input", "ref": "f91d0a8a78462bc59398f2c5d7a84fcff491c26ba54c4833478b202796c8aafd:0", "label": "Input" }
 { "type": "output", "ref": "f91d0a8a78462bc59398f2c5d7a84fcff491c26ba54c4833478b202796c8aafd:1", "label": "Output", "spendable": false }
 { "type": "xpub", "ref": "xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8", "label": "Extended Public Key" }
+{ "type": "spscan", "ref": "spscan1q5zs2pg9q5zs2pg9q5zs2pg9q5zs2pg9q5zs2pg9q5zs2pg9q5zsq9q6qjevn2kmdrnpuxt0v6h2kr2a2epkr0g6nk55ftf0xcxtddazgkrth3e", "label": "Silent Payments Scan Key Expression" }
 { "type": "tx", "ref": "f546156d9044844e02b181026a1a407abfca62e7ea1159f87bbeaa77b4286c74", "label": "Account #1 Transaction", "origin": "wpkh([d34db33f/84'/0'/1'])" }
 </pre>
 

--- a/bip-0329.mediawiki
+++ b/bip-0329.mediawiki
@@ -21,7 +21,7 @@ This BIP is licensed under the BSD 2-clause license.
 
 The export and import of funds across different Bitcoin wallet applications is well defined through standards such as BIP39, BIP32, BIP44 etc.
 These standards are well supported and allow users to move easily between different wallets.
-There is, however, no defined standard to transfer any labels the user may have applied to the transactions, addresses, public keys, inputs, outputs or xpubs in their wallet.
+There is, however, no defined standard to transfer any labels the user may have applied to the transactions, addresses, public keys, inputs, outputs, xpubs or spscans in their wallet.
 The UTXO model that Bitcoin uses makes these labels particularly valuable as they may indicate the source of funds, whether received externally or as a result of change from a prior transaction.
 In both cases, care must be taken when spending to avoid undesirable leaks of private information.
 
@@ -159,7 +159,7 @@ but should be given if they are readily available.
 
 * <tt>fee</tt>: Integer giving the number of Satoshis that went to the miner for this transaction.
 
-* <tt>value</tt>: Signed integer giving the number of Satoshis that came into the wallet by this transaction. Will be negative when sats leave the wallet. Could be zero if it is a consolidation transaction that moves from old UTXO to new. 
+* <tt>value</tt>: Signed integer giving the number of Satoshis that came into the wallet by this transaction. Will be negative when sats leave the wallet. Could be zero if it is a consolidation transaction that moves from old UTXO to new.
 
 * <tt>rate</tt>: Exchange rate at time of transaction. This is the value of a Bitcoin, expressed in another currency, at the time of the transaction, based on user preferences for data source. Multiple currencies can be given. Keys are ISO 4217 currency codes where possible. Example: <tt>"rate": { "USD":  105620.00 }</tt>
 


### PR DESCRIPTION
This PR adds `spscan` as a label type to BIP329, permitting labelling of silent payments wallets. These label values are keyed with the scan key expression for the single argument form of a silent payments output descriptor as defined in BIP392, analogous to the `xpub` label type.