### PR TITLE
script: check link format in Markdown files

### DIFF
--- a/scripts/link-format-chk.sh
+++ b/scripts/link-format-chk.sh
@@ -4,19 +4,36 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #
-# Check wrong mediawiki link format
+# Check wrong mediawiki and markdown link formats
 
 ECODE=0
+MEDIAWIKI_ECODE=0
 while IFS= read -r fname; do
     GRES=$(grep -nE '\]\((https?://|\.\./bip-|/bip-)' "$fname")
     if [ "$GRES" != "" ]; then
-        if [ $ECODE -eq 0 ]; then
+        if [ $MEDIAWIKI_ECODE -eq 0 ]; then
             >&2 echo "Github Mediawiki format writes links as [URL text], not as [text](URL):"
         fi
+        MEDIAWIKI_ECODE=1
         ECODE=1
         while IFS= read -r line; do
             echo "- ${fname#./}:$line"
         done <<< "$GRES"
     fi
 done < <(find . -type f -name '*.mediawiki' | sort)
+
+MARKDOWN_ECODE=0
+while IFS= read -r fname; do
+    GRES=$(grep -nE '\[[[:space:]]*https?://[^][]*\]|\[\[(\.\./|/)?bip-[^][]*\]\]' "$fname")
+    if [ "$GRES" != "" ]; then
+        if [ $MARKDOWN_ECODE -eq 0 ]; then
+            >&2 echo "Github Markdown format writes links as [text](URL), not as [URL text] or [[URL|text]]:"
+        fi
+        MARKDOWN_ECODE=1
+        ECODE=1
+        while IFS= read -r line; do
+            echo "- ${fname#./}:$line"
+        done <<< "$GRES"
+    fi
+done < <(find . -type f -name '*.md' | sort)
 exit $ECODE


### PR DESCRIPTION
Update the link format check to scan Markdown files for MediaWiki-formatted links.

This follows up on #2199 by checking for the inverse link-format mistake in `.md` files.