### PR TITLE
bip47: Change BIP type, move text from above preamble

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -279,7 +279,7 @@ users (see also: [https://en.bitcoin.it/wiki/Economic_majority economic majority
 | Applications
 | Reusable Payment Codes for Hierarchical Deterministic Wallets
 | Justus Ranvier
-| Informational
+| Specification
 | Deployed
 |- style="background-color: #cfffcf"
 | [[bip-0048.mediawiki|48]]

--- a/bip-0047.mediawiki
+++ b/bip-0047.mediawiki
@@ -6,7 +6,7 @@
   Comments-Summary: Unanimously Discourage for implementation
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0047
   Status: Deployed
-  Type: Informational
+  Type: Specification
   Assigned: 2015-04-24
 </pre>
 

--- a/bip-0047.mediawiki
+++ b/bip-0047.mediawiki
@@ -1,8 +1,3 @@
-RECENT CHANGES:
-* (15 Feb 2021) Finalize specification
-* (28 Sep 2017) Adjust text to match test vectors
-* (19 Apr 2016) Define version 2 payment codes
-
 <pre>
   BIP: 47
   Layer: Applications
@@ -385,3 +380,12 @@ Alice's wallet should spend the notification change output at the next appropria
 * [[https://en.bitcoin.it/wiki/Base58Check_encoding|Base58Check encoding]]
 * [[https://bitmessage.org/bitmessage.pdf|Bitmessage]]
 * [[https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2015-April/007812.html|Mailing list discussion]]
+
+==Changelog==
+
+* 2021-02-15:
+** Finalize specification
+* 2017-09-28:
+** Adjust text to match test vectors
+* 2016-04-19:
+** Define version 2 payment codes

--- a/bip-0047.mediawiki
+++ b/bip-0047.mediawiki
@@ -3,8 +3,6 @@
   Layer: Applications
   Title: Reusable Payment Codes for Hierarchical Deterministic Wallets
   Authors: Justus Ranvier <justus@openbitcoinprivacyproject.org>
-  Comments-Summary: Unanimously Discourage for implementation
-  Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0047
   Status: Deployed
   Type: Specification
   Assigned: 2015-04-24


### PR DESCRIPTION
BIP47 describes a scheme that an implementation can be compliant with. Therefore, it should be a Specification BIP. It also has a Changelog above the Preamble which is not compliant with BIP3. This text is moved to the bottom of the document into a new Changelog section instead.