### PR TITLE
bip-0085: add Go reference implementation

### DIFF
--- a/bip-0085.mediawiki
+++ b/bip-0085.mediawiki
@@ -438,6 +438,7 @@ BIP32, BIP39
 * 1.3.0 Python 3.x library implementation: [https://github.com/akarve/bipsea]
 * 1.1.0 Python 2.x library implementation: [https://github.com/ethankosakovsky/bip85]
 * 1.0.0 JavaScript library implementation: [https://github.com/hoganri/bip85-js]
+* 2.0.0 Go library implementation: [https://github.com/shurlinet/go-bip85]
 
 ==Changelog==
 


### PR DESCRIPTION
Add [shurlinet/go-bip85](https://github.com/shurlinet/go-bip85) to the BIP85 reference implementations list.

- BIP85 v2.0.0 (includes DICE application)
- All 12 spec test vectors pass byte-for-byte
- 268 cross-implementation vectors generated from [bipsea](https://github.com/akarve/bipsea)
- Test patterns adopted from [ethankosakovsky/bip85](https://github.com/ethankosakovsky/bip85) (DRNG split reads, length edge cases)
- RSA supported via DRNG workaround (Go 1.24+ FIPS 140-3 constraint)
- MIT license
- [pkg.go.dev documentation](https://pkg.go.dev/github.com/shurlinet/go-bip85)
