### PR TITLE
bip360: fix stale links, version header and a size example label

### DIFF
--- a/bip-0360.mediawiki
+++ b/bip-0360.mediawiki
@@ -9,7 +9,7 @@
   Type: Specification
   Assigned: 2024-12-18
   License: BSD-3-Clause
-  Version: 0.12.0
+  Version: 0.12.1
   Requires: 340, 341, 342
 </pre>
 
@@ -281,7 +281,7 @@ P2MR witness for a depth-1 tree (135 bytes):
 [count] (1 byte), # Number of elements in the witness
 [size] signature (1 + 64 bytes = 65 bytes),
 leaf script = [size] [OP_PUSHBYTES_32, 32-byte public key, OP_CHECKSIG] (1 + 1 + 32 + 1 bytes = 35 bytes),
-control block = [size] [control byte] [merkle path (empty)] (1 + 1 + 32 bytes = 34 bytes)
+control block = [size] [control byte] [merkle path] (1 + 1 + 32 bytes = 34 bytes)
 </source>
 
 P2TR key path spend witness (66 bytes):
@@ -341,11 +341,11 @@ We also imagine the possibility of introducing multiple post-quantum signatures 
 
 ==Test Vectors and Reference Code==
 
-Test vector data for creation of P2MR UTXOs can be found [https://github.com/bitcoin/bips/blob/master/bip-0360/ref-impl/common/tests/data/P2MR_construction.json here].
+Test vector data for creation of P2MR UTXOs can be found [https://github.com/bitcoin/bips/blob/master/bip-0360/ref-impl/common/tests/data/p2mr_construction.json here].
 
 These test vectors build off of the test vectors for [[bip-0341.mediawiki|BIP 341]] (Taproot). One important distinction is that the P2MR test vectors do not include keypath spend scenarios.
 
-Also included are test vectors in [https://github.com/bitcoin/bips/tree/master/bip-0360/ref-impl/rust rust implementation] and [https://github.com/bitcoin/bips/tree/master/bip-0360/ref-impl/python python implementation]. One of these tests demonstrates a tapscript that requires a secp256k1 signature to spend the P2MR UTXO (modeled after one of the extremely valuable examples provided by [https://learnmeabitcoin.com/technical/upgrades/taproot/#example-3-script-path-spend-signature this Taproot script path spend example]. Similar to BIP 341 test vectors, all signatures are created with an all-zero (0x0000...0000) [[bip-0340.mediawiki|BIP 340]] auxiliary randomness array.
+Also included is a [https://github.com/bitcoin/bips/tree/master/bip-0360/ref-impl/python python implementation]. One of its tests demonstrates a tapscript that requires a secp256k1 signature to spend the P2MR UTXO (modeled after one of the extremely valuable examples provided by [https://learnmeabitcoin.com/technical/upgrades/taproot/#example-3-script-path-spend-signature this Taproot script path spend example]. Similar to BIP 341 test vectors, all signatures are created with an all-zero (0x0000...0000) [[bip-0340.mediawiki|BIP 340]] auxiliary randomness array.
 
 ==Related Work==
 


### PR DESCRIPTION
Small doc fixes in bip-0360.mediawiki, noticed while implementing against the published vectors:

- The Test Vectors section linked P2MR_construction.json; the file on disk is lowercase p2mr_construction.json, so the link 404s.
- The same section still linked the rust implementation under bip-0360/ref-impl/rust, which #2202 moved out of the repository. Kept the python link and adjusted the sentence around it.
- The header said Version: 0.12.0 while the changelog's latest entry is 0.12.1.
- The 135-byte depth-1 witness example labeled the merkle path "(empty)" while counting 32 bytes for it. A depth-1 path has one 32-byte node.

Two things I left unchanged because they affect consumers' parsers: the schema mixes given.scriptTree (most vectors) with given.script_tree (the missing-tree error vectors), and a missing tree is encoded both as null and as an empty string. Happy to normalize those too if there is a preferred spelling.
