### PR TITLE
BIP-0322: remove address optionality for PoF

### DIFF
--- a/bip-0322.mediawiki
+++ b/bip-0322.mediawiki
@@ -263,6 +263,8 @@ Validation consists of the following steps:
 ## The use of Segwit versions greater than 1 is forbidden.
 ## If any of the above steps failed, the validator should stop and output the ''inconclusive'' state.
 # Let ''T'' be the nLockTime of <code>to_sign</code> and ''S'' be the nSequence of the first input of <code>to_sign</code>. Output the state ''valid at time T and age S''.
+## For ''full Proof of Funds'' signatures, a validator MAY additionally report any non-zero nSequence values on the Proof of Funds inputs (i.e., <code>vin[1..n]</code>), and MAY verify them against the current chain state when the UTXO set is available; such checks are advisory and do not affect the output state.
+
 
 === Signing ===
 

--- a/bip-0322.mediawiki
+++ b/bip-0322.mediawiki
@@ -219,7 +219,7 @@ output with prevout <code>000...000:FFFFFFFF</code> does not exist.
 
 === Verification ===
 
-A validator is given as input an address ''A'' (which may be omitted in a proof-of-funds), signature
+A validator is given as input an address ''A'', signature
 ''s'' and message ''m'', and outputs one of three states:
 
 <ul>
@@ -489,10 +489,12 @@ and many others for their feedback on the specification.
 
 == Changelog ==
 
+* '''1.0.1''' (2026-06-04):
+** Clarify that the message_challenge is ''not'' optional for "Proof of Funds".
 * '''1.0.0''' (2026-04-15):
 ** Mark Complete
 ** Breaking change: Add human-readable prefix to encoded signature
-** Breaking change: format of "Proof of Funds" signatures to be base64-encoded finalized PSBT
+** Breaking change: Format of "Proof of Funds" signatures to be base64-encoded finalized PSBT
 ** Add new PSBT global field for PSBT-based signing
 * '''0.0.1''' (2018-09-10):
 ** Proposed as draft


### PR DESCRIPTION
This is cleaning up an artifact that was left over from #1352.
The alternative to removing the optionality of the address would be to assume `OP_TRUE` in case of an empty address.
But that sounds like it could open up any number of potential vulnerabilities.
And a user still has the ability to use an `OP_TRUE` script in a p2wsh or p2tr address.