### PR TITLE
BIP68: fix wrong upper bound for nHeight

### DIFF
--- a/bip-0068.mediawiki
+++ b/bip-0068.mediawiki
@@ -240,7 +240,7 @@ Additionally, this BIP specifies only 16 bits to actually encode relative lock-t
 The most efficient way to calculate sequence number from relative lock-time is with bit masks and shifts:
 
 <pre>
-    // 0 <= nHeight < 65,535 blocks (1.25 years)
+    // 0 <= nHeight <= 65,535 blocks (1.25 years)
     nSequence = nHeight;
     nHeight = nSequence & 0x0000ffff;
 


### PR DESCRIPTION
65_535 is a valid value for `nHeight`, see bitcoin-core code [here](https://github.com/bitcoin/bitcoin/blob/00af5620f01dbd1d2e696487303fad0382b67591/src/primitives/transaction.h#L104), [here](https://github.com/bitcoin/bitcoin/blob/00af5620f01dbd1d2e696487303fad0382b67591/src/script/descriptor.cpp#L1655) and [here](https://github.com/bitcoin/bitcoin/blob/00af5620f01dbd1d2e696487303fad0382b67591/src/consensus/tx_verify.cpp#L90).