### PR TITLE
script: check link format in nested mediawiki files

### DIFF
--- a/scripts/link-format-chk.sh
+++ b/scripts/link-format-chk.sh
@@ -8,10 +8,10 @@
 
 ECODE=0
 while IFS= read -r fname; do
-    GRES=$(grep -n '](http' "$fname")
+    GRES=$(grep -nE '\]\((https?://|\.\./bip-|/bip-)' "$fname")
     if [ "$GRES" != "" ]; then
         if [ $ECODE -eq 0 ]; then
-            >&2 echo "Github Mediawiki format writes link as [URL text], not as [text](url):"
+            >&2 echo "Github Mediawiki format writes links as [URL text], not as [text](URL):"
         fi
         ECODE=1
         while IFS= read -r line; do

--- a/scripts/link-format-chk.sh
+++ b/scripts/link-format-chk.sh
@@ -7,14 +7,16 @@
 # Check wrong mediawiki link format
 
 ECODE=0
-for fname in *.mediawiki; do
+while IFS= read -r fname; do
     GRES=$(grep -n '](http' "$fname")
     if [ "$GRES" != "" ]; then
         if [ $ECODE -eq 0 ]; then
             >&2 echo "Github Mediawiki format writes link as [URL text], not as [text](url):"
         fi
         ECODE=1
-        echo "- $fname:$GRES"
+        while IFS= read -r line; do
+            echo "- ${fname#./}:$line"
+        done <<< "$GRES"
     fi
-done
+done < <(find . -type f -name '*.mediawiki' | sort)
 exit $ECODE


### PR DESCRIPTION
Update the link format check to scan nested .mediawiki files as well as top-level BIP files.