### PR TITLE
bip-85: add example use for age key derivation

### DIFF
--- a/bip-0085.mediawiki
+++ b/bip-0085.mediawiki
@@ -282,6 +282,44 @@ INPUT:
 OUTPUT
 * DERIVED ENTROPY=492db4698cf3b73a5a24998aa3e9d7fa96275d85724a91e71aa2d645442f878555d078fd1f1f67e368976f04137b1f7a0d19232136ca50c44614af72b5582a5c
 
+====<code>age</code> file encryption keys====
+
+A 32-byte HEX-application output at <code>m/83696968'/128169'/32'/{index}'</code> is a
+cryptographically random value usable directly as the secret key of an
+[https://age-encryption.org/v1 age] file-encryption identity. age has two identity flavours;
+both encode this 32-byte seed, and the matching recipient (public key) is derived from it:
+
+{| class="wikitable"
+! Flavour !! Role !! HRP !! Bech32-encoded payload
+|-
+| classic (X25519) || identity || <code>AGE-SECRET-KEY-</code> || the 32-byte seed
+|-
+| classic (X25519) || recipient || <code>age</code> || <code>X25519(seed, G)</code>, 32 bytes
+|-
+| post-quantum (X-Wing) || identity || <code>AGE-SECRET-KEY-PQ-</code> || the same 32-byte seed
+|-
+| post-quantum (X-Wing) || recipient || <code>age1pq</code> || X-Wing encapsulation key, 1216 bytes
+|}
+
+Every string above is Bech32 (BIP-173) of the form <code>HRP || "1" || encode(payload) || checksum</code>.
+<code>G</code> is the Curve25519 base point, so <code>X25519(seed, G)</code> is the classic
+recipient's public key. For the post-quantum flavour (age v1.3.0+), X-Wing SHAKE256-expands the
+seed into its ML-KEM-768 and X25519 components, and the recipient encodes the resulting
+1216-byte X-Wing encapsulation key.
+
+INPUT:
+* MASTER BIP32 ROOT KEY: xprv9s21ZrQH143K2LBWUUQRFXhucrQqBpKdRRxNVq2zBqsx8HVqFk2uYo8kmbaLLHRdqtQpUm98uKfu3vca1LqdGhUtyoFnCNkfmXRyPXLjbKb
+* PATH: m/83696968'/128169'/32'/0'
+
+OUTPUT:
+* DERIVED ENTROPY=ea3ceb0b02ee8e587779c63f4b7b3a21e950a213f1ec53cab608d13e8796e6dc
+* DERIVED AGE IDENTITY (classic)=AGE-SECRET-KEY-1AG7WKZCZA689SAMECCL5K7E6Y854PGSN78K98J4KPRGNAPUKUMWQWNNT4U
+* DERIVED AGE RECIPIENT (classic)=age1m0hhzxelxsxnxm4ennvdpk75j8s7mn5w4tt3e4ntug5qx256wslqmdz8e9
+* DERIVED AGE IDENTITY (PQ)=AGE-SECRET-KEY-PQ-1AG7WKZCZA689SAMECCL5K7E6Y854PGSN78K98J4KPRGNAPUKUMWQ5AN2M5
+* DERIVED AGE RECIPIENT (PQ) SHA-256 (of the 1959-char bech32 string, no trailing newline)=855bd04ee0cd6cfdf5717fb946d859824a79fbbdf6304dadcc11dbb91abe0df6
+
+A reference implementation is [https://github.com/dmonakhov/age-keygen-det age-keygen-det].
+
 ===PWD BASE64===
 Application number: 707764'
 

--- a/bip-0085.mediawiki
+++ b/bip-0085.mediawiki
@@ -282,6 +282,47 @@ INPUT:
 OUTPUT
 * DERIVED ENTROPY=492db4698cf3b73a5a24998aa3e9d7fa96275d85724a91e71aa2d645442f878555d078fd1f1f67e368976f04137b1f7a0d19232136ca50c44614af72b5582a5c
 
+====<code>age</code> file encryption keys====
+
+A 32-byte HEX-application output at <code>m/83696968'/128169'/32'/{index}'</code> is a
+cryptographically random value usable directly as the secret key of an
+[https://age-encryption.org/v1 age] file-encryption identity. age has two identity flavors.
+Both encode a 32-byte seed. The matching recipient (public key) is derived from the seed as follows:
+
+{| class="wikitable"
+! Flavor !! Role !! HRP !! Bech32-encoded payload
+|-
+| classic (X25519) || identity || <code>AGE-SECRET-KEY-</code> || 32-byte seed
+|-
+| classic (X25519) || recipient || <code>age</code> || <code>X25519(seed, G)</code>, 32 bytes
+|-
+| post-quantum (X-Wing) || identity || <code>AGE-SECRET-KEY-PQ-</code> || 32-byte seed
+|-
+| post-quantum (X-Wing) || recipient || <code>age1pq</code> || X-Wing encapsulation key, 1216 bytes
+|}
+
+A given index SHOULD be used with only one flavor: a cryptographically-relevant quantum computer
+could recover the seed from the published classic recipient <code>X25519(seed, G)</code> and
+thereby also compromise the post-quantum identity derived from the same seed.
+
+Every string above takes the form <code>HRP || "1" || encode(payload) || checksum</code>, using the
+Bech32 (BIP-173) character set and checksum but without Bech32's 90-character length limit.
+<code>G</code> is the Curve25519 base point, so <code>X25519(seed, G)</code> is the classic
+recipient's public key. For the post-quantum flavor (age v1.3.0+), X-Wing SHAKE256-expands the
+seed into its ML-KEM-768 and X25519 components, and the recipient encodes the resulting
+1216-byte X-Wing encapsulation key.
+
+INPUT:
+* MASTER BIP32 ROOT KEY: xprv9s21ZrQH143K2LBWUUQRFXhucrQqBpKdRRxNVq2zBqsx8HVqFk2uYo8kmbaLLHRdqtQpUm98uKfu3vca1LqdGhUtyoFnCNkfmXRyPXLjbKb
+* PATH: m/83696968'/128169'/32'/0'
+
+OUTPUT:
+* DERIVED ENTROPY=ea3ceb0b02ee8e587779c63f4b7b3a21e950a213f1ec53cab608d13e8796e6dc
+* DERIVED AGE IDENTITY (classic)=AGE-SECRET-KEY-1AG7WKZCZA689SAMECCL5K7E6Y854PGSN78K98J4KPRGNAPUKUMWQWNNT4U
+* DERIVED AGE RECIPIENT (classic)=age1m0hhzxelxsxnxm4ennvdpk75j8s7mn5w4tt3e4ntug5qx256wslqmdz8e9
+* DERIVED AGE IDENTITY (PQ)=AGE-SECRET-KEY-PQ-1AG7WKZCZA689SAMECCL5K7E6Y854PGSN78K98J4KPRGNAPUKUMWQ5AN2M5
+* DERIVED AGE RECIPIENT (PQ) SHA-256 (of the 1959-char bech32 string, no trailing newline)=855bd04ee0cd6cfdf5717fb946d859824a79fbbdf6304dadcc11dbb91abe0df6
+
 ===PWD BASE64===
 Application number: 707764'
 


### PR DESCRIPTION
## Motivation

[age](https://age-encryption.org/v1) is a widely-deployed file-encryption format. Both its classic (X25519, since 2021)
and post-quantum (X-Wing / HPKE-MLKEM768-X25519, age v1.3.0+ Dec 2024) identity types take a 32-byte uniform seed as the secret-key material — which is precisely what BIP-85's HEX application at `num_bytes=32` already returns.

This PR adds a brief example-use subsection at the end of the HEX application section, documenting how to interpret the existing 32-byte HEX output as an age identity. **No new application number, no normative MUSTs added, no changes required in existing implementations** — the HEX application already produces exactly what age consumes; this PR just records the connection in the spec.

Documenting this gives users a single backup story: the same BIP-39 mnemonic that already secures their Bitcoin wallets can deterministically produce age identities, with no additional key-rotation infrastructure on top of what they already do.

It also unblocks downstream hardware-wallet firmware integration  maintainers of firmware projects accept "implement this BIP-85 use case" much more readily than "implement a convention from a third-party repo." A spec-blessed convention turns the conversation from a bespoke contribution into a standards-conformance issue.

## What changes

A new `====<code>age</code> file encryption keys====` subsection at
the end of the `===HEX===` section in `bip-0085.mediawiki`.

The subsection:
- Describes the bech32 encoding for both classic and PQ age   identities + their corresponding recipients.
- Adds a worked test vector using the **same master xprv** as  the existing HEX test vector, so a reader can derive both side-by-side from one master.

## Scope

This amendment is intentionally minimal:

- **No new application number** — reuses the existing HEX
  application (128169').
- **No normative MUSTs** added beyond what BIP-85 already says
  about the HEX application.
- **No changes required** in existing implementations
  ([bipsea](https://github.com/akarve/bipsea),   [bip85-js](https://github.com/hoganri/bip85-js),   [ethankosakovsky/bip85](https://github.com/ethankosakovsky/bip85)).

Possible follow-ups (**not** in this PR):

- A dedicated `AGE` subsection paralleling the existing RSA-GPG  subsection, with full worked examples for each flavour and an   optional index-partition recommendation (e.g. `[0, 1000)` for   PQ identities, `[1000, 2000)` for classic identities, to avoid  producing the same 32 bytes under two different HRPs when the  same master is used for both flavours).
- A dedicated application number for age (e.g. `0x616765'` = hex-pack of ASCII "age"), with independent paths per flavour.

These are noted only to clarify that this PR deliberately picks the minimal form; they can be raised separately if there is appetite.

## Implementations

Per review, the spec text does not link a reference implementation.
A follow-up PR extending [bipsea](https://github.com/akarve/bipsea)
with age derivation is planned.

## Open question

Should the subsection also include the index-range partition guidance (`[0, 1000)` for PQ identities, `[1000, 2000)` for classic identities) to avoid producing the same 32 bytes under two different HRPs when both flavours are derived from one master? Including it would be useful guidance; excluding it keeps the amendment maximally minimal. Open to reviewer preference.

---

cc @ethankosakovsky @akarve — original BIP-85 authors per the
BIP header. Happy to revise based on review feedback.