### PR TITLE
BIP321: use a valid base58 example address, warn against paying it

### DIFF
--- a/bip-0321.mediawiki
+++ b/bip-0321.mediawiki
@@ -142,22 +142,24 @@ Any existing BIP 21 implementation should automatically be fully compliant with 
 
 === Examples ===
 
+Note: The addresses used in these examples are for illustration only and must not be used to send funds.
+
 ==== URIs ====
 
 Just the address:
- bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W
+ bitcoin:1NS17iag9jJgTHD1VXjvLCEnZuQ3rJED9L
 
 Address with recipient's name as label:
- bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?label=Luke-Jr
+ bitcoin:1NS17iag9jJgTHD1VXjvLCEnZuQ3rJED9L?label=Luke-Jr
 
 Request 20.30 BTC to "Luke-Jr":
- bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?amount=20.3&label=Luke-Jr
+ bitcoin:1NS17iag9jJgTHD1VXjvLCEnZuQ3rJED9L?amount=20.3&label=Luke-Jr
 
 Request 50 BTC with message:
- bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?amount=50&label=Luke-Jr&message=Donation%20for%20project%20xyz
+ bitcoin:1NS17iag9jJgTHD1VXjvLCEnZuQ3rJED9L?amount=50&label=Luke-Jr&message=Donation%20for%20project%20xyz
 
 Request funds to be paid over lightning to a BOLT 11 invoice with a fallback to on-chain payments:
- bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?lightning=lnbc420bogusinvoice
+ bitcoin:1NS17iag9jJgTHD1VXjvLCEnZuQ3rJED9L?lightning=lnbc420bogusinvoice
 
 Request funds to be paid over lightning to a BOLT 11 invoice with no fallback:
  bitcoin:?lightning=lnbc420bogusinvoice
@@ -172,13 +174,13 @@ Request funds to be paid to a silent payments address with no fallback:
  bitcoin:?sp=sp1qsilentpayment
 
 Request funds to be paid to a silent payments address with a fallback:
- bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?sp=sp1qsilentpayment
+ bitcoin:1NS17iag9jJgTHD1VXjvLCEnZuQ3rJED9L?sp=sp1qsilentpayment
 
 Some future version that has variables which are (currently) not understood and required and thus invalid:
- bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?req-somethingyoudontunderstand=50&req-somethingelseyoudontget=999
+ bitcoin:1NS17iag9jJgTHD1VXjvLCEnZuQ3rJED9L?req-somethingyoudontunderstand=50&req-somethingelseyoudontget=999
 
 Some future version that has variables which are (currently) not understood but not required and thus valid:
- bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?somethingyoudontunderstand=50&somethingelseyoudontget=999
+ bitcoin:1NS17iag9jJgTHD1VXjvLCEnZuQ3rJED9L?somethingyoudontunderstand=50&somethingelseyoudontget=999
 
 Multiple segwit addresses may be included for various versions of segwit, note that the human-readable part for all of them is `bc`
  bitcoin:?bc=bc1qufgy354j3kmvuch987xe4s40836x3h0lg8f5n2&bc=bc1p5swkugezn97763tl0yty6556856uug0q6jflljvep9m4p7339x5qzyrh4g
@@ -195,16 +197,16 @@ Characters must be URI encoded properly.
 ==== Invalid URIs ====
 
 Labels must not appear twice:
- bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?label=Luke-Jr&label=Matt
+ bitcoin:1NS17iag9jJgTHD1VXjvLCEnZuQ3rJED9L?label=Luke-Jr&label=Matt
 
 Amounts must not appear twice:
- bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?amount=42&amount=10
+ bitcoin:1NS17iag9jJgTHD1VXjvLCEnZuQ3rJED9L?amount=42&amount=10
 
 Amounts must not appear twice even if they are the same:
- bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?amount=42&amount=42
+ bitcoin:1NS17iag9jJgTHD1VXjvLCEnZuQ3rJED9L?amount=42&amount=42
 
 Multiple proof of payment URIs must not appear, even if they are sometimes prefixed with req-:
- bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?pop=callback%3a&req-pop=callback%3a
+ bitcoin:1NS17iag9jJgTHD1VXjvLCEnZuQ3rJED9L?pop=callback%3a&req-pop=callback%3a
 
 A testnet segwit addresses must be included in the `tb` parameter, not the `bc` parameter.
  bitcoin:?bc=tb1qghfhmd4zh7ncpmxl3qzhmq566jk8ckq4gafnmg
@@ -212,7 +214,7 @@ A testnet segwit addresses must be included in the `tb` parameter, not the `bc` 
 ==== Proof of Payment ====
 
 If the original URI is
- bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?pop=initiatingapp%3a
+ bitcoin:1NS17iag9jJgTHD1VXjvLCEnZuQ3rJED9L?pop=initiatingapp%3a
 the wallet should perform the payment information callback by opening
  initiatingapp:onchain=$HEX_ENCODED_TRANSACTION
 
@@ -222,16 +224,16 @@ the wallet should perform the proof-of-payment callback by opening
  callbackuri:body?pop=lightning=$HEX_ENCODED_PAYMENT_PREIMAGE
 
 If the original URI is
- bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?lightning=lnbc420bogusinvoice&pop=app%3a%3f
+ bitcoin:1NS17iag9jJgTHD1VXjvLCEnZuQ3rJED9L?lightning=lnbc420bogusinvoice&pop=app%3a%3f
 and the wallet pays on-chain, it should perform the payment information callback by opening
  app:?onchain=$HEX_ENCODED_TRANSACTION
 but if the app pays using lightning, it should perform the proof-of-payment callback by opening
  app:?lightning=$HEX_ENCODED_PAYMENT_PREIMAGE
 
 If the original URI is
- bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?pop=https%3aiwantyouripaddress.com
+ bitcoin:1NS17iag9jJgTHD1VXjvLCEnZuQ3rJED9L?pop=https%3aiwantyouripaddress.com
 the wallet should make a payment as it normally would but MUST NOT interact with iwantyouripaddress.com
 
 If the original URI is
- bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?req-pop=https%3aevilwebsite.com
+ bitcoin:1NS17iag9jJgTHD1VXjvLCEnZuQ3rJED9L?req-pop=https%3aevilwebsite.com
 the wallet MUST NOT make a payment


### PR DESCRIPTION
This revives #119, which @laanwj closed in 2015 for lack of author consensus. One of three mutually exclusive options for the same problem — see the table at the bottom. My preference is #2229, not this PR; this one is here so the option is stated explicitly rather than assumed dead.

### The inconsistency

BIP 321's base58 example address has a deliberately broken checksum, but the bech32/bech32m examples added after the fork from BIP 21 do not follow that convention:

| Address | Status on master |
| --- | --- |
| `175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W` | invalid checksum (intentional) |
| `bc1qufgy354j3kmvuch987xe4s40836x3h0lg8f5n2` | valid bech32, witness v0, mainnet |
| `bc1p5swkugezn97763tl0yty6556856uug0q6jflljvep9m4p7339x5qzyrh4g` | valid bech32m, witness v1, mainnet |
| `tb1qghfhmd4zh7ncpmxl3qzhmq566jk8ckq4gafnmg` | valid bech32, witness v0, testnet |

Three of the four are already valid, so the document is inconsistent either way. #2228 and #2229 resolve it downward (document, or extend, the invalidity). This PR resolves it upward.

### This PR

Two changes:

1. Replaces the base58 address with `1NS17iag9jJgTHD1VXjvLCEnZuQ3rJED9L`, the replacement proposed in #119, at all 16 occurrences. Every address in the document then has a valid checksum, so all the example URIs parse and can be used as test vectors as they stand.
2. Adds a note that says not to pay them:

> Note: The addresses used in these examples are for illustration only and must not be used to send funds.

The note is the part that answers @laanwj's objection in #119 — that a valid example address is a spendable one — by warning the reader instead of breaking the encoding. Unlike BIP 21's note, it makes no claim about validity, so it stays true regardless of which addresses the document carries.

Why that specific address: it is BIP 20's example address, and BIP 20 already pairs it with the same `label=Luke-Jr` these examples use, so the labels stay coherent — the objection @luke-jr raised in #119 ("maybe change the label to something else too, if it isn't going to be _my_ address"). Verified as a valid P2PKH mainnet address.

### The case for it, from the #119 thread

- @schildbach: "from time to time, a user approaches me with a bug: Bitcoin Wallet does not parse certain bitcoin URIs. It turned out they were trying to use the malformed URIs from this document." A decade later, BIP 321 still ships those URIs.
- @evoskuil, who opened #119: the examples cannot be used as test vectors as they stand, and a non-address in a field the spec defines as an address is unrepresentative — "it might as well be _anything_, making the example fairly pointless".

### The case against, which closed #119

A note is a weaker guarantee than an unspendable string: it protects the reader who reads it, not the one who copies a URI out of a code block. The RFC analogy @laanwj drew (documentation IP ranges) argues for keeping example addresses structurally unusable, and this PR would take the document from two spendable mainnet addresses to four. That is why I still prefer #2229.

@laanwj also suggested a middle path in that thread: use **testnet** addresses throughout, so the examples are valid and parseable but accidental payments are harmless. That would be a fourth option, and a larger change than any of these three; happy to prepare it if that is the direction maintainers prefer.

There is also a smaller variant of this PR's approach — repairing the existing address's checksum in place, one character — which I worked out [in a comment below](https://github.com/bitcoin/bips/pull/2230#issuecomment-5147535469). It has the smallest diff of anything discussed here and the largest hazard, because it resurrects a real third-party address.

### The three options

| PR | Approach | Diff | |
| --- | --- | --- | --- |
| #2228 | keep the addresses, word the note to match reality | +2 | |
| #2229 | invalidate every address, add BIP 21's note verbatim | +7 / -5 | **my preference** |
| #2230 | make every address valid, warn against paying them | +18 / -16 | this PR |

Only one should be merged; I'll close the other two.

**My preference is #2229.** It is the only one of the three that leaves no spendable address anywhere in the document, it makes BIP 21's existing wording literally true here so the two documents stay in sync, and the whole cost is four characters. #2228 is the minimal-diff fallback if maintainers would rather not touch strings that downstream implementations may already be using as test vectors. This PR is the one I would close first.
