### PR TITLE
BIP 77: Specify v1-fallback response mechanism

### DIFF
--- a/bip-0077.md
+++ b/bip-0077.md
@@ -405,6 +405,13 @@ Oblivious HTTP to the directory's OHTTP Gateway. OHTTP serializes the
 inner request as BHTTP, and provides another layer of HPKE encryption,
 between the client and directory.
 
+The above describes the receiver's reply path when the sender used
+Version 2. When the sender used the BIP 78 backwards-compatible path
+(the Original PSBT was a BIP 78 cleartext payload rather than an
+HPKE-encrypted v2 message), the receiver's response MUST instead follow
+[Backwards compatibility](#backwards-compatibility): the *Proposal PSBT*
+is not HPKE-encrypted and the request method is `PUT`.
+
 Once the receiver makes this request, they wait for either transaction from the
 Original PSBT or Proposal PSBT to be broadcast to the Bitcoin network.
 
@@ -743,6 +750,16 @@ request, a BIP 78 response must be returned to the sender within 30
 seconds or else the directory should respond with an `unavailable` JSON
 error code as [defined in BIP
 78](https://github.com/bitcoin/bips/blob/master/bip-0078.mediawiki#receivers-well-known-errors).
+
+When responding to a BIP 78 sender, the receiver MUST NOT HPKE-encrypt
+the *Proposal PSBT*. The receiver MUST send the *Proposal PSBT* as the
+body of a PUT request, with the body being the base64-encoded PSBT,
+encoded as ASCII bytes. The target mailbox endpoint MUST be the
+receiver's own mailbox (the same mailbox at which the sender posted the
+*Original PSBT*), because a BIP 78 sender provides no reply key from which
+a sender-side reply mailbox could be derived. The PUT request is then
+OHTTP-encapsulated to the directory's OHTTP Gateway as for any other
+Payjoin Directory interaction.
 
 ## Reference implementation
 


### PR DESCRIPTION
The receiver-to-sender response section presented HPKE encryption and POST as the only path, when v2 receivers servicing v1 (BIP 78) senders in the wild send the cleartext base64 PSBT via PUT to their own mailbox. Add a forward-reference from the v2 path to Backwards compatibility, and specify the v1-fallback response (no HPKE; PUT method; UTF-8 body; receiver's own mailbox as target) normatively in that section.

This puts the spec in line with PDK integrations in the wild.

Addresses payjoin/rust-payjoin#1487. Partially addresses payjoin/rust-payjoin#844.

Seeking your review, @nothingmuch 