### PR TITLE
bip360: fix leafHashes order and a control byte in the pqc test vectors

### DIFF
--- a/bip-0360/ref-impl/common/tests/data/p2mr_pqc_construction.json
+++ b/bip-0360/ref-impl/common/tests/data/p2mr_pqc_construction.json
@@ -72,7 +72,7 @@
                 "bip350Address": "bc1zzcvuumfz53k75pzuft0h7hen66qs6qxsa8y2f3a6xhdn0wg4cczq0h84sj",
                 "scriptPathControlBlocks": [
                     "c1f224a923cd0021ab202ab139cc56802ddb92dcfc172b9212261a539df79a112a",
-                    "c13bb0db8c6adcd87330a4a8c91be0fe1b23da3c151b6f2fb4f269429c43b8d8bc"
+                    "fb3bb0db8c6adcd87330a4a8c91be0fe1b23da3c151b6f2fb4f269429c43b8d8bc"
                 ]
             }
         },
@@ -184,9 +184,9 @@
             },
             "intermediary": {
                 "leafHashes": [
-                    "0840c39e59eda6c9deee687a480cb169130c2f053ed2eb3134511ec1cfd8a2c7",
+                    "b2a5304f678cc5a2ed51feb377dd0a609bd22ec979cc608bfcf884d0f8e6f93a",
                     "837ef6677aeb0df2b0de47f45024684cc6ca03bda10fa30bb5bc05a94beb8dd1",
-                    "b2a5304f678cc5a2ed51feb377dd0a609bd22ec979cc608bfcf884d0f8e6f93a"
+                    "0840c39e59eda6c9deee687a480cb169130c2f053ed2eb3134511ec1cfd8a2c7"
                 ],
                 "merkleRoot": "eaf8f557fdb9673de7bb9bad7e7452da9f44a3e65133fdadf2849c55cfb3cf5b"
             },
@@ -232,9 +232,9 @@
             },
             "intermediary": {
                 "leafHashes": [
-                    "52e9326c2bf04d926b7e9f6c7645dd853f3f007b870201de9b814952750c9310",
+                    "ddb521a44e33ff4974e618d8b8b7794275b7dc754d847c537404f84330454361",
                     "dcef3ce86cc8cea78c9e00f3d9ef58360cb6ed3cb90ec62efe00b9703854ba5c",
-                    "ddb521a44e33ff4974e618d8b8b7794275b7dc754d847c537404f84330454361"
+                    "52e9326c2bf04d926b7e9f6c7645dd853f3f007b870201de9b814952750c9310"
                 ],
                 "merkleRoot": "51e3c1151ba73d9efce801837773331bf9030977242f62dfeb6756795f482409"
             },


### PR DESCRIPTION
Two fixes in bip-0360/ref-impl/common/tests/data/p2mr_pqc_construction.json, found while implementing BIP 360 against the published vectors.

First, the three-leaf vectors (p2mr_three_leaf_complex and p2mr_three_leaf_alternative) list intermediary.leafHashes with entries 0 and 2 swapped relative to the depth-first order of the script tree. The merkle root, scriptPubKey, address and control blocks in those same vectors all follow depth-first order, as do the equivalent trees in p2mr_construction.json. This looks like a leftover from the ordering problem that #2202 fixed for the control blocks.

Check against the spec formulas:

```python
import json, hashlib

def tagged(tag, data):
    t = hashlib.sha256(tag.encode()).digest()
    return hashlib.sha256(t + t + data).digest()

d = json.load(open("p2mr_pqc_construction.json"))
tv = [t for t in d["test_vectors"] if t["id"] == "p2mr_three_leaf_complex"][0]
leaves = []
def walk(n):
    if isinstance(n, list):
        for x in n: walk(x)
    else: leaves.append(n)
walk(tv["given"]["scriptTree"])
for i, leaf in enumerate(leaves):
    s = bytes.fromhex(leaf["script"])
    h = tagged("TapLeaf", bytes([leaf["leafVersion"]]) + bytes([len(s)]) + s).hex()
    print(i, h == tv["intermediary"]["leafHashes"][i])
```

Before this change that prints "0 False / 1 True / 2 False", i.e. entries 0 and 2 hold each other's values. Same for p2mr_three_leaf_alternative.

Second, in p2mr_different_version_leaves the second leaf has "leafVersion": 250 (0xfa), but scriptPathControlBlocks[1] started with c1. The control byte carries the leaf version in its upper 7 bits with the low bit set, so it should be fb. The vector's leafHashes[1] and merkle root already correspond to the leaf hashed under 0xfa and the path bytes are correct, so only the first byte was wrong. As published, a spender using that control block would recompute the leaf hash under 0xc0 and fail the merkle check.

After both fixes every success vector in the file passes a full recomputation from the spec formulas: leaf hashes, merkle root, scriptPubKey, bech32m address, control blocks, and walking each control block path back to the root.
