### PR TITLE
script: link check improvements

### DIFF
--- a/scripts/link-format-chk.sh
+++ b/scripts/link-format-chk.sh
@@ -36,4 +36,20 @@ while IFS= read -r fname; do
         done <<< "$GRES"
     fi
 done < <(find . -type f -name '*.md' | sort)
+
+REDUNDANT_ECODE=0
+while IFS= read -r fname; do
+    # Matches [url](url)
+    GRES=$(grep -nE '\[(https?://[^]]+)\]\(\1\)' "$fname")
+    if [ "$GRES" != "" ]; then
+        if [ $REDUNDANT_ECODE -eq 0 ]; then
+            >&2 echo "Markdown links where the text matches the URL are redundant. Use <URL> instead:"
+        fi
+        REDUNDANT_ECODE=1
+        ECODE=1
+        while IFS= read -r line; do
+            echo "- ${fname#./}:$line"
+        done <<< "$GRES"
+    fi
+done < <(find . -type f -name '*.md' | sort)
 exit $ECODE

--- a/scripts/link-format-chk.sh
+++ b/scripts/link-format-chk.sh
@@ -24,7 +24,7 @@ done < <(find . -type f -name '*.mediawiki' | sort)
 
 MARKDOWN_ECODE=0
 while IFS= read -r fname; do
-    GRES=$(grep -nE '\[[[:space:]]*https?://[^][]*\]|\[\[(\.\./|/)?bip-[^][]*\]\]' "$fname")
+    GRES=$(grep -nE '\[[[:space:]]*https?://[^][[:space:]]+[[:space:]]+[^][]*\]|\[\[https?://[^][]*\]\]|\[\[(\.\./|/)?bip-[^][]*\]\]' "$fname")
     if [ "$GRES" != "" ]; then
         if [ $MARKDOWN_ECODE -eq 0 ]; then
             >&2 echo "Github Markdown format writes links as [text](URL), not as [URL text] or [[URL|text]]:"

--- a/scripts/link-format-chk.sh
+++ b/scripts/link-format-chk.sh
@@ -4,7 +4,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #
-# Check wrong mediawiki and markdown link formats
+# Check mediawiki and markdown link formats
 
 ECODE=0
 MEDIAWIKI_ECODE=0
@@ -12,7 +12,7 @@ while IFS= read -r fname; do
     GRES=$(grep -nE '\]\((https?://|\.\./bip-|/bip-)' "$fname")
     if [ "$GRES" != "" ]; then
         if [ $MEDIAWIKI_ECODE -eq 0 ]; then
-            >&2 echo "Github Mediawiki format writes links as [URL text], not as [text](URL):"
+            >&2 echo "GitHub Mediawiki format writes links as [URL text], not as [text](URL):"
         fi
         MEDIAWIKI_ECODE=1
         ECODE=1
@@ -27,7 +27,7 @@ while IFS= read -r fname; do
     GRES=$(grep -nE '\[[[:space:]]*https?://[^][[:space:]]+[[:space:]]+[^][]*\]|\[\[https?://[^][]*\]\]|\[\[(\.\./|/)?bip-[^][]*\]\]' "$fname")
     if [ "$GRES" != "" ]; then
         if [ $MARKDOWN_ECODE -eq 0 ]; then
-            >&2 echo "Github Markdown format writes links as [text](URL), not as [URL text] or [[URL|text]]:"
+            >&2 echo "GitHub Markdown format writes links as [text](URL), not as [URL text] or [[URL|text]]:"
         fi
         MARKDOWN_ECODE=1
         ECODE=1


### PR DESCRIPTION
Don't raise on `[url](url)` or `[url]` in the markdown format check.

Instead, optionally flag `[url](url)` in a separate check with an appropriate message.

Finish with a few editorial touch-ups.