### PR TITLE
BIP 343: change status from deployed to closed

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1184,13 +1184,13 @@ users (see also: [https://en.bitcoin.it/wiki/Economic_majority economic majority
 | Pieter Wuille, Jonas Nick, Anthony Towns
 | Specification
 | Deployed
-|- style="background-color: #cfffcf"
+|- style="background-color: #ffcfcf"
 | [[bip-0343.mediawiki|343]]
 | Consensus (soft fork)
 | Mandatory activation of taproot deployment
 | Shinobius, Michael Folkson
 | Specification
-| Deployed
+| Closed
 |- style="background-color: #ffcfcf"
 | [[bip-0345.mediawiki|345]]
 | Consensus (soft fork)

--- a/bip-0343.mediawiki
+++ b/bip-0343.mediawiki
@@ -4,7 +4,7 @@
   Title: Mandatory activation of taproot deployment
   Authors: Shinobius <quantumedusa@gmail.com>
            Michael Folkson <michaelfolkson@gmail.com>
-  Status: Deployed
+  Status: Closed
   Type: Specification
   Assigned: 2021-04-25
   License: BSD-3-Clause OR CC0-1.0

--- a/bip-0343.mediawiki
+++ b/bip-0343.mediawiki
@@ -40,6 +40,11 @@ The BIP8 (LOT=true) deployment has also been deliberately designed to be compati
 
 The deployment of BIP148 demonstrated that multiple implementations with different activation mechanisms can incentivize the necessary actors to act so that the different deployments activate in sync. A BIP8 LOT=true deployment can run in parallel with other BIP8 activation mechanisms that have eventual mandatory signaling or no mandatory signaling. Eventual mandatory signaling ensures that miners cannot prevent the activation of a desired feature with community consensus indefinitely.
 
+==Changelog==
+
+* 2026-06-01:
+** Moved to Closed due to no longer being relevant and the absence of known deployments.
+
 ==Acknowledgements==
 
 Thanks to Shaolin Fry and Luke Dashjr for their work on BIP148 and BIP8 which were important prerequisites for this proposal.


### PR DESCRIPTION
As a co-author I would like to move this BIP's status to Closed due to its current irrelevance and lack of any known deployments on the network. 

If I could I would delete it fully, or better yet go back in time to prevent it from being written.