### PR TITLE
bip8: Advance to Complete

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -43,13 +43,13 @@ users (see also: [https://en.bitcoin.it/wiki/Economic_majority economic majority
 | Murch
 | Process
 | Deployed
-|-
+|- style="background-color: #ffffcf"
 | [[bip-0008.mediawiki|8]]
 |
 | Version bits with lock-in by height
 | Shaolin Fry, Luke Dashjr
 | Informational
-| Draft
+| Complete
 |- style="background-color: #cfffcf"
 | [[bip-0009.mediawiki|9]]
 |

--- a/bip-0008.mediawiki
+++ b/bip-0008.mediawiki
@@ -3,7 +3,7 @@
   Title: Version bits with lock-in by height
   Authors: Shaolin Fry <shaolinfry@protonmail.ch>
            Luke Dashjr <luke+bip@dashjr.org>
-  Status: Draft
+  Status: Complete
   Type: Informational
   Assigned: 2017-02-01
   License: BSD-3-Clause OR CC0-1.0

--- a/bip-0008.mediawiki
+++ b/bip-0008.mediawiki
@@ -7,6 +7,7 @@
   Type: Informational
   Assigned: 2017-02-01
   License: BSD-3-Clause OR CC0-1.0
+  Version: 0.3.2
 </pre>
 
 ==Abstract==
@@ -275,3 +276,30 @@ A living list of deployment proposals can be found [[bip-0008/assignments.mediaw
 
 This document is dual licensed as BSD 3-clause, and Creative Commons CC0 1.0 Universal.
 
+==Changelog==
+* **0.3.2** (2021-02-17):
+** Make activation threshold configurable.
+** Reduce recommended threshold from 95% to 90%.
+** Update guidance for bit selection and naming conventions.
+** Clarify economic majority upgrade expectations.
+* **0.3.1** (2021-02-04):
+** Simplify pseudocode for MUST_SIGNAL validation check.
+* **0.3.0** (2021-02-02):
+** Make signaling during LOCKED_IN recommended instead of mandatory.
+** Allow some blocks to not signal during MUST_SIGNAL as long as threshold is met.
+* **0.2.0** (2020-10-17):
+** Replace FAILING state with MUST_SIGNAL phase.
+** Require startheight and timeoutheight to be at retarget boundaries.
+** Require timeoutheight to be at least 4032 blocks after startheight.
+** Add note about lockinontimeout=true peer connectivity.
+* **0.1.0** (2020-06-26):
+** Return document Draft status.
+** Fix timeout logic and state transition ordering.
+** Add minimum_activation_height parameter.
+** Update GBT section for MUST_SIGNAL state.
+** Add reference implementation link.
+** Fix pseudocode initialization bug.
+* **0.0.2** (2020-02-26):
+** Move to Rejected due to 3-year time-out.
+* **0.0.1** (2017-02-01):
+** Initial Draft published.

--- a/bip-0008.mediawiki
+++ b/bip-0008.mediawiki
@@ -3,11 +3,11 @@
   Title: Version bits with lock-in by height
   Authors: Shaolin Fry <shaolinfry@protonmail.ch>
            Luke Dashjr <luke+bip@dashjr.org>
-  Status: Draft
+  Status: Complete
   Type: Informational
   Assigned: 2017-02-01
   License: BSD-3-Clause OR CC0-1.0
-  Version: 0.3.2
+  Version: 1.0.0
 </pre>
 
 ==Abstract==
@@ -277,6 +277,8 @@ A living list of deployment proposals can be found [[bip-0008/assignments.mediaw
 This document is dual licensed as BSD 3-clause, and Creative Commons CC0 1.0 Universal.
 
 ==Changelog==
+* **1.0.0** (2026-08-03):
+** Advance to Complete.
 * **0.3.2** (2021-02-17):
 ** Make activation threshold configurable.
 ** Reduce recommended threshold from 95% to 90%.


### PR DESCRIPTION
BIP8 has not had significant updates since 2021, but continues to be relevant. E.g., the BIP110 activation appears to have been modeled on BIP8, and the Speedy Trial activation of Taproot was implemented based on BIP8.

I therefore posit that BIP8 should be advanced to Complete rather being in Draft status.

cc: @shaolinfry, @luke-jr as the BIP owners, but anyone’s review is welcome.