### PR TITLE
BIP-322 nit fixes

### DIFF
--- a/bip-0322.mediawiki
+++ b/bip-0322.mediawiki
@@ -167,7 +167,7 @@ A ''full'' signature consists of the variant-prefixed (<code>ful</code>) base64-
 
 === Full (Proof of Funds) ===
 
-The [[#full-proof-of-funds|Proof of Funds]] variant extends the basic scheme: in addition to signing
+The Proof of Funds variant extends the basic scheme: in addition to signing
 a message under a single address's key, the signer proves control over an arbitrary set of UTXOs.
 This UTXO set is chosen freely by the signer and MAY be associated with the signing address
 (the <code>message_challenge</code>). For example, it may consist of outputs paid to that address,
@@ -260,7 +260,7 @@ Validation consists of the following steps:
 # Check the '''upgradeable rules'''
 ## The version of <code>to_sign</code> must be 0 or 2.
 ## The use of NOPs reserved for upgrades is forbidden.
-## The use of Segwit versions greater than 1 are forbidden.
+## The use of Segwit versions greater than 1 is forbidden.
 ## If any of the above steps failed, the validator should stop and output the ''inconclusive'' state.
 # Let ''T'' be the nLockTime of <code>to_sign</code> and ''S'' be the nSequence of the first input of <code>to_sign</code>. Output the state ''valid at time T and age S''.
 
@@ -459,7 +459,7 @@ A '''transaction finalizer''' of a BIP322 PSBT must follow these steps:
 This specification is backwards-compatible with the legacy signmessage/verifymessage specification
 through the special case [[#legacy|as described above]].
 To support backward compatibility with implementations of this BIP before it was finalized, a
-verifier might assume the ''simple' variant in the absence of a prefix.
+verifier might assume the ''simple'' variant in the absence of a prefix.
 
 == Reference implementation ==
 
@@ -493,7 +493,7 @@ and many others for their feedback on the specification.
 ** Mark Complete
 ** Breaking change: Add human-readable prefix to encoded signature
 ** Breaking change: format of "Proof of Funds" signatures to be base64-encoded finalized PSBT
-** Add new PSBT input field for PSBT-based signing
+** Add new PSBT global field for PSBT-based signing
 * '''0.0.1''' (2018-09-10):
 ** Proposed as draft
 


### PR DESCRIPTION
Hi,

Writing from the Coldcard team — we shipped BIP-322 Proof-of-Reserves on 2026-03-06, before #2141 was merged. Reading the BIP-322 related PRs from last weeks it seems you have no idea we have live BIP-322 support in prod.

Refs:
* https://blog.coinkite.com/bip322-wif/
* https://github.com/Coldcard/firmware/blob/master/releases/ChangeLog.md
* https://x.com/COLDCARDwallet/status/2031008718188576918

As I understand updated BIP, none of the prefix business is part of `Signer` (HWW) flow. So we will be adding  PSBT_GLOBAL_GENERIC_SIGNED_MESSAGE + relaxing the requirement for 0th input to have non-witness utxo. Nothing else.

 Thank you for moving the BIP forward!

  One more observation: the `pof` prefix on the wire format looks structurally redundant. The spec already requires `PSBT_GLOBAL_GENERIC_SIGNED_MESSAGE`  to be present,
  plus the prevout-of-to_spend and single-OP_RETURN-output rules — and PSBTs are self-marked at position 0 of the base64 (always start with cHNidP8). Dropping the prefix would let
  verifier-side libraries feed the base64 straight into their existing PSBT parsers (without any change).

For future BIP-322 work we'd appreciate being tagged/contacted.
  
Thanks.



PR patch-list contains few small issues I found while reading...