### PR TITLE
BIP174: Clarify proprietary fields are retained on finalization

### DIFF
--- a/bip-0174.mediawiki
+++ b/bip-0174.mediawiki
@@ -514,7 +514,7 @@ The Input Finalizer must only accept a PSBT.
 For each input, the Input Finalizer determines if the input has enough data to pass validation. If it does, it must construct the <tt>0x07</tt> Finalized scriptSig and <tt>0x08</tt> Finalized scriptWitness and place them into the input key-value map. If the input has a <tt>PSBT_IN_SIGHASH_TYPE</tt> field, the Input Finalizer must fail to finalize that input if any signature does not match the specified sighash type.
 If scriptSig is empty for an input, <tt>0x07</tt> should remain unset rather than assigned an empty array.
 Likewise, if no scriptWitness exists for an input, <tt>0x08</tt> should remain unset rather than assigned an empty array.
-All other data except the UTXO and unknown fields in the input key-value map should be cleared from the PSBT. The UTXO should be kept to allow Transaction Extractors to verify the final network serialized transaction.
+All other data except the UTXO and unknown fields (including <tt>PSBT_IN_PROPRIETARY</tt> fields the Input Finalizer does not understand) in the input key-value map should be cleared from the PSBT. The UTXO should be kept to allow Transaction Extractors to verify the final network serialized transaction.
 
 ===Transaction Extractor===
 


### PR DESCRIPTION
Note that the Input Finalizer retains PSBT_IN_PROPRIETARY fields it does not understand, treating them like unknown fields so it does not clear proprietary data it cannot interpret.
