### PR TITLE
BIP321: make all example addresses intentionally invalid

### DIFF
--- a/bip-0321.mediawiki
+++ b/bip-0321.mediawiki
@@ -142,6 +142,8 @@ Any existing BIP 21 implementation should automatically be fully compliant with 
 
 === Examples ===
 
+Note: The addresses used in these examples are intentionally invalid to prevent accidental transactions.
+
 ==== URIs ====
 
 Just the address:
@@ -181,14 +183,14 @@ Some future version that has variables which are (currently) not understood but 
  bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?somethingyoudontunderstand=50&somethingelseyoudontget=999
 
 Multiple segwit addresses may be included for various versions of segwit, note that the human-readable part for all of them is `bc`
- bitcoin:?bc=bc1qufgy354j3kmvuch987xe4s40836x3h0lg8f5n2&bc=bc1p5swkugezn97763tl0yty6556856uug0q6jflljvep9m4p7339x5qzyrh4g
+ bitcoin:?bc=bc1qufgy354j3kmvuch987xe4s40836x3h0lg8f5nq&bc=bc1p5swkugezn97763tl0yty6556856uug0q6jflljvep9m4p7339x5qzyrh4q
 
 Many QR codes utilize all-uppercase URIs, which should be handled fine
- BITCOIN:BC1QUFGY354J3KMVUCH987XE4S40836X3H0LG8F5N2?BC=BC1P5SWKUGEZN97763TL0YTY6556856UUG0Q6JFLLJVEP9M4P7339X5QZYRH4G
- BITCOIN:?BC=BC1QUFGY354J3KMVUCH987XE4S40836X3H0LG8F5N2&BC=BC1P5SWKUGEZN97763TL0YTY6556856UUG0Q6JFLLJVEP9M4P7339X5QZYRH4G
+ BITCOIN:BC1QUFGY354J3KMVUCH987XE4S40836X3H0LG8F5NQ?BC=BC1P5SWKUGEZN97763TL0YTY6556856UUG0Q6JFLLJVEP9M4P7339X5QZYRH4Q
+ BITCOIN:?BC=BC1QUFGY354J3KMVUCH987XE4S40836X3H0LG8F5NQ&BC=BC1P5SWKUGEZN97763TL0YTY6556856UUG0Q6JFLLJVEP9M4P7339X5QZYRH4Q
 
 A testnet segwit addresses must be included in the `tb` parameter
- bitcoin:?tb=tb1qghfhmd4zh7ncpmxl3qzhmq566jk8ckq4gafnmg
+ bitcoin:?tb=tb1qghfhmd4zh7ncpmxl3qzhmq566jk8ckq4gafnmq
 
 Characters must be URI encoded properly.
 
@@ -207,7 +209,7 @@ Multiple proof of payment URIs must not appear, even if they are sometimes prefi
  bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?pop=callback%3a&req-pop=callback%3a
 
 A testnet segwit addresses must be included in the `tb` parameter, not the `bc` parameter.
- bitcoin:?bc=tb1qghfhmd4zh7ncpmxl3qzhmq566jk8ckq4gafnmg
+ bitcoin:?bc=tb1qghfhmd4zh7ncpmxl3qzhmq566jk8ckq4gafnmq
 
 ==== Proof of Payment ====
 


### PR DESCRIPTION
One of three mutually exclusive options for the same problem — see the table at the bottom. This is the one I'd recommend merging.

BIP 21's example address `175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W` has a deliberately broken checksum (the final character was replaced, per @TheBlueMatt in #119), and #1861 documented that intent with a note. BIP 321 inherited the address but not the note, and the addresses added to BIP 321 after the fork from BIP 21 do **not** follow the convention — their checksums are valid:

| Address | Status on master |
| --- | --- |
| `175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W` | invalid checksum (intentional) |
| `bc1qufgy354j3kmvuch987xe4s40836x3h0lg8f5n2` | **valid** bech32, witness v0, mainnet |
| `bc1p5swkugezn97763tl0yty6556856uug0q6jflljvep9m4p7339x5qzyrh4g` | **valid** bech32m, witness v1, mainnet |
| `tb1qghfhmd4zh7ncpmxl3qzhmq566jk8ckq4gafnmg` | **valid** bech32, witness v0, testnet |

So the document currently ships two spendable mainnet addresses in its examples — exactly the accident #119 and #1861 were about.

### This PR

Applies the existing convention to the remaining addresses by altering the final checksum character of each, then adds BIP 21's note verbatim, which is now accurate for every address in the document:

> Note: The addresses used in these examples are intentionally invalid to prevent accidental transactions.

Properties preserved:

- Bech32 detects **any** single-character substitution, so the modified strings cannot be valid addresses under either the bech32 or bech32m constant. I verified all of them against a reference implementation of both.
- Human-readable part, charset and length are unchanged (42 and 62 characters), so the examples stay structurally representative of P2WPKH and P2TR and remain usable as negative test vectors.
- The uppercase QR-code variants are updated to match.
- The changed testnet address in the "Invalid URIs" section still demonstrates its point, which is the HRP/parameter-key mismatch (a `tb` address in the `bc` parameter), not the checksum.

### The three options

| PR | Approach | Diff | |
| --- | --- | --- | --- |
| #2228 | keep the addresses, word the note to match reality | +2 | |
| #2229 | invalidate every address, add BIP 21's note verbatim | +7 / -5 | this PR, **my preference** |
| #2230 | make every address valid, warn against paying them | +18 / -16 | |

Only one should be merged; I'll close the other two.

**My preference is this PR.** It is the only one of the three that leaves no spendable address anywhere in the document, it makes BIP 21's existing wording literally true here so the two documents stay in sync, and the whole cost is four characters. #2228 is the minimal-diff fallback if maintainers would rather not touch strings that downstream implementations may already be using as test vectors. #2230 is on the table because #119 was closed for lack of author consensus rather than on the merits, so the option deserves to be stated explicitly rather than assumed dead — but it is the one I would close first.
