### PR TITLE
BIP174: Mention sighash type requirement in Input Finalizer section

### DIFF
--- a/bip-0174.mediawiki
+++ b/bip-0174.mediawiki
@@ -511,7 +511,7 @@ Or, for participants performing fA(psbt) and fB(psbt): Combine(fA(psbt), fB(psbt
 ===Input Finalizer===
 
 The Input Finalizer must only accept a PSBT.
-For each input, the Input Finalizer determines if the input has enough data to pass validation. If it does, it must construct the <tt>0x07</tt> Finalized scriptSig and <tt>0x08</tt> Finalized scriptWitness and place them into the input key-value map.
+For each input, the Input Finalizer determines if the input has enough data to pass validation. If it does, it must construct the <tt>0x07</tt> Finalized scriptSig and <tt>0x08</tt> Finalized scriptWitness and place them into the input key-value map. If the input has a <tt>PSBT_IN_SIGHASH_TYPE</tt> field, the Input Finalizer must fail to finalize that input if any signature does not match the specified sighash type.
 If scriptSig is empty for an input, <tt>0x07</tt> should remain unset rather than assigned an empty array.
 Likewise, if no scriptWitness exists for an input, <tt>0x08</tt> should remain unset rather than assigned an empty array.
 All other data except the UTXO and unknown fields in the input key-value map should be cleared from the PSBT. The UTXO should be kept to allow Transaction Extractors to verify the final network serialized transaction.


### PR DESCRIPTION
### Description

Mention the `PSBT_IN_SIGHASH_TYPE` constraint in the **Input Finalizer** section. This mirrors the description of the per-input field.

### Rationale

Implementers of the **Input Finalizer** role have been missing this check.

* https://github.com/bitcoindevkit/bdk-tx/issues/75
* https://github.com/rust-bitcoin/rust-miniscript/blob/a19d92c96a9d398568d9e64415db2681581141c6/src/psbt/finalizer.rs#L428