### PR TITLE
bip78: Advance to Deployed

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -442,13 +442,13 @@ users (see also: [https://en.bitcoin.it/wiki/Economic_majority economic majority
 | Dan Gould, Yuval Kogman
 | Specification
 | Draft
-|-
+|- style="background-color: #cfffcf"
 | [[bip-0078.mediawiki|78]]
 | Applications
 | A Simple Payjoin Proposal
 | Nicolas Dorier
 | Specification
-| Draft
+| Deployed
 |- style="background-color: #ffcfcf"
 | [[bip-0079.mediawiki|79]]
 | Applications

--- a/bip-0078.mediawiki
+++ b/bip-0078.mediawiki
@@ -3,7 +3,7 @@
   Layer: Applications
   Title: A Simple Payjoin Proposal
   Authors: Nicolas Dorier <nicolas.dorier@gmail.com>
-  Status: Draft
+  Status: Deployed
   Type: Specification
   Assigned: 2019-05-01
   License: BSD-2-Clause


### PR DESCRIPTION
According to the BIP78 itself, there are multiple projects that have implemented support for this proposal on mainnet:
https://github.com/bitcoin/bips/blob/master/bip-0078.mediawiki#implementations

It therefore seems appropriate to advance BIP78 to Deployed.

cc: @NicolasDorier