### PR TITLE
bip10: Record Withdrawal in Changelog

### DIFF
--- a/bip-0010.mediawiki
+++ b/bip-0010.mediawiki
@@ -95,6 +95,13 @@ The style of communication is taken directly from PGP/GPG, which uses blocks of 
 
 A party receiving this TxDP can simply add their signature to the appropriate _TXINPUT_ line.  If that is the last signature required, they can broadcast it themselves.  Any software that implements this standard should be able to combine multiple TxDPs into a single TxDP.  However, even without the programmatic support, a user could manually combine them by copying the appropriate _SIG_ lines between serializations, though it is not the recommended method for combining TxDPs.
 
+== Changelog ==
+
+* 2014-11-26:
+** Withdrawn after Armory stopped using BIP10 and no other projects were known to implement support (see [https://github.com/bitcoin/bips/pull/125 bips#125]).
+* 2011-10-28:
+** Original Draft published.
+
 == Reference Implementation ==
 
 This proposal was implemented and tested in the older versions of ''Armory'' Bitcoin software for use in offline-wallet transaction signing (as a 1-of-1 transaction). Implementation can be found in https://github.com/etotheipi/BitcoinArmory/blob/v0.91-beta/armoryengine/Transaction.py under the class PyTxDistProposal. However, as of version 0.92 released in July 2014, Armory no longer uses this proposal for offline wallet transaction signing and has moved on to a new format.


### PR DESCRIPTION
BIP10 was withdrawn per #125 after Armory stopped using it and no other projects were known to implement support.