### PR TITLE
bip360: correct the claimed P2MR witness size saving

### DIFF
--- a/bip-0360.mediawiki
+++ b/bip-0360.mediawiki
@@ -307,7 +307,7 @@ control block = [size] [control byte] [Merkle path] (1 + 1 + 32*m = 2 + 32*m byt
 
 ====Comparison with P2TR script path spend====
 
-A P2MR witness will be smaller than the witness to an equivalent P2TR script path spend. This is because P2MR does not require inclusion of an internal public key in the control block to unlock and spend an output. For this reason, a P2MR witness will always be 32 bytes smaller than an equivalent P2TR script path spend witness.
+A P2MR witness will be smaller than the witness to an equivalent P2TR script path spend. This is because P2MR does not require inclusion of an internal public key in the control block to unlock and spend an output. For this reason, a P2MR witness will be 32 bytes smaller than an equivalent P2TR script path spend witness, except at ''m = 7'', where the two control blocks fall on opposite sides of the compact size boundary and the saving is 34 bytes.
 
 ==Performance Impact==
 


### PR DESCRIPTION
In Transaction Size and Fees, the BIP says a P2MR witness "will always be 32 bytes smaller than an equivalent P2TR script path spend witness". That holds at every depth except m = 7, where it is 34.

The control blocks are 1 + 32*m for P2MR and 33 + 32*m for P2TR, and each is serialised with a compact size prefix. At m = 7 the P2TR control block is 257 bytes, which crosses the 253-byte boundary and takes a 3-byte prefix, while the P2MR one is 225 bytes and still takes 1:

```python
def cs(n): return 1 if n < 253 else 3
for m in range(1, 12):
    a, b = 1 + 32*m, 33 + 32*m
    print(m, (cs(b) + b) - (cs(a) + a))
# 1..6 -> 32, 7 -> 34, 8..11 -> 32
```

The same section already footnotes this boundary a few paragraphs earlier, for the P2MR side only ("If m >= 8, then the compact size will use 3 bytes rather than 1 byte"), so the reasoning is there, it just isn't carried into the comparison.

Noticed while measuring witness weights for a regtest implementation of the BIP.
