### PR TITLE
BIP179: Advance to Complete

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1016,13 +1016,13 @@ users (see also: [https://en.bitcoin.it/wiki/Economic_majority economic majority
 | Karl-Johan Alm
 | Specification
 | Draft
-|-
+|- style="background-color: #ffffcf"
 | [[bip-0179.mediawiki|179]]
 |
 | Name for payment recipient identifiers
 | Emil Engler, Luke Dashjr
 | Informational
-| Draft
+| Complete
 |- style="background-color: #ffcfcf"
 | [[bip-0180.mediawiki|180]]
 | Peer Services

--- a/bip-0179.mediawiki
+++ b/bip-0179.mediawiki
@@ -3,7 +3,7 @@
   Title: Name for payment recipient identifiers
   Authors: Emil Engler <me@emilengler.com>
            Luke Dashjr <luke+bip@dashjr.org>
-  Status: Draft
+  Status: Complete
   Type: Informational
   Assigned: 2019-10-17
   License: CC0-1.0


### PR DESCRIPTION
It seems to me that all planned work on BIP 179 has been concluded — at least it hasn’t gotten an update in many years. In that case, the document could be advanced to the [Complete](https://github.com/bitcoin/bips/blob/master/bip-0003.md#complete6) status, which is the natural final BIP Status for Informational BIPs.

Please let me know what you think, @cvengler and @luke-jr.

I could also make an update to the author names, if that would be your preference, @cvengler.