### PR TITLE
bip1: Record close reason

### DIFF
--- a/bip-0001.mediawiki
+++ b/bip-0001.mediawiki
@@ -177,6 +177,9 @@ This document was derived heavily from Python's PEP-0001. In many places text wa
 
 ==Changelog==
 
-10 Oct 2015 - Added clarifications about submission process and BIP number assignment.
-
-01 Jan 2016 - Clarified early stages of BIP idea championing, collecting community feedback, etc.
+* 2016-12-14:
+** Closed: [https://github.com/bitcoin/bips/pull/478 Superseded by BIP2]
+* 2016-01-01:
+** Clarified early stages of BIP idea championing, collecting community feedback, etc.
+* 2015-10-10:
+** Added clarifications about submission process and BIP number assignment.


### PR DESCRIPTION
This commit forgoes introducing a version, as the BIP has been closed for a decade and it is no longer necessary to update the readers regarding specification changes of BIP1.