### PR TITLE
BIP-352: sync "Version" header, add "Requires" header

### DIFF
--- a/bip-0352.mediawiki
+++ b/bip-0352.mediawiki
@@ -13,7 +13,8 @@
               2022-03-28: https://gnusha.org/pi/bitcoindev/CAPv7TjbXm953U2h+-12MfJ24YqOM5Kcq77_xFTjVK+R2nf-nYg@mail.gmail.com/ [bitcoin-dev] Silent Payments – Non-interactive private payments with no on-chain overhead
               2022-10-11: https://gnusha.org/pi/bitcoindev/P_21MLHGJicZ-hkbC4DGu86c5BtNKiH8spY4TOw5FJsfimdi_6VyHzU_y-s1mZsOcC2FA3EW_6w6W5qfV9dRK_7AvTAxDlwVfU-yhWZPEuo=@protonmail.com/ [bitcoin-dev] Silent Payment v4 (coinjoin support added)
               2023-08-04: https://gnusha.org/pi/bitcoindev/ZM03twumu88V2NFH@petertodd.org/ [bitcoin-dev] BIP-352 Silent Payments addresses should have an expiration time
-  Version: 1.0.2
+  Version: 1.1.1
+  Requires: 340, 341, 350
 </pre>
 
 == Introduction ==


### PR DESCRIPTION
This PR updates the "Version" header (seems we forgot to do that in the latest two version bumps, #2106 and #2142) and adds a "Requires" header, referring to the following BIPs:

* BIP-340: Tagged hashes, X-only pubkeys, Schnorr signatures
* BIP-341: Taproot output encoding, spending
* BIP-350: bech32m address encoding

Other BIPs are mentioned in the document as well (BIP-32, BIP-158 etc.), but those are not strictly required for a compliant BIP-352 implementation.