### PR TITLE
Split BIP54 into bundle constituents

### DIFF
--- a/bip-0054.md
+++ b/bip-0054.md
@@ -8,159 +8,102 @@
   Type: Specification
   Assigned: 2025-04-11
   License: CC0-1.0
+  Requires: 53, TBD-1, TBD-2, TBD-3
 ```
 
 ## Abstract
 
-This document proposes new consensus rules in order to fix the timewarp attack, reduce the worst
-case block validation time, prevent Merkle tree weaknesses, and avoid duplicate transactions without
-[bip-0030][BIP30] validation.
+This document specifies Consensus Cleanup, a bundle soft fork that activates four independent
+consensus cleanups together:
+
+- [BIP 53](bip-0053.mediawiki), which disallows 64-byte transactions;
+- [TBD-1](bip-tbd-1.md), which constrains timestamps at difficulty adjustment boundaries;
+- [TBD-2](bip-tbd-2.md), which limits legacy signature operations per transaction;
+- [TBD-3](bip-tbd-3.md), which prevents duplicate coinbase transactions without BIP 30 validation.
+
+Together, these changes fix the timewarp attack, reduce the worst case block validation time,
+prevent Merkle tree weaknesses, and avoid duplicate transactions without [BIP 30][BIP30]
+validation.
 
 ## Motivation
 
-This proposal addresses a number of long-standing vulnerabilities and weaknesses in the Bitcoin
-protocol. Bundling these fixes together amortizes the fixed cost of deploying a Bitcoin soft fork.
+The Bitcoin protocol has several long-standing vulnerabilities and weaknesses that can be addressed
+by tightening existing consensus rules. Bundling these fixes together amortizes the fixed cost of
+deploying a Bitcoin soft fork while leaving the design, review, and implementation details of each
+constituent rule in its own BIP.
 
-The [timewarp bug][SE timewarp] makes it possible for a majority-hashrate attacker to arbitrarily
-lower mining difficulty, and therefore arbitrarily increase the block rate. In the worst case, an
-attacker can bring down the difficulty to its minimum within 38 days of starting the attack. Besides
-empowering a 51% attacker, the presence of this bug makes it harder to reason about miners'
-incentives. Accelerating the block rate allows an attacker to steal block subsidy from future
-miners and increases available block space. It may be in the interest of short-sighted users and
-miners to exploit this vulnerability to materially increase the block rate without fatally hurting
-the network.
+[TBD-1](bip-tbd-1.md) fixes the [timewarp bug][SE timewarp], which makes it possible for a
+majority-hashrate attacker to arbitrarily lower mining difficulty and increase the block rate. It
+also prevents the related Murch-Zawy negative-time-period vulnerability.
 
-Specially crafted blocks may be expensive to process, [taking up to][Delving worst block] several
-minutes to validate even on high-end devices, and up to a few hours on lower-end devices. Long block
-validation times are a nuisance to users, increasing the cost to independently fully validate the
-consensus rules. In addition they can be used by miners to attack their competition, creating
-perverse incentives, centralization pressures and leading to reduced network security.
+[TBD-2](bip-tbd-2.md) bounds the legacy signature operation work a transaction can impose during
+block validation. This mitigates specially crafted blocks that can take several minutes to validate
+on high-end devices and much longer on lower-end devices.
 
-In computing a block's Merkle root, a transaction with exactly 64 bytes of non-witness data can be
-interpreted both as an intermediate node in the tree and as a leaf in the tree. This makes it
-possible to trick an SPV verifier into accepting an inclusion proof for a transaction that is not
-part of a block, by pretending a 64-byte block transaction is actually an inner node[^9]. Invalidating
-64-byte transactions addresses this vulnerability without requiring users of SPV verifiers, or
-any other user of Merkle proofs, to rely on one of the available workarounds[^13] or even to know one is
-necessary in the first place.
+[BIP 53](bip-0053.mediawiki) disallows transactions whose witness-stripped serialized size is
+exactly 64 bytes. Such transactions can be interpreted both as Merkle tree leaves and as intermediate
+nodes, which creates weaknesses for Merkle proof users and complexity for full node implementations.
 
-Since [bip-0034][BIP34] activation, explicit [bip-0030][BIP30] validation is not necessary until
-block height 1,983,702[^0]. Resuming [bip-0030][BIP30] validation would unnecessarily increase block
-validation overhead and preclude alternative full node designs (such as [bip-0182][BIP182] Utreexo).
-Enforcing that new coinbase transactions are different from the early [bip-0034][BIP34] violations
-makes it possible to get rid of [bip-0030][BIP30] validation forever.
+[TBD-3](bip-tbd-3.md) constrains coinbase transactions so that new coinbases cannot duplicate early
+[BIP 34][BIP34] violations. This permits implementations to avoid resuming explicit [BIP 30][BIP30]
+validation in the future.
 
 ## Specification
 
-For all blocks after activation the following new rules apply.
+For all blocks after activation, implementations must enforce the consensus rules specified by
+[BIP 53](bip-0053.mediawiki), [TBD-1](bip-tbd-1.md), [TBD-2](bip-tbd-2.md), and
+[TBD-3](bip-tbd-3.md).
 
-Given a block at height `N`:
-- if `N % 2016` is equal to 0, the timestamp of the block must be set to a value higher than or
-  equal to the value of the timestamp of block at height `N-1` minus 7200 (T<sub>N</sub> &ge;
-  T<sub>N−1</sub> − 7200);
-- if `N % 2016` is equal to 2015, the timestamp of the block must be set to a value higher than
-  or equal to the value of the timestamp of the block at height `N-2015` (T<sub>N</sub> &ge;
-  T<sub>N−2015</sub>).
-
-A limit is set on the number of signature operations present in the scripts used to validate a
-transaction. It applies to all transactions in the block except the coinbase transaction[^1]. For
-each input in the transaction, count the number of `CHECKSIG` and `CHECKMULTISIG` in the input
-scriptSig and previous output's scriptPubKey, including the P2SH redeemScript. If the total summed
-over all transaction inputs is strictly higher than 2500, the transaction is invalid. The accounting is the
-same as for [bip-0016][BIP16 specs], evaluating the scriptSig, scriptPubKey, and P2SH redeemScript
-separately:
-
-1. `CHECKSIG` and `CHECKSIGVERIFY` count as 1 signature operation, whether or not they are evaluated.
-2. `CHECKMULTISIG` and `CHECKMULTISIGVERIFY` immediately preceded by `OP_1` through `OP_16` are counted as 1 to 16 signature operations, whether or not they are evaluated.
-3. All other `CHECKMULTISIG` and `CHECKMULTISIGVERIFY` are counted as 20 signature operations, whether or not they are evaluated.
-
-Transactions whose witness-stripped serialized size is exactly 64 bytes are invalid.
-
-The coinbase transaction's `nLockTime` field must be set to the height of the block minus 1[^2]
-and its `nSequence` field must not be equal to 0xffffffff.
+A block is valid under this BIP only if it satisfies all four constituent BIPs. This BIP defines no
+additional block validity rules beyond simultaneous activation of the four required BIPs.
 
 ## Rationale
 
-The restrictions on the timestamp of the first and last blocks of a difficulty adjustment period fix
-the timewarp and Murch–Zawy vulnerabilities[^3]. The latter poses mostly theoretical concerns but is
-extremely low risk to fix: the duration of an adjustment period has never been, and should never be,
-negative. The former is fixed by preventing the timestamp of the first block of a difficulty period
-from being lower than the previous block's, with a two-hour grace period. A [previous
-proposal][BIP-XXXX] to fix the timewarp attack used a ten-minute grace period instead, and this
-approach has been adopted for [testnet4][BIP94 timewarp]. Out of an abundance of caution and because it only trivially worsens the
-block rate increase under attack, a two-hour grace period is used here[^4].
+Each constituent BIP can be reviewed, implemented, and reasoned about independently. This BIP exists
+to specify the combined deployment: the four rules are activated together because each addresses a
+long-standing consensus weakness and the operational cost of a soft fork is dominated by deployment,
+not by the number of narrowly scoped restrictions included in the deployment.
 
-Disabling some Script operations and functionalities was [previously proposed][BIP-XXXX] to reduce
-the worst case block validation time but was met with resistance due to confiscation concerns[^5]. A
-delicate balance needs to be struck between minimizing the confiscation risks of a mitigation, even
-if merely theoretical, and bounding the costs one could impose on all other users of the system. To
-that end, limiting potentially executed signature operations targets the exact harmful behaviour while
-preserving maximal flexibility in Script usage.
-Such a limit reduces the worst case block validation time by a factor of 40 and drastically
-increases the preparation cost of an attack, making it uneconomical for a miner[^6]. The maximum of
-2500 was chosen as the tightest value that did not make any non-pathological standard transaction
-invalid[^7].
-
-64-byte transactions can only contain a scriptPubKey that lets anyone spend the funds, or one that
-burns them. They have also been non-standard since 2019 and never been used since 2016.  Several
-alternatives to invalidating them were previously proposed. Some believe the improvements for users
-of Merkle proofs are too marginal to be worth introducing a discontinuity in the set of valid
-witness-stripped transaction sizes. Others have suggested instead committing to the Merkle
-tree depth in the header's version field[^8], which would make one workaround for a known
-vulnerability easier to deploy. The authors believe it is preferable to address the root cause by
-invalidating 64-byte transactions, fixing the vulnerability without Merkle proof users having to
-rely on any workaround or even know one is necessary in the first place. See [this post][64 bytes
-debate] for an attempt at summarizing the arguments for both sides of this debate.
-
-The `nLockTime` field of transactions is a natural place to store a block height and is currently
-unused in coinbase transactions. Using it to enforce that new coinbase transactions differ from
-early [bip-0034][BIP34] violations also allows applications to recover the block height without
-having to parse Script. Leveraging the existing timelock mechanism makes the check self-contained:
-the same coinbase transaction cannot have been valid in a previous block[^11]. This simplifies both
-reasoning and client implementation, since the [bip-0030][BIP30] check can be skipped entirely past
-Consensus Cleanup activation, regardless of the [bip-0034][BIP34] activation status[^12]. One person
-[raised the concern][miningdev nLockTime] that the `nLockTime` field would be an ideal extranonce
-for ASIC controllers if such controllers ever became a bottleneck in mining operations. Others
-[replied][miningdev nLockTime] that the same benefits could be achieved by using a dummy output
-instead, should that ever become necessary. The authors [believe][ML remaining concerns] the
-benefits of using `nLockTime` to differentiate coinbase transactions outweigh the theoretical
-cost of making it unavailable for extranonce rolling by ASIC controllers.
+The bundle does not create dependencies between the constituent rules. If one of the required BIPs
+is changed before deployment, this BIP inherits that change through the `Requires` relationship.
 
 ## Backward compatibility
 
 This proposal only tightens the block validation rules: there is no block that is valid under the
-rules proposed in this BIP but not under the existing Bitcoin consensus rules. As a consequence
+rules proposed in this BIP but not under the existing Bitcoin consensus rules. As a consequence,
 these changes are backward-compatible with non-upgraded node software. That said, the authors
 strongly encourage node operators to upgrade in order to fully validate all consensus rules.
 
 ## Miner forward compatibility
 
 Bitcoin Core version [29.0][Core 29.0] and later will not generate a block template that violates
-the timestamp restrictions introduced in this BIP. Although it would be extremely unlikely due to
-the grace period used in this proposal, miners should use the `curtime` or `mintime` field from the
-`getblocktemplate` result for their block's timestamp to make sure they always create blocks valid
-according to this proposal. Note this is not a new requirement: using a timestamp lower than the
-`mintime` field from the `getblocktemplate` result already leads to creating an invalid block.
+the timestamp restrictions introduced in [TBD-1](bip-tbd-1.md). Although it would be extremely
+unlikely due to the grace period used in that proposal, miners should use the `curtime` or `mintime`
+field from the `getblocktemplate` result for their block's timestamp to make sure they always create
+blocks valid according to this proposal. Note this is not a new requirement: using a timestamp lower
+than the `mintime` field from the `getblocktemplate` result already leads to creating an invalid
+block.
 
 Bitcoin Core version [30.0][Core 30.0] and later will not generate a block template including a
-transaction that violates the signature operations limit introduced in this BIP.
+transaction that violates the signature operations limit introduced in [TBD-2](bip-tbd-2.md).
 
 Bitcoin Core version [0.16.1][Core 0.16.1] and later will neither relay nor create block templates
-that include transactions whose witness-stripped serialized size is exactly 64 bytes.
+that include transactions whose witness-stripped serialized size is exactly 64 bytes, as disallowed
+by [BIP 53](bip-0053.mediawiki).
 
 The coinbase transaction is usually crafted by mining pool software. To the best of the authors'
 knowledge, there does not exist an open source reference broadly in use today for such software.
 We encourage mining pools to update their software to craft coinbase transactions that are
-forward-compatible with the changes proposed in this BIP.
+forward-compatible with [TBD-3](bip-tbd-3.md).
 
 ## Reference implementation
 
-An implementation of BIP54 for Bitcoin Core is available [here][Core BIP 54 implem].
+An implementation of BIP 54 for Bitcoin Core is available [here][Core BIP 54 implem].
 
 ## Test vectors
 
-Documented test vectors are available [here](./bip-0054/test_vectors/) for all mitigations
-introduced in this BIP.
+Documented test vectors are available [here](./bip-0054/test_vectors/) for all constituent rules
+activated by this BIP.
 
 ## Acknowledgements
 
@@ -170,7 +113,8 @@ The authors would like to thank everyone involved in researching the most approp
 each of these bugs. We would like to thank in particular Anthony Towns and Sjors Provoost for their
 direct contributions to this proposal, as well as @0xb10c and Brian Groll for providing the authors
 with data to analyze the proposed mitigations. Thanks to Chris Stewart for digging up historical
-violations to the new transaction size rule, which are partially reused in this BIP's test vectors.
+violations to the 64-byte transaction size rule, which are partially reused in this BIP's test
+vectors.
 
 ## Copyright
 
@@ -178,89 +122,16 @@ This document is licensed under the Creative Commons CC0 1.0 Universal license.
 
 ## Changelog
 
+* __1.1.0__ (2026-05-23):
+    * Split the constituent consensus changes into individual BIPs and made this document a bundle BIP.
 * __1.0.0__ (2026-05-22):
     * Complete planned work on the BIP.
 
-
-[^0]: Block 1,983,702 is the earliest future block which could contain a duplicate coinbase
-transaction while still respecting [bip-0034][BIP34]. See [this post][Delving duplicable] for a list
-of all such future blocks.
-[^1]: Technically this limit *cannot* apply to a coinbase transaction as the size of its sole
-input's scriptSig is limited.
-[^2]: The locktime validation, which is also performed for coinbase transactions, enforces that the
-nLockTime value is the last block at which a transaction is invalid, not the first one at which it
-is valid.
-[^3]: The timewarp attack is described [here][SE timewarp] and the Murch–Zawy attack [here][Delving
-Murch-Zawy].
-[^4]: The testnet4 difficulty exception pushed blocks' timestamps in the future when abused,
-revealing how some broken pool software may produce blocks that don't respect a 10 minutes grace
-period. Some [raised concerns][Sjors grace period] similarly broken software might be used on
-mainnet. Using a grace period of 2 hours instead of 10 minutes only reduces the expected block
-interval time under attack by ~2.2 seconds. See [this post][grace period debate summary] for more.
-[^5]: The argument is about someone having a timelocked presigned transaction using some of those
-features in its output script. The transaction cannot be mined before activation. Such outputs would
-not be covered by an amnesty for old UTxOs. See for instance [here][O'Connor OP_CODESEPARATOR] and
-[here][O'Connor sighash type] for discussions on this topic.
-[^6]: It is important to reduce the worst case block validation time as well as the ratio of
-validation time imposed over preparation cost. The former is to limit the damages an externally
-motivated attacker can do. The latter is to disincentivize miners slowing down their competition by
-mining expensive blocks. See [this thread][ML thread validation time] for more.
-[^7]: A non-pathological transaction would have a public key per signature operation and at least
-one signature per input. Per standardness a single P2SH input may not have more than 15 signature
-operations. Even by using 1-of-15 `CHECKMULTISIG`s a transaction would bump against the maximum
-standard transaction size before running into the newly introduced limit. To run against the newly
-introduced limit but not the transaction size a transaction would need to spend P2SH inputs with a
-redeem script similar to `CHECKSIG DROP CHECKSIG DROP ...`. This type of redeem script serves no
-purpose beyond increasing its validation cost, which is exactly what this proposal aims to mitigate.
-[^8]: By Sergio Demian Lerner in a [blog post][Sergio post].
-[^9]: Conversely, pretending that the inner nodes on one level of the tree are the actual block
-transactions is another source of complexity for full node implementations, which previously
-resulted in consensus bugs. For instance, Bitcoin Core versions between 0.13.0 and 0.13.2
-implemented caching that made it vulnerable to this attack. See [this writeup][Suhas Merkle] by
-Suhas Daftuar for a detailed explanation. Invalidating 64-byte transactions may avoid this risk, but
-the issue is largely orthogonal to this proposal: it is fundamentally about caching validation
-status for malleable blocks.
-[^11]: Technically it could be argued a duplicate could in principle always be possible before block
-31,001 when `nLockTime` enforcement [was originally soft-forked][Harding nLockTime]. But treating
-coinbase transactions as not having duplicate past Consensus Cleanup activation would be consistent
-for any implementation which enforces `nLockTime` from the genesis block, which is the behaviour
-notably of Bitcoin Core but also of all other implementations the authors are aware of.
-[^12]: For instance Bitcoin Core only disables [bip-0030][BIP30] validation for a specific chain
-where [bip-0034][BIP34] violations have been manually inspected (see [here][Core validation.cpp
-BIP34]). Without the guarantee given by enforcing the timelock on coinbase transactions, this would
-have to be perpetuated for the Consensus Cleanup.
-[^13]: The authors are aware of three workarounds for SPV verifiers. The first is to request a
-Merkle proof for the coinbase transaction in addition to the transaction of interest, to infer the
-depth of the Merkle tree. The second is to reject Merkle proofs in which any inner node is also a
-valid serialisation of a Bitcoin transaction. More details about these are available [here][Sergio
-post]. A third workaround is to change the Merkle proof structure by requiring inner nodes to be
-provided as the single-SHA256 of their preimage, instead of the double-SHA256. See [here][Sergio
-MERKLEBLOCK] for a full description.
-
-[Delving worst block]: https://delvingbitcoin.org/t/great-consensus-cleanup-revival/710/93
 [BIP30]: https://github.com/bitcoin/bips/blob/master/bip-0030.mediawiki
-[BIP182]: https://github.com/bitcoin/bips/pull/1923
-[BIP-XXXX]: https://github.com/TheBlueMatt/bips/blob/7f9670b643b7c943a0cc6d2197d3eabe661050c2/bip-XXXX.mediawiki
 [BIP34]: https://github.com/bitcoin/bips/blob/master/bip-0034.mediawiki
-[BIP16 specs]: https://github.com/bitcoin/bips/blob/master/bip-0016.mediawiki#specification
 [SE timewarp]: https://bitcoin.stackexchange.com/questions/75831/what-is-time-warp-attack-and-how-does-it-work-in-general/75834#75834
-[Delving Murch-Zawy]: https://delvingbitcoin.org/t/zawy-s-alternating-timestamp-attack/1062#variant-on-zawys-attack-2
-[BIP94 timewarp]: https://github.com/bitcoin/bips/blob/master/bip-0094.mediawiki#time-warp-fix
-[Sjors grace period]: https://delvingbitcoin.org/t/timewarp-attack-600-second-grace-period/1326
-[grace period debate summary]: https://delvingbitcoin.org/t/great-consensus-cleanup-revival/710/66
-[O'Connor OP_CODESEPARATOR]: https://gnusha.org/pi/bitcoindev/CAMZUoKneArC+YZ36YFwxNTKsDtJhEz5P2cosXKxJS8Rf_3Nyuw@mail.gmail.com
-[O'Connor sighash type]: https://gnusha.org/pi/bitcoindev/CAMZUoK=1kgZLR1YZ+cJgzwmEOwrABYFs=2Ri=xGX=BCr+w=VQw@mail.gmail.com
-[ML thread validation time]: https://gnusha.org/pi/bitcoindev/VsltJ2PHqWfzG4BU9YETTXjL7fYBbJhjVXKZQyItemySIA1okvNee9kf0zAOyLMeJ4Nqv1VOrYbWns5nP4TANCWvPJYu1ew_yxQSaudizzk=@protonmail.com
-[Suhas Merkle]: https://gnusha.org/pi/bitcoindev/CAFp6fsGtEm9p-ZQF_XqfqyQGzZK7BS2SNp2z680QBsJiFDraEA@mail.gmail.com
-[Sergio post]: https://bitslog.com/2018/06/09/leaf-node-weakness-in-bitcoin-merkle-tree-design
-[Sergio MERKLEBLOCK]: https://bitslog.com/2018/08/21/simple-change-to-the-bitcoin-merkleblock-command-to-protect-from-leaf-node-weakness-in-transaction-merkle-tree/
-[64 bytes debate]: https://delvingbitcoin.org/t/great-consensus-cleanup-revival/710/41
-[Harding nLockTime]: https://bitcoin.stackexchange.com/questions/90229/nlocktime-in-bitcoin-core
-[Delving duplicable]: https://delvingbitcoin.org/t/great-consensus-cleanup-revival/710/4
+[BIP-XXXX]: https://github.com/TheBlueMatt/bips/blob/7f9670b643b7c943a0cc6d2197d3eabe661050c2/bip-XXXX.mediawiki
 [Core 0.16.1]: https://bitcoincore.org/en/releases/0.16.1
 [Core 29.0]: https://bitcoincore.org/en/releases/29.0
-[Core BIP 54 implem]: https://github.com/darosior/bitcoin/tree/bip54
 [Core 30.0]: https://bitcoincore.org/en/releases/30.0
-[Core validation.cpp BIP34]: https://github.com/bitcoin/bitcoin/blob/390e7d61bd531505bb3d13f38316c282b85ed1dd/src/validation.cpp#L2401-L2459
-[miningdev nLockTime]: https://groups.google.com/g/bitcoinminingdev/c/jlqlNHHNSNk
-[ML remaining concerns]: https://gnusha.org/pi/bitcoindev/UsKuvCXXhSAnNVx5a0K2UfP3srAr3slW9mcOjtYk9LnolaOXfWrW9jpqbxsQQPkyQuZogkhz2Hbfwii2VsTm79vRDpgKduxk35hpBu_t7Do=@protonmail.com/
+[Core BIP 54 implem]: https://github.com/darosior/bitcoin/tree/bip54

--- a/bip-0054/test_vectors/README.md
+++ b/bip-0054/test_vectors/README.md
@@ -1,7 +1,7 @@
 ## BIP54 test vectors
 
-This folder contains a set of test vectors for each mitigation introduced in the BIP. This document
-presents them in more detail.
+This folder contains a set of test vectors for each mitigation activated by the BIP54 bundle. This
+document presents them in more detail.
 
 The code used to generate half of the test vectors is included with the implementation and available
 [here][other-vectors]. The other half requires mining mainnet blocks and is [published
@@ -23,21 +23,21 @@ some of the last headers without having to re-generate the whole chain.
 ### Difficulty adjustment exploits
 
 The [`timestamps.json`](./timestamps.json) test vectors exercise the two constraints on block header
-timestamps introduced by BIP54 to mitigate the Timewarp and Murch-Zawy attacks. Each test case
+timestamps introduced by TBD-1 to mitigate the Timewarp and Murch-Zawy attacks. Each test case
 features a chain of mainnet headers starting from the genesis block, and whether this header chain
-is valid by BIP54 rules. Each test case also contains a comment describing why this particular chain
-is (in)valid according to BIP54.  All test cases are valid according to current Bitcoin consensus
-rules. It is intended to be used to test a BIP54 implementation by feeding the header chain to a
-Bitcoin node implementation, enforcing the BIP54 rules on this chain from genesis.
+is valid by TBD-1 rules. Each test case also contains a comment describing why this particular chain
+is (in)valid according to TBD-1. All test cases are valid according to current Bitcoin consensus
+rules. It is intended to be used to test a TBD-1 implementation by feeding the header chain to a
+Bitcoin node implementation, enforcing the TBD-1 rules on this chain from genesis.
 
 The test vector file features a JSON array of JSON objects, each corresponding to a test case. Each
 JSON object features the following entries:
 - `header_chain`: a JSON array of strings. An ordered list of hex-encoded mainnet block headers.
-- `valid`: a JSON boolean. Whether this chain of headers is valid according to BIP54.
+- `valid`: a JSON boolean. Whether this chain of headers is valid according to TBD-1.
 - `comment`: a JSON string. Description of the test case.
 
 For the purpose of testing a Timewarp fix, a Timewarp attack was included early on in the history of
-testnet3. An implementer of BIP54 may want to ensure that syncing testnet3 by enforcing BIP54 since
+testnet3. An implementer of TBD-1 may want to ensure that syncing testnet3 by enforcing TBD-1 since
 genesis will treat block `00000000118da1e2165a19307b86f87eba814845e8a0f99734dce279ca3fb029` as
 invalid.
 
@@ -45,14 +45,14 @@ invalid.
 ### Long block validation time
 
 The [`sigops.json`](sigops.json) file contains test vectors for the limit on the number of
-potentially-executed legacy signature operations in a single transaction, introduced by BIP54 in
+potentially-executed legacy signature operations in a single transaction, introduced by TBD-2 in
 order to mitigate long block validation times. Each test case represents a transaction and whether a
-block containing it would be valid according to BIP54. The test cases feature an extensive set of
+block containing it would be valid according to TBD-2. The test cases feature an extensive set of
 combinations of inputs and output types, ways to run into the limit, historical violations and some
 pathological transactions exhibiting the specific implementation details. All test cases but those
 belonging to this last category feature transactions that are valid under current Bitcoin consensus
 rules. Each test case also features a comment describing why the transaction is (in)valid according
-to BIP54.
+to TBD-2.
 
 The test vector file features a JSON array of JSON objects, each corresponding to a test case. Each
 JSON object features the following entries:
@@ -60,30 +60,30 @@ JSON object features the following entries:
   transaction outputs spent by each input of this test case's transaction.
 - `tx`: a JSON string. A hex-encoded Bitcoin-serialized transaction to be evaluated.
 - `valid`: a JSON boolean. Whether this transaction is valid according to current consensus rules
-  supplemented by BIP54.
+  supplemented by TBD-2.
 - `comment`: a JSON string. Description of the test case.
 
 
 ### Merkle tree malleability with 64-byte transactions
 
 The [`txsize.json`](./txsize.json) file contains test cases exercising the new constraint on
-non-witness transaction size introduced in BIP54. Each test case contains a transaction and whether
-it would be valid according to BIP54, as well as a comment describing why it is (in)valid. All test
+non-witness transaction size introduced in BIP53. Each test case contains a transaction and whether
+it would be valid according to BIP53, as well as a comment describing why it is (in)valid. All test
 cases are otherwise valid according to current Bitcoin consensus rules.
 
 The test vector file features a JSON array of JSON objects, each corresponding to a test case. Each
 JSON object features the following entries:
 - `tx`: a JSON string. A hex-encoded Bitcoin-serialized transaction to be evaluated.
-- `valid`: a JSON boolean. Whether this transaction is valid according to BIP54.
+- `valid`: a JSON boolean. Whether this transaction is valid according to BIP53.
 - `comment`: a JSON string. Description of the test case.
 
 
 ### Possibility of duplicate coinbase transactions
 
 The [`coinbases.json`](./coinbases.json) file contains test cases exercising the new restrictions on
-coinbase transactions introduced in BIP54 to prevent duplicate coinbase transactions without
+coinbase transactions introduced in TBD-3 to prevent duplicate coinbase transactions without
 resorting to BIP30 validation. Each test case contains a chain of mainnet blocks (including the
-genesis block), and whether this block chain is valid according to BIP54. All test cases are valid
+genesis block), and whether this block chain is valid according to TBD-3. All test cases are valid
 according to current Bitcoin's consensus rules, except one that features a block containing a
 coinbase transaction timelocked to a future block height.
 
@@ -91,7 +91,7 @@ The test vector file features a JSON array of JSON objects, each corresponding t
 JSON object features the following entries:
 - `block_chain`: a JSON array of strings. An ordered list of hex-encoded mainnet blocks.
 - `valid`: a JSON boolean. Whether this block chain is valid according to current Bitcoin consensus
-  rules supplemented by BIP54.
+  rules supplemented by TBD-3.
 - `comment`: a JSON string. Description of the test case.
 
 

--- a/bip-tbd-1.md
+++ b/bip-tbd-1.md
@@ -1,0 +1,105 @@
+```
+  BIP: TBD-1
+  Layer: Consensus (soft fork)
+  Title: Difficulty Period Timestamp Limits
+  Authors: Antoine Poinsot <mail@antoinep.com>
+           Matt Corallo <bips@bluematt.me>
+  Status: Complete
+  Type: Specification
+  Assigned: ?
+  License: CC0-1.0
+```
+
+## Abstract
+
+This document proposes consensus restrictions on block timestamps at the boundaries of each 2016-block
+difficulty adjustment period. These restrictions fix the timewarp attack and the Murch-Zawy
+negative-time-period vulnerability.
+
+## Motivation
+
+The [timewarp bug][SE timewarp] makes it possible for a majority-hashrate attacker to arbitrarily
+lower mining difficulty, and therefore arbitrarily increase the block rate. In the worst case, an
+attacker can bring down the difficulty to its minimum within 38 days of starting the attack. Besides
+empowering a 51% attacker, the presence of this bug makes it harder to reason about miners'
+incentives. Accelerating the block rate allows an attacker to steal block subsidy from future
+miners and increases available block space. It may be in the interest of short-sighted users and
+miners to exploit this vulnerability to materially increase the block rate without fatally hurting
+the network.
+
+The [Murch-Zawy attack][Delving Murch-Zawy] allows the duration of a difficulty adjustment period to
+become negative by manipulating the last block timestamp of the period. While the practical impact is
+mostly theoretical, it is straightforward to prevent at the same difficulty-period boundary where the
+timewarp mitigation applies.
+
+## Specification
+
+For all blocks after activation, the following new rules apply.
+
+Given a block at height `N` with timestamp T<sub>N</sub>:
+
+- if `N % 2016` is equal to 0, the timestamp of the block must be set to a value higher than or
+  equal to the value of the timestamp of block at height `N-1` minus 7200
+  (T<sub>N</sub> &ge; T<sub>N-1</sub> - 7200);
+- if `N % 2016` is equal to 2015, the timestamp of the block must be set to a value higher than
+  or equal to the value of the timestamp of the block at height `N-2015`
+  (T<sub>N</sub> &ge; T<sub>N-2015</sub>).
+
+## Rationale
+
+The restriction on the timestamp of the first block of a difficulty adjustment period fixes the
+timewarp vulnerability by preventing the first timestamp in the period from being much lower than the
+last timestamp in the preceding period. A two-hour grace period is provided to avoid invalidating
+blocks produced by software with minor timestamp inconsistencies.
+
+The restriction on the timestamp of the last block of a difficulty adjustment period fixes the
+Murch-Zawy vulnerability by ensuring that each retarget period has a non-negative duration.
+
+A [previous proposal][BIP-XXXX] to fix the timewarp attack used a ten-minute grace period instead,
+and this approach has been adopted for [testnet4][BIP94 timewarp]. Out of an abundance of caution
+and because it only trivially worsens the block rate increase under attack, a two-hour grace period
+is used here.[^1]
+
+## Backward compatibility
+
+This proposal only tightens the block validation rules: there is no block that is valid under the
+rules proposed in this BIP but not under the existing Bitcoin consensus rules. As a consequence,
+these changes are backward-compatible with non-upgraded node software. That said, the authors
+strongly encourage node operators to upgrade in order to fully validate all consensus rules.
+
+## Miner forward compatibility
+
+Bitcoin Core version [29.0][Core 29.0] and later will not generate a block template that violates
+the timestamp restrictions introduced in this BIP. Although it would be extremely unlikely due to
+the grace period used in this proposal, miners should use the `curtime` or `mintime` field from the
+`getblocktemplate` result for their block's timestamp to make sure they always create blocks valid
+according to this proposal. Note this is not a new requirement: using a timestamp lower than the
+`mintime` field from the `getblocktemplate` result already leads to creating an invalid block.
+
+## Reference implementation
+
+An implementation of this rule as part of BIP 54 is available [here][Core BIP 54 implem].
+
+## Test vectors
+
+Test vectors for this rule are available in [`timestamps.json`](./bip-0054/test_vectors/timestamps.json).
+
+## Copyright
+
+This document is licensed under the Creative Commons CC0 1.0 Universal license.
+
+[^1]: The testnet4 difficulty exception pushed blocks' timestamps in the future when abused,
+revealing how some broken pool software may produce blocks that don't respect a 10-minute grace
+period. Some [raised concerns][Sjors grace period] similarly broken software might be used on
+mainnet. Using a grace period of 2 hours instead of 10 minutes only reduces the expected block
+interval time under attack by approximately 2.2 seconds. See [this post][grace period debate
+summary] for more.
+
+[SE timewarp]: https://bitcoin.stackexchange.com/questions/75831/what-is-time-warp-attack-and-how-does-it-work-in-general/75834#75834
+[Delving Murch-Zawy]: https://delvingbitcoin.org/t/zawy-s-alternating-timestamp-attack/1062#variant-on-zawys-attack-2
+[BIP-XXXX]: https://github.com/TheBlueMatt/bips/blob/7f9670b643b7c943a0cc6d2197d3eabe661050c2/bip-XXXX.mediawiki
+[BIP94 timewarp]: https://github.com/bitcoin/bips/blob/master/bip-0094.mediawiki#time-warp-fix
+[Sjors grace period]: https://delvingbitcoin.org/t/timewarp-attack-600-second-grace-period/1326
+[grace period debate summary]: https://delvingbitcoin.org/t/great-consensus-cleanup-revival/710/66
+[Core 29.0]: https://bitcoincore.org/en/releases/29.0
+[Core BIP 54 implem]: https://github.com/darosior/bitcoin/tree/bip54

--- a/bip-tbd-2.md
+++ b/bip-tbd-2.md
@@ -1,0 +1,105 @@
+```
+  BIP: TBD-2
+  Layer: Consensus (soft fork)
+  Title: Legacy Sigops Transaction Limit
+  Authors: Antoine Poinsot <mail@antoinep.com>
+           Matt Corallo <bips@bluematt.me>
+  Status: Complete
+  Type: Specification
+  Assigned: ?
+  License: CC0-1.0
+```
+
+## Abstract
+
+This document proposes a per-transaction consensus limit on legacy signature operations. The limit
+reduces the worst case block validation time while preserving existing Script functionality.
+
+## Motivation
+
+Specially crafted blocks may be expensive to process, [taking up to][Delving worst block] several
+minutes to validate even on high-end devices, and up to a few hours on lower-end devices. Long block
+validation times are a nuisance to users, increasing the cost to independently fully validate the
+consensus rules. In addition, they can be used by miners to attack their competition, creating
+perverse incentives, centralization pressures, and leading to reduced network security.
+
+## Specification
+
+For all blocks after activation, a limit is set on the number of signature operations present in the
+scripts used to validate a transaction. It applies to all transactions in the block except the
+coinbase transaction.[^1]
+
+For each input in the transaction, count the number of `CHECKSIG` and `CHECKMULTISIG` operations in
+the input scriptSig and previous output's scriptPubKey, including the P2SH redeemScript. If the
+total summed over all transaction inputs is strictly higher than 2500, the transaction is invalid.
+The accounting is the same as for [BIP 16][BIP16 specs], evaluating the scriptSig, scriptPubKey, and
+P2SH redeemScript separately:
+
+1. `CHECKSIG` and `CHECKSIGVERIFY` count as 1 signature operation, whether or not they are evaluated.
+2. `CHECKMULTISIG` and `CHECKMULTISIGVERIFY` immediately preceded by `OP_1` through `OP_16` are counted as 1 to 16 signature operations, whether or not they are evaluated.
+3. All other `CHECKMULTISIG` and `CHECKMULTISIGVERIFY` operations are counted as 20 signature operations, whether or not they are evaluated.
+
+## Rationale
+
+Disabling some Script operations and functionalities was [previously proposed][BIP-XXXX] to reduce
+the worst case block validation time but was met with resistance due to confiscation concerns.[^2]
+A delicate balance needs to be struck between minimizing the confiscation risks of a mitigation,
+even if merely theoretical, and bounding the costs one could impose on all other users of the
+system. To that end, limiting potentially executed signature operations targets the exact harmful
+behaviour while preserving maximal flexibility in Script usage.
+
+Such a limit reduces the worst case block validation time by a factor of 40 and drastically
+increases the preparation cost of an attack, making it uneconomical for a miner.[^3] The maximum of
+2500 was chosen as the tightest value that did not make any non-pathological standard transaction
+invalid.[^4]
+
+## Backward compatibility
+
+This proposal only tightens the block validation rules: there is no block that is valid under the
+rules proposed in this BIP but not under the existing Bitcoin consensus rules. As a consequence,
+these changes are backward-compatible with non-upgraded node software. That said, the authors
+strongly encourage node operators to upgrade in order to fully validate all consensus rules.
+
+## Miner forward compatibility
+
+Bitcoin Core version [30.0][Core 30.0] and later will not generate a block template including a
+transaction that violates the signature operations limit introduced in this BIP.
+
+## Reference implementation
+
+An implementation of this rule as part of BIP 54 is available [here][Core BIP 54 implem].
+
+## Test vectors
+
+Test vectors for this rule are available in [`sigops.json`](./bip-0054/test_vectors/sigops.json).
+
+## Copyright
+
+This document is licensed under the Creative Commons CC0 1.0 Universal license.
+
+[^1]: Technically this limit cannot apply to a coinbase transaction as the size of its sole input's
+scriptSig is limited.
+[^2]: The argument is about someone having a timelocked presigned transaction using some of those
+features in its output script. The transaction cannot be mined before activation. Such outputs would
+not be covered by an amnesty for old UTxOs. See for instance [here][O'Connor OP_CODESEPARATOR] and
+[here][O'Connor sighash type] for discussions on this topic.
+[^3]: It is important to reduce the worst case block validation time as well as the ratio of
+validation time imposed over preparation cost. The former is to limit the damages an externally
+motivated attacker can do. The latter is to disincentivize miners slowing down their competition by
+mining expensive blocks. See [this thread][ML thread validation time] for more.
+[^4]: A non-pathological transaction would have a public key per signature operation and at least
+one signature per input. Per standardness a single P2SH input may not have more than 15 signature
+operations. Even by using 1-of-15 `CHECKMULTISIG`s a transaction would bump against the maximum
+standard transaction size before running into the newly introduced limit. To run against the newly
+introduced limit but not the transaction size a transaction would need to spend P2SH inputs with a
+redeem script similar to `CHECKSIG DROP CHECKSIG DROP ...`. This type of redeem script serves no
+purpose beyond increasing its validation cost, which is exactly what this proposal aims to mitigate.
+
+[Delving worst block]: https://delvingbitcoin.org/t/great-consensus-cleanup-revival/710/93
+[BIP16 specs]: https://github.com/bitcoin/bips/blob/master/bip-0016.mediawiki#specification
+[BIP-XXXX]: https://github.com/TheBlueMatt/bips/blob/7f9670b643b7c943a0cc6d2197d3eabe661050c2/bip-XXXX.mediawiki
+[O'Connor OP_CODESEPARATOR]: https://gnusha.org/pi/bitcoindev/CAMZUoKneArC+YZ36YFwxNTKsDtJhEz5P2cosXKxJS8Rf_3Nyuw@mail.gmail.com
+[O'Connor sighash type]: https://gnusha.org/pi/bitcoindev/CAMZUoK=1kgZLR1YZ+cJgzwmEOwrABYFs=2Ri=xGX=BCr+w=VQw@mail.gmail.com
+[ML thread validation time]: https://gnusha.org/pi/bitcoindev/VsltJ2PHqWfzG4BU9YETTXjL7fYBbJhjVXKZQyItemySIA1okvNee9kf0zAOyLMeJ4Nqv1VOrYbWns5nP4TANCWvPJYu1ew_yxQSaudizzk=@protonmail.com
+[Core 30.0]: https://bitcoincore.org/en/releases/30.0
+[Core BIP 54 implem]: https://github.com/darosior/bitcoin/tree/bip54

--- a/bip-tbd-3.md
+++ b/bip-tbd-3.md
@@ -1,0 +1,102 @@
+```
+  BIP: TBD-3
+  Layer: Consensus (soft fork)
+  Title: Coinbase Locktime Duplicate Prevention
+  Authors: Antoine Poinsot <mail@antoinep.com>
+           Matt Corallo <bips@bluematt.me>
+  Status: Complete
+  Type: Specification
+  Assigned: ?
+  License: CC0-1.0
+```
+
+## Abstract
+
+This document proposes consensus restrictions on the coinbase transaction's `nLockTime` and
+`nSequence` fields. These restrictions make new coinbase transactions distinct from earlier
+BIP 34 violations and avoid the need to resume BIP 30 duplicate transaction validation.
+
+## Motivation
+
+Since [BIP 34][BIP34] activation, explicit [BIP 30][BIP30] validation is not necessary until block
+height 1,983,702.[^1] Resuming [BIP 30][BIP30] validation would unnecessarily increase block
+validation overhead and preclude alternative full node designs such as [BIP 182][BIP182] Utreexo.
+
+Enforcing that new coinbase transactions are different from the early [BIP 34][BIP34] violations
+makes it possible to get rid of [BIP 30][BIP30] validation forever.
+
+## Specification
+
+For all blocks after activation, the coinbase transaction's `nLockTime` field must be set to the
+height of the block minus 1[^2] and the `nSequence` field of its sole input must not be equal to
+`0xffffffff`.
+
+## Rationale
+
+The `nLockTime` field of transactions is a natural place to store a block height and is currently
+unused in coinbase transactions. Using it to enforce that new coinbase transactions differ from
+early [BIP 34][BIP34] violations also allows applications to recover the block height without
+having to parse Script.
+
+Leveraging the existing timelock mechanism makes the check self-contained: the same coinbase
+transaction cannot have been valid in a previous block.[^3] This simplifies both reasoning and
+client implementation, since the [BIP 30][BIP30] check can be skipped entirely past activation,
+regardless of the [BIP 34][BIP34] activation status.[^4] Requiring the coinbase input's `nSequence`
+field to be non-final ensures that `nLockTime` is consensus-enforced.
+
+One person [raised the concern][miningdev nLockTime] that the `nLockTime` field would be an ideal
+extranonce for ASIC controllers if such controllers ever became a bottleneck in mining operations.
+Others [replied][miningdev nLockTime] that the same benefits could be achieved by using a dummy
+output instead, should that ever become necessary. The authors [believe][ML remaining concerns] the
+benefits of using `nLockTime` to differentiate coinbase transactions outweigh the theoretical cost
+of making it unavailable for extranonce rolling by ASIC controllers.
+
+## Backward compatibility
+
+This proposal only tightens the block validation rules: there is no block that is valid under the
+rules proposed in this BIP but not under the existing Bitcoin consensus rules. As a consequence,
+these changes are backward-compatible with non-upgraded node software. That said, the authors
+strongly encourage node operators to upgrade in order to fully validate all consensus rules.
+
+## Miner forward compatibility
+
+The coinbase transaction is usually crafted by mining pool software. To the best of the authors'
+knowledge, there does not exist an open source reference broadly in use today for such software.
+We encourage mining pools to update their software to craft coinbase transactions that are
+forward-compatible with the changes proposed in this BIP.
+
+## Reference implementation
+
+An implementation of this rule as part of BIP 54 is available [here][Core BIP 54 implem].
+
+## Test vectors
+
+Test vectors for this rule are available in [`coinbases.json`](./bip-0054/test_vectors/coinbases.json).
+
+## Copyright
+
+This document is licensed under the Creative Commons CC0 1.0 Universal license.
+
+[^1]: Block 1,983,702 is the earliest future block which could contain a duplicate coinbase
+transaction while still respecting [BIP 34][BIP34]. See [this post][Delving duplicable] for a list
+of all such future blocks.
+[^2]: The locktime validation, which is also performed for coinbase transactions, enforces that the
+`nLockTime` value is the last block at which a transaction is invalid, not the first one at which it
+is valid.
+[^3]: Technically it could be argued a duplicate could in principle always be possible before block
+31,001 when `nLockTime` enforcement [was originally soft-forked][Harding nLockTime]. But treating
+coinbase transactions as not having duplicate past activation would be consistent for any
+implementation which enforces `nLockTime` from the genesis block, which is the behaviour notably of
+Bitcoin Core but also of all other implementations the authors are aware of.
+[^4]: For instance Bitcoin Core only disables [BIP 30][BIP30] validation for a specific chain where
+[BIP 34][BIP34] violations have been manually inspected. Without the guarantee given by enforcing
+the timelock on coinbase transactions, this would have to be perpetuated after activation.
+
+[BIP30]: https://github.com/bitcoin/bips/blob/master/bip-0030.mediawiki
+[BIP34]: https://github.com/bitcoin/bips/blob/master/bip-0034.mediawiki
+[BIP182]: https://github.com/bitcoin/bips/pull/1923
+[Delving duplicable]: https://delvingbitcoin.org/t/great-consensus-cleanup-revival/710/4
+[Harding nLockTime]: https://bitcoin.stackexchange.com/questions/90229/nlocktime-in-bitcoin-core
+[miningdev nLockTime]: https://groups.google.com/g/bitcoinminingdev/c/jlqlNHHNSNk
+[ML remaining concerns]: https://gnusha.org/pi/bitcoindev/UsKuvCXXhSAnNVx5a0K2UfP3srAr3slW9mcOjtYk9LnolaOXfWrW9jpqbxsQQPkyQuZogkhz2Hbfwii2VsTm79vRDpgKduxk35hpBu_t7Do=@protonmail.com/
+[Core BIP 54 implem]: https://github.com/darosior/bitcoin/tree/bip54


### PR DESCRIPTION
This is largely an editorial question for the BIP Editors, although authors of BIP 54 may care... Largely looking for approach ack at this step before I do a more careful conformance check that there are no semantic changes from splitting.

It likely makes sense to split-out the fixes proposed in 54 into some constituent BIPs and assign a number. e.g. see https://x.com/satofishi/status/2040424065630953933 for request to have each change have a separate BIP.

That also has a long term benefit of being able to refer to specific changes as BIP-TBD-1 compliance.

Conservatively, I chose to _preserve authorship_ of the sub-bips (except for @Christewart's BIP-53) by attributing the new BIPs to 54's authors, and marking them COMPLETE to preserve 54's complete status.

Alternatively, I could put forth new BIPs (under my or other authoriship?) and later BIP-54 could later be pared down to REQUIRES these?



some other links/comments supportive of splitting:
- https://github.com/bitcoin/bips/pull/1800#pullrequestreview-2785335249
- https://github.com/bitcoin/bips/pull/1800#pullrequestreview-2788772574
- https://github.com/bitcoin/bips/pull/1800#issuecomment-2827218755

Against:
- https://github.com/bitcoin/bips/pull/1800#issuecomment-2836126414
- https://github.com/bitcoin/bips/pull/1800#pullrequestreview-2791514520