### PR TITLE
BIP352: complete type annotations on bitcoin_utils class methods

### DIFF
--- a/bip-0352/bitcoin_utils.py
+++ b/bip-0352/bitcoin_utils.py
@@ -3,7 +3,7 @@ import struct
 from io import BytesIO
 from ripemd160 import ripemd160
 from secp256k1lab.secp256k1 import Scalar
-from typing import List, Union
+from typing import List, Optional, Union
 
 
 def from_hex(hex_string: str) -> BytesIO:
@@ -65,17 +65,17 @@ def deser_string_vector(f: BytesIO) -> List[bytes]:
 class COutPoint:
     __slots__ = ("hash", "n",)
 
-    def __init__(self, hash=b"", n=0,):
+    def __init__(self, hash: bytes = b"", n: int = 0) -> None:
         self.hash = hash
         self.n = n
 
-    def serialize(self):
+    def serialize(self) -> bytes:
         r = b""
         r += self.hash
         r += struct.pack("<I", self.n)
         return r
 
-    def deserialize(self, f):
+    def deserialize(self, f: BytesIO) -> None:
         self.hash = f.read(32)
         self.n = struct.unpack("<I", f.read(4))[0]
 
@@ -83,7 +83,14 @@ class COutPoint:
 class VinInfo:
     __slots__ = ("outpoint", "scriptSig", "txinwitness", "prevout", "private_key")
 
-    def __init__(self, outpoint=None, scriptSig=b"", txinwitness=None, prevout=b"", private_key=None):
+    def __init__(
+        self,
+        outpoint: Optional["COutPoint"] = None,
+        scriptSig: bytes = b"",
+        txinwitness: Optional["CTxInWitness"] = None,
+        prevout: bytes = b"",
+        private_key: Optional[Scalar] = None,
+    ) -> None:
         if outpoint is None:
             self.outpoint = COutPoint()
         else:
@@ -103,11 +110,11 @@ class VinInfo:
 class CScriptWitness:
     __slots__ = ("stack",)
 
-    def __init__(self):
+    def __init__(self) -> None:
         # stack is a vector of strings
-        self.stack = []
+        self.stack: List[bytes] = []
 
-    def is_null(self):
+    def is_null(self) -> bool:
         if self.stack:
             return False
         return True
@@ -116,14 +123,14 @@ class CScriptWitness:
 class CTxInWitness:
     __slots__ = ("scriptWitness",)
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.scriptWitness = CScriptWitness()
 
-    def deserialize(self, f: BytesIO):
+    def deserialize(self, f: BytesIO) -> "CTxInWitness":
         self.scriptWitness.stack = deser_string_vector(f)
         return self
 
-    def is_null(self):
+    def is_null(self) -> bool:
         return self.scriptWitness.is_null()
 
 


### PR DESCRIPTION
## Summary

Direct follow-up to PR #2154 (which annotated the free-function half of `bip-0352/bitcoin_utils.py`) and 2f7117c ("BIP352: fix Any typing"). The four classes in this file — `COutPoint`, `VinInfo`, `CScriptWitness`, and `CTxInWitness` — still had unannotated
`__init__`, `serialize`, `deserialize`, and `is_null` methods, so mypy could not flow types through the surrounding `reference.py`
code that constructs and passes these objects.

This PR annotates every method on all four classes:

| Class | Methods annotated |
|---|---|
| `COutPoint` | `__init__(hash: bytes, n: int) -> None`, `serialize() -> bytes`, `deserialize(f: BytesIO) -> None` |
| `VinInfo` | `__init__` (typed `Optional` defaults for the three construct-on-`None` fields) |
| `CScriptWitness` | `__init__() -> None`, `is_null() -> bool`, plus an inline `stack: List[bytes]` declaration matching what the rest of the file already assumes |
| `CTxInWitness` | `__init__() -> None`, `deserialize(f: BytesIO) -> "CTxInWitness"` (forward ref since it returns `self`), `is_null() -> bool` |

`Optional` is added to the existing `typing` import; `List` was already added by #2154. No behavior changes.

## Verification

```
$ mypy --ignore-missing-imports ./bip-0352/bitcoin_utils.py
Success: no issues found in 1 source file

$ python3 -c "
import sys
sys.path.insert(0, 'bip-0352')
sys.path.insert(0, 'bip-0352/secp256k1lab/src')
import bitcoin_utils
from io import BytesIO

op1 = bitcoin_utils.COutPoint(b'\\x11' * 32, 7)
data = op1.serialize()
print('COutPoint serialize len:', len(data))
op2 = bitcoin_utils.COutPoint()
op2.deserialize(BytesIO(data))
print('COutPoint round-trip:', op2.hash.hex()[:16], op2.n)

csw = bitcoin_utils.CScriptWitness()
print('CScriptWitness empty is_null:', csw.is_null())
csw.stack.append(b'\\x01\\x02')
print('CScriptWitness with-stack is_null:', csw.is_null())

ctw = bitcoin_utils.CTxInWitness()
print('CTxInWitness deserialize returned self:',
      ctw.deserialize(BytesIO(b'\\x00')) is ctw)

vi = bitcoin_utils.VinInfo()
print('VinInfo defaults:', type(vi.outpoint).__name__,
      type(vi.txinwitness).__name__, type(vi.private_key).__name__)
"
COutPoint serialize len: 36
COutPoint round-trip: 1111111111111111 7
CScriptWitness empty is_null: True
CScriptWitness with-stack is_null: False
CTxInWitness deserialize returned self: True
VinInfo defaults: COutPoint CTxInWitness Scalar

$ cd bip-0352 && python3 -c "import reference" (exits 0 — reference.py still imports cleanly)
```

## Notes

- Direct follow-up to #2154 ("BIP352: complete return type annotations in bitcoin_utils") in the same file. Closes the remaining annotation gap.
- No behavior changes. No new dependencies.
- Single-commit, single-file diff: `bip-0352/bitcoin_utils.py`, +18 / −11.