### PR TITLE
bip38: Advance to Deployed

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -211,13 +211,13 @@ users (see also: [https://en.bitcoin.it/wiki/Economic_majority economic majority
 | Mike Hearn, Matt Corallo
 | Specification
 | Deployed
-|-
+|- style="background-color: #cfffcf"
 | [[bip-0038.mediawiki|38]]
 | Applications
 | Passphrase-protected private key
 | Mike Caldwell, Aaron Voisine
 | Specification
-| Draft
+| Deployed
 |- style="background-color: #cfffcf"
 | [[bip-0039.mediawiki|39]]
 | Applications

--- a/bip-0038.mediawiki
+++ b/bip-0038.mediawiki
@@ -6,7 +6,7 @@
            Aaron Voisine <voisine@gmail.com>
   Comments-Summary: Unanimously Discourage for implementation
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0038
-  Status: Draft (Some confusion applies: The announcements for this never made it to the list, so it hasn't had public discussion)
+  Status: Deployed
   Type: Specification
   Assigned: 2012-11-20
   License: PD


### PR DESCRIPTION
BIP38 is in Draft, but there appear to be several projects that implement support, e.g.:

- [bitcoinjs](https://github.com/bitcoinjs/bip38)
- [BlueWallet](https://github.com/BlueWallet/BlueWallet/wiki/Supported-wallet-types)
- bitcoinaddress•org

As such, it seems outdated that the proposal is in Draft status, and I propose that it be advanced to [Deployed](https://github.com/bitcoin/bips/blob/master/bip-0003.md#deployed) instead.

cc: @casascius, @voisine