### PR TITLE
bip351: close due to lack of activity

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1245,7 +1245,7 @@ users (see also: [https://en.bitcoin.it/wiki/Economic_majority economic majority
 | Applications
 | Private Payments
 | Alfred Hodler, Clark Moody
-| Informational
+| Specification
 | Draft
 |- style="background-color: #ffffcf"
 | [[bip-0352.mediawiki|352]]

--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1240,13 +1240,13 @@ users (see also: [https://en.bitcoin.it/wiki/Economic_majority economic majority
 | Pieter Wuille
 | Specification
 | Deployed
-|-
+|- style="background-color: #ffcfcf"
 | [[bip-0351.mediawiki|351]]
 | Applications
 | Private Payments
 | Alfred Hodler, Clark Moody
 | Specification
-| Draft
+| Closed
 |- style="background-color: #ffffcf"
 | [[bip-0352.mediawiki|352]]
 | Applications

--- a/bip-0351.mediawiki
+++ b/bip-0351.mediawiki
@@ -4,7 +4,7 @@
   Title: Private Payments
   Authors: Alfred Hodler <alfred_hodler@protonmail.com>
            Clark Moody <clark@clarkmoody.com>
-  Status: Draft
+  Status: Closed
   Type: Specification
   Assigned: 2022-07-10
   License: MIT
@@ -260,3 +260,6 @@ Reference implementation is available at https://github.com/private-payments/rus
 * [[bip-0158.mediawiki|BIP158 - Compact Block Filters for Light Clients]]
 * [https://gist.github.com/RubenSomsen/21c477c90c942acf45f8e8f5c1ad4fae BIP47 Prague Discussion (acknowledgements: @rubensomsen, @afilini, @kixunil])
 
+==Changelog==
+* 2026-07-22:
+** Moved to Closed due to lack of activity

--- a/bip-0351.mediawiki
+++ b/bip-0351.mediawiki
@@ -5,7 +5,7 @@
   Authors: Alfred Hodler <alfred_hodler@protonmail.com>
            Clark Moody <clark@clarkmoody.com>
   Status: Draft
-  Type: Informational
+  Type: Specification
   Assigned: 2022-07-10
   License: MIT
 </pre>


### PR DESCRIPTION
Since this proposal describes a scheme that can be implemented and an implementation can be in compliance with, I propose to change the type to Specification.

It is my impression that there has been no activity on BIP351 since September 2022 and that the BIP has not been adopted by a Bitcoin project. I therefore propose updating it to the Closed status which indicates that currently nobody is working on advancing this proposal.

cc BIP Owners: @alfred-hodler, @clarkmoody

Please let me know if I got the wrong impression and you instead want to work on moving the BIP to Complete. At first glance it looks like it is mostly there, as there are test vectors and a reference implementation.

This PR is not eligible to be merged until [four weeks](https://github.com/bitcoin/bips/blob/master/bip-0003.md#draft--closed) have passed on 2026-08-19 or later.