### PR TITLE
BIP352: complete return type annotations in bitcoin_utils

### DIFF
--- a/bip-0352/bitcoin_utils.py
+++ b/bip-0352/bitcoin_utils.py
@@ -3,10 +3,10 @@ import struct
 from io import BytesIO
 from ripemd160 import ripemd160
 from secp256k1lab.secp256k1 import Scalar
-from typing import Union
+from typing import List, Union
 
 
-def from_hex(hex_string):
+def from_hex(hex_string: str) -> BytesIO:
     """Deserialize from a hex string representation (e.g. from RPC)"""
     return BytesIO(bytes.fromhex(hex_string))
 
@@ -15,15 +15,15 @@ def ser_uint32(u: int) -> bytes:
     return u.to_bytes(4, "big")
 
 
-def ser_uint256(u):
+def ser_uint256(u: int) -> bytes:
     return u.to_bytes(32, 'little')
 
 
-def deser_uint256(f):
+def deser_uint256(f: BytesIO) -> int:
     return int.from_bytes(f.read(32), 'little')
 
 
-def deser_txid(txid: str):
+def deser_txid(txid: str) -> bytes:
     # recall that txids are serialized little-endian, but displayed big-endian
     # this means when converting from a human readable hex txid, we need to first
     # reverse it before deserializing it
@@ -31,7 +31,7 @@ def deser_txid(txid: str):
     return bytes.fromhex(dixt)
 
 
-def deser_compact_size(f: BytesIO):
+def deser_compact_size(f: BytesIO) -> int:
     view = f.getbuffer()
     nbytes = view.nbytes
     view.release()
@@ -48,12 +48,12 @@ def deser_compact_size(f: BytesIO):
     return nit
 
 
-def deser_string(f: BytesIO):
+def deser_string(f: BytesIO) -> bytes:
     nit = deser_compact_size(f)
     return f.read(nit)
 
 
-def deser_string_vector(f: BytesIO):
+def deser_string_vector(f: BytesIO) -> List[bytes]:
     nit = deser_compact_size(f)
     r = []
     for _ in range(nit):


### PR DESCRIPTION
## Summary

The serialization helpers in `bip-0352/bitcoin_utils.py` are partially
typed. `ser_uint32`, `hash160`, and the `is_p2*` helpers already declare
both argument and return types, but the surrounding `from_hex`,
`ser_uint256`, `deser_uint256`, `deser_txid`, `deser_compact_size`,
`deser_string`, and `deser_string_vector` helpers omit them.

Fill in the missing return types (and the obvious argument types) so
the file is consistent and so static analysis can flow types through
the callers in `reference.py`. Follow-up to 2f7117c
("BIP352: fix Any typing").

No behavior changes.

## Diff

| Function | Before | After |
|---|---|---|
| `from_hex` | `def from_hex(hex_string)` | `def from_hex(hex_string: str) -> BytesIO` |
| `ser_uint256` | `def ser_uint256(u)` | `def ser_uint256(u: int) -> bytes` |
| `deser_uint256` | `def deser_uint256(f)` | `def deser_uint256(f: BytesIO) -> int` |
| `deser_txid` | `def deser_txid(txid: str)` | `def deser_txid(txid: str) -> bytes` |
| `deser_compact_size` | `def deser_compact_size(f: BytesIO)` | `def deser_compact_size(f: BytesIO) -> int` |
| `deser_string` | `def deser_string(f: BytesIO)` | `def deser_string(f: BytesIO) -> bytes` |
| `deser_string_vector` | `def deser_string_vector(f: BytesIO)` | `def deser_string_vector(f: BytesIO) -> List[bytes]` |

`List` is added to the existing `typing` import. The `ser_uint32` and
`hash160` annotations on adjacent lines were the model.

## Verification

Imported the module and round-tripped each helper to confirm runtime
behavior is unchanged:

```
$ python3 -c "
import sys
sys.path.insert(0, 'bip-0352')
sys.path.insert(0, 'bip-0352/secp256k1lab/src')
import bitcoin_utils
print('from_hex   ', bitcoin_utils.from_hex('deadbeef').read(2).hex())
print('ser_uint32 ', bitcoin_utils.ser_uint32(1).hex())
print('ser_uint256', bitcoin_utils.ser_uint256(1).hex()[:16])
print('deser_txid ', bitcoin_utils.deser_txid('00112233' * 8).hex()[:16])
"
from_hex    dead
ser_uint32  00000001
ser_uint256 0100000000000000
deser_txid  3322110033221100
```

Type-checker is happy across the whole file (matching @theStack's
verification on the PR):

```
$ mypy --ignore-missing-imports ./bip-0352/bitcoin_utils.py
Success: no issues found in 1 source file
```
