### PR TITLE
docs: improve clarity in BIP-451 RPC reference

### DIFF
--- a/bip-0451.md
+++ b/bip-0451.md
@@ -214,7 +214,7 @@ The implementation provides:
 - Automatic dust detection based on a configurable amount threshold
 - Transaction batching via RBF
 - Support for P2PKH, P2SH, P2WPKH, P2WSH, and P2TR input descriptors
-- Integration with Bitcoin Core (version 31.0+) via RPC for syncing and broadcasting transactions
+- Integration with Bitcoin Core (version 31.0+) via the RPC interface for syncing and broadcasting transactions
 
 ## Test Cases
 


### PR DESCRIPTION
## Description
Improved clarity of RPC interface reference in BIP-451 for better readability.

## Changes
- Changed "via RPC" to "via the RPC interface" for clarity

## Files Modified
- `bip-0451.md`

## Testing
- Documentation-only change
- Improves technical clarity