### PR TITLE
bip360: add spend-path test vectors

### DIFF
--- a/bip-0360/ref-impl/common/tests/data/p2mr_spending.json
+++ b/bip-0360/ref-impl/common/tests/data/p2mr_spending.json
@@ -1,0 +1,1285 @@
+{
+ "version": 1,
+ "comment": "BIP 360 P2MR spend-path test vectors. Deterministic: privkeys are sha256('p2mr_spending/key/<n>'), prevout txids sha256('p2mr_spending/prevout/<n>'), BIP 340 signing with all-zero aux. The trees for txinIndex 3 and 4 are p2mr_single_leaf_script_tree and p2mr_different_version_leaves from p2mr_construction.json. For inputs spent without a signature, privkey/hashType/annex/sigMsg/sigHash are null.",
+ "scriptPathSpending": [
+  {
+   "given": {
+    "rawUnsignedTx": "02000000063dcbe4adeac7da46f817a2736ed551cf039c1821c46096a48ed431654721f0810000000000fdffffff26b41f369a3050a49b6817e9aa203e7adfa376eb7da416351df82c1a5c84b3ed0100000000fdffffffbfd673a06a11bd8eebd420db5bc2a096ce701ee8a4867098bc9e93474d71bdd40200000000fdffffffa382b7978bbdbb3d3bc4582fdfb5bab1d270975bab8718ee4569f1dd4991d94a0300000000fdffffffd53e354b34d4ffa32d229c46565ffe75ae24867d71125f0c428c2a7efa7ba6480400000000fdffffff6fda80b4d409d4d059aedc7a030b55ab9cd31244874ed52817fefeaca5fae7c40500000000fdffffff01483b0900000000001600149b56225c85821fe9adb5abfded9ca33475130ce100000000",
+    "utxosSpent": [
+     {
+      "scriptPubKey": "522086f6637557256e2690b1b29cc2cbaebc164f1e2d1b6eeb81ebae1e42f5f5b256",
+      "amountSats": 100000
+     },
+     {
+      "scriptPubKey": "522001fc7a50a53871b80922aa7bcdbb5cc4270f816f34dbad769bfd9f11f347ab4a",
+      "amountSats": 101000
+     },
+     {
+      "scriptPubKey": "522086f6637557256e2690b1b29cc2cbaebc164f1e2d1b6eeb81ebae1e42f5f5b256",
+      "amountSats": 102000
+     },
+     {
+      "scriptPubKey": "5220c525714a7f49c28aedbbba78c005931a81c234b2f6c99a73e4d06082adc8bf2b",
+      "amountSats": 103000
+     },
+     {
+      "scriptPubKey": "52206c2dc106ab816b73f9d07e3cd1ef2c8c1256f519748e0813e4edd2405d277bef",
+      "amountSats": 104000
+     },
+     {
+      "scriptPubKey": "5220d15412fa20b21faaad02ec28ed1e0c001e9c0a26d41652fa41b9acb7299806c0",
+      "amountSats": 105000
+     }
+    ]
+   },
+   "intermediary": {
+    "hashAmounts": "b2d4688c2de9c023c3c0b14b81ad8415d8c45d9cb59e2ceba295d9f9bf2d028d",
+    "hashOutputs": "6235bdd81da747937f892b0309c7e1cbce7d1c1f280e08ff7d749b103d0c17c6",
+    "hashPrevouts": "dac2d10c87ff27c217bf9d4cf034ce5be164dbc10c69e9715f668318a21a6ad1",
+    "hashScriptPubkeys": "c52ec7508eb595a3faa883f295ef349226147cb9c563ea3f99ff519d3c17a067",
+    "hashSequences": "7227d3dacd64b5b7113e8ee68b80a576e94f9be0a00cb33beef18a4171b978d4"
+   },
+   "inputSpending": [
+    {
+     "given": {
+      "txinIndex": 0,
+      "scriptTree": [
+       {
+        "id": 0,
+        "script": "20da9e2f49a6ccb36f2b73e424b463ee11c233994da1f38e76762ceb4b587924f2ac",
+        "leafVersion": 192
+       },
+       {
+        "id": 1,
+        "script": "20a9746601b2c6a3b4ac2be8976f3f54ea9c6b6308c62eb72ddc643104da26c3f5ac",
+        "leafVersion": 192
+       }
+      ],
+      "leafId": 0,
+      "privkey": "7626f304b9e1dfff540a97b48a6b84bd7b7032fa51c0b04eb02b24ed34b0d9c7",
+      "hashType": 0,
+      "annex": null
+     },
+     "intermediary": {
+      "leafHash": "f942e6568a9e3dd96445eab8c6cee7fc087c87d9d468c780513645092d0032dc",
+      "merkleRoot": "86f6637557256e2690b1b29cc2cbaebc164f1e2d1b6eeb81ebae1e42f5f5b256",
+      "controlBlock": "c1c2e1db7e44fea793ef1b6aad64e78d7ef6cae882b5720a3e37ff7b1ad53ba278",
+      "sigMsg": "00000200000000000000dac2d10c87ff27c217bf9d4cf034ce5be164dbc10c69e9715f668318a21a6ad1b2d4688c2de9c023c3c0b14b81ad8415d8c45d9cb59e2ceba295d9f9bf2d028dc52ec7508eb595a3faa883f295ef349226147cb9c563ea3f99ff519d3c17a0677227d3dacd64b5b7113e8ee68b80a576e94f9be0a00cb33beef18a4171b978d46235bdd81da747937f892b0309c7e1cbce7d1c1f280e08ff7d749b103d0c17c60200000000f942e6568a9e3dd96445eab8c6cee7fc087c87d9d468c780513645092d0032dc00ffffffff",
+      "sigHash": "12a1ea6fe7594d42fca97138a9472920d26f5806e36a0ba378adec02963dda55"
+     },
+     "expected": {
+      "witness": [
+       "3dbd800f2e7869a5df728c79807941e21e9c130de39d6482822e8d4aaf8c2c17ccef5f33776b247f12e1cf0a071860106e6c2b7224e5fe78f302ccee72f4b2eb",
+       "20da9e2f49a6ccb36f2b73e424b463ee11c233994da1f38e76762ceb4b587924f2ac",
+       "c1c2e1db7e44fea793ef1b6aad64e78d7ef6cae882b5720a3e37ff7b1ad53ba278"
+      ]
+     },
+     "comment": "two-leaf tree, depth-1 leaf, SIGHASH_DEFAULT"
+    },
+    {
+     "given": {
+      "txinIndex": 1,
+      "scriptTree": [
+       {
+        "id": 0,
+        "script": "201aa440b85a3daae4415ceb12f0571c4ce4f53482f876f4dca64cd1961a486ddaac",
+        "leafVersion": 192
+       },
+       [
+        {
+         "id": 1,
+         "script": "2097309ed83e5abb588978f449af6f83f8bab1c16618922a1469ff0d1fca4fff01ac",
+         "leafVersion": 192
+        },
+        {
+         "id": 2,
+         "script": "20da9e2f49a6ccb36f2b73e424b463ee11c233994da1f38e76762ceb4b587924f2ac",
+         "leafVersion": 192
+        }
+       ]
+      ],
+      "leafId": 1,
+      "privkey": "07cd7c0b918753794ade15311f2e2933080c0e7da9590ee7ed38ffa6d341917b",
+      "hashType": 1,
+      "annex": null
+     },
+     "intermediary": {
+      "leafHash": "1a269f8048f8cf165f9c290016056a649485f8c7c4a7bfd869c264b81b5766b6",
+      "merkleRoot": "01fc7a50a53871b80922aa7bcdbb5cc4270f816f34dbad769bfd9f11f347ab4a",
+      "controlBlock": "c1f942e6568a9e3dd96445eab8c6cee7fc087c87d9d468c780513645092d0032dc8ffbba8dc2562a8affa8a0d0f8b6f0893458c749b51740c9270014f38f566bce",
+      "sigMsg": "00010200000000000000dac2d10c87ff27c217bf9d4cf034ce5be164dbc10c69e9715f668318a21a6ad1b2d4688c2de9c023c3c0b14b81ad8415d8c45d9cb59e2ceba295d9f9bf2d028dc52ec7508eb595a3faa883f295ef349226147cb9c563ea3f99ff519d3c17a0677227d3dacd64b5b7113e8ee68b80a576e94f9be0a00cb33beef18a4171b978d46235bdd81da747937f892b0309c7e1cbce7d1c1f280e08ff7d749b103d0c17c602010000001a269f8048f8cf165f9c290016056a649485f8c7c4a7bfd869c264b81b5766b600ffffffff",
+      "sigHash": "bd8a830cd2f916b1bda80006c5155b5704850bdff620e89a7fc863691a9dac51"
+     },
+     "expected": {
+      "witness": [
+       "39714e2e24224b8a3b4c0dfd3a1c8fe9300eb2c4f4d1f1ed0dd4350c081e1e0982b95c035b55331af6b0f995cb9b7ab0fb1a30b44513395f1be6e30af51eb3fc01",
+       "2097309ed83e5abb588978f449af6f83f8bab1c16618922a1469ff0d1fca4fff01ac",
+       "c1f942e6568a9e3dd96445eab8c6cee7fc087c87d9d468c780513645092d0032dc8ffbba8dc2562a8affa8a0d0f8b6f0893458c749b51740c9270014f38f566bce"
+      ]
+     },
+     "comment": "three-leaf tree, depth-2 leaf, SIGHASH_ALL"
+    },
+    {
+     "given": {
+      "txinIndex": 2,
+      "scriptTree": [
+       {
+        "id": 0,
+        "script": "20da9e2f49a6ccb36f2b73e424b463ee11c233994da1f38e76762ceb4b587924f2ac",
+        "leafVersion": 192
+       },
+       {
+        "id": 1,
+        "script": "20a9746601b2c6a3b4ac2be8976f3f54ea9c6b6308c62eb72ddc643104da26c3f5ac",
+        "leafVersion": 192
+       }
+      ],
+      "leafId": 1,
+      "privkey": "f7f4693aa949a9127cac7d7833167990c8f748460d6cee2467120186fd4aedfb",
+      "hashType": 0,
+      "annex": "5070326d7220616e6e6578"
+     },
+     "intermediary": {
+      "leafHash": "c2e1db7e44fea793ef1b6aad64e78d7ef6cae882b5720a3e37ff7b1ad53ba278",
+      "merkleRoot": "86f6637557256e2690b1b29cc2cbaebc164f1e2d1b6eeb81ebae1e42f5f5b256",
+      "controlBlock": "c1f942e6568a9e3dd96445eab8c6cee7fc087c87d9d468c780513645092d0032dc",
+      "sigMsg": "00000200000000000000dac2d10c87ff27c217bf9d4cf034ce5be164dbc10c69e9715f668318a21a6ad1b2d4688c2de9c023c3c0b14b81ad8415d8c45d9cb59e2ceba295d9f9bf2d028dc52ec7508eb595a3faa883f295ef349226147cb9c563ea3f99ff519d3c17a0677227d3dacd64b5b7113e8ee68b80a576e94f9be0a00cb33beef18a4171b978d46235bdd81da747937f892b0309c7e1cbce7d1c1f280e08ff7d749b103d0c17c60302000000850d9d88ab7918607ef8df3b77489fce314a340a6f66cb6376d237b1f26c5b68c2e1db7e44fea793ef1b6aad64e78d7ef6cae882b5720a3e37ff7b1ad53ba27800ffffffff",
+      "sigHash": "49b224a0a9c889086f093e3535a4eb9dea227788f98c60181f62ed58457dbfc0"
+     },
+     "expected": {
+      "witness": [
+       "56f6533d4c196efcd3c8e84fa24f87dc4348c265a92c9f4d843bf8ddd1c1569b9738611bfe49bb7e48a215bbe2a131c3464c256a0024858e97213d5d7e5368f4",
+       "20a9746601b2c6a3b4ac2be8976f3f54ea9c6b6308c62eb72ddc643104da26c3f5ac",
+       "c1f942e6568a9e3dd96445eab8c6cee7fc087c87d9d468c780513645092d0032dc",
+       "5070326d7220616e6e6578"
+      ]
+     },
+     "comment": "annex present: last witness element, covered by the signature"
+    },
+    {
+     "given": {
+      "txinIndex": 3,
+      "scriptTree": {
+       "id": 0,
+       "script": "20b617298552a72ade070667e86ca63b8f5789a9fe8731ef91202a91c9f3459007ac",
+       "asm": "b617298552a72ade070667e86ca63b8f5789a9fe8731ef91202a91c9f3459007 OP_CHECKSIG",
+       "leafVersion": 192
+      },
+      "leafId": 0,
+      "privkey": null,
+      "hashType": null,
+      "annex": null
+     },
+     "intermediary": {
+      "leafHash": "c525714a7f49c28aedbbba78c005931a81c234b2f6c99a73e4d06082adc8bf2b",
+      "merkleRoot": "c525714a7f49c28aedbbba78c005931a81c234b2f6c99a73e4d06082adc8bf2b",
+      "controlBlock": "c1",
+      "sigMsg": null,
+      "sigHash": null
+     },
+     "expected": {
+      "witness": [
+       "20b617298552a72ade070667e86ca63b8f5789a9fe8731ef91202a91c9f3459007ac",
+       "c1"
+      ]
+     },
+     "comment": "p2mr_single_leaf_script_tree: depth-0, script execution is skipped, no signature; anyone who knows the leaf script can spend (v0.12.0 rule)"
+    },
+    {
+     "given": {
+      "txinIndex": 4,
+      "scriptTree": [
+       {
+        "id": 0,
+        "script": "20387671353e273264c495656e27e39ba899ea8fee3bb69fb2a680e22093447d48ac",
+        "asm": "387671353e273264c495656e27e39ba899ea8fee3bb69fb2a680e22093447d48 OP_CHECKSIG",
+        "leafVersion": 192
+       },
+       {
+        "id": 1,
+        "script": "06424950333431",
+        "asm": "424950333431",
+        "description": "just pushes the string 'BIP341' onto the stack",
+        "leafVersion": 250
+       }
+      ],
+      "leafId": 1,
+      "privkey": null,
+      "hashType": null,
+      "annex": null
+     },
+     "intermediary": {
+      "leafHash": "f224a923cd0021ab202ab139cc56802ddb92dcfc172b9212261a539df79a112a",
+      "merkleRoot": "6c2dc106ab816b73f9d07e3cd1ef2c8c1256f519748e0813e4edd2405d277bef",
+      "controlBlock": "fb8ad69ec7cf41c2a4001fd1f738bf1e505ce2277acdcaa63fe4765192497f47a7",
+      "sigMsg": null,
+      "sigHash": null
+     },
+     "expected": {
+      "witness": [
+       "06424950333431",
+       "fb8ad69ec7cf41c2a4001fd1f738bf1e505ce2277acdcaa63fe4765192497f47a7"
+      ]
+     },
+     "comment": "p2mr_different_version_leaves through the 0xfa leaf: unknown leaf versions are unencumbered"
+    },
+    {
+     "given": {
+      "txinIndex": 5,
+      "scriptTree": [
+       [
+        [
+         [
+          [
+           [
+            [
+             [
+              [
+               [
+                [
+                 [
+                  [
+                   [
+                    [
+                     [
+                      [
+                       [
+                        [
+                         [
+                          [
+                           [
+                            [
+                             [
+                              [
+                               [
+                                [
+                                 [
+                                  [
+                                   [
+                                    [
+                                     [
+                                      [
+                                       [
+                                        [
+                                         [
+                                          [
+                                           [
+                                            [
+                                             [
+                                              [
+                                               [
+                                                [
+                                                 [
+                                                  [
+                                                   [
+                                                    [
+                                                     [
+                                                      [
+                                                       [
+                                                        [
+                                                         [
+                                                          [
+                                                           [
+                                                            [
+                                                             [
+                                                              [
+                                                               [
+                                                                [
+                                                                 [
+                                                                  [
+                                                                   [
+                                                                    [
+                                                                     [
+                                                                      [
+                                                                       [
+                                                                        [
+                                                                         [
+                                                                          [
+                                                                           [
+                                                                            [
+                                                                             [
+                                                                              [
+                                                                               [
+                                                                                [
+                                                                                 [
+                                                                                  [
+                                                                                   [
+                                                                                    [
+                                                                                     [
+                                                                                      [
+                                                                                       [
+                                                                                        [
+                                                                                         [
+                                                                                          [
+                                                                                           [
+                                                                                            [
+                                                                                             [
+                                                                                              [
+                                                                                               [
+                                                                                                [
+                                                                                                 [
+                                                                                                  [
+                                                                                                   [
+                                                                                                    [
+                                                                                                     [
+                                                                                                      [
+                                                                                                       [
+                                                                                                        [
+                                                                                                         [
+                                                                                                          [
+                                                                                                           [
+                                                                                                            [
+                                                                                                             [
+                                                                                                              [
+                                                                                                               [
+                                                                                                                [
+                                                                                                                 [
+                                                                                                                  [
+                                                                                                                   [
+                                                                                                                    [
+                                                                                                                     [
+                                                                                                                      [
+                                                                                                                       [
+                                                                                                                        [
+                                                                                                                         [
+                                                                                                                          [
+                                                                                                                           [
+                                                                                                                            [
+                                                                                                                             [
+                                                                                                                              [
+                                                                                                                               [
+                                                                                                                                [
+                                                                                                                                 [
+                                                                                                                                  [
+                                                                                                                                   [
+                                                                                                                                    [
+                                                                                                                                     [
+                                                                                                                                      {
+                                                                                                                                       "id": 0,
+                                                                                                                                       "script": "201aa440b85a3daae4415ceb12f0571c4ce4f53482f876f4dca64cd1961a486ddaac",
+                                                                                                                                       "leafVersion": 192
+                                                                                                                                      },
+                                                                                                                                      {
+                                                                                                                                       "id": 1,
+                                                                                                                                       "script": "51",
+                                                                                                                                       "leafVersion": 192
+                                                                                                                                      }
+                                                                                                                                     ],
+                                                                                                                                     {
+                                                                                                                                      "id": 2,
+                                                                                                                                      "script": "51",
+                                                                                                                                      "leafVersion": 192
+                                                                                                                                     }
+                                                                                                                                    ],
+                                                                                                                                    {
+                                                                                                                                     "id": 3,
+                                                                                                                                     "script": "51",
+                                                                                                                                     "leafVersion": 192
+                                                                                                                                    }
+                                                                                                                                   ],
+                                                                                                                                   {
+                                                                                                                                    "id": 4,
+                                                                                                                                    "script": "51",
+                                                                                                                                    "leafVersion": 192
+                                                                                                                                   }
+                                                                                                                                  ],
+                                                                                                                                  {
+                                                                                                                                   "id": 5,
+                                                                                                                                   "script": "51",
+                                                                                                                                   "leafVersion": 192
+                                                                                                                                  }
+                                                                                                                                 ],
+                                                                                                                                 {
+                                                                                                                                  "id": 6,
+                                                                                                                                  "script": "51",
+                                                                                                                                  "leafVersion": 192
+                                                                                                                                 }
+                                                                                                                                ],
+                                                                                                                                {
+                                                                                                                                 "id": 7,
+                                                                                                                                 "script": "51",
+                                                                                                                                 "leafVersion": 192
+                                                                                                                                }
+                                                                                                                               ],
+                                                                                                                               {
+                                                                                                                                "id": 8,
+                                                                                                                                "script": "51",
+                                                                                                                                "leafVersion": 192
+                                                                                                                               }
+                                                                                                                              ],
+                                                                                                                              {
+                                                                                                                               "id": 9,
+                                                                                                                               "script": "51",
+                                                                                                                               "leafVersion": 192
+                                                                                                                              }
+                                                                                                                             ],
+                                                                                                                             {
+                                                                                                                              "id": 10,
+                                                                                                                              "script": "51",
+                                                                                                                              "leafVersion": 192
+                                                                                                                             }
+                                                                                                                            ],
+                                                                                                                            {
+                                                                                                                             "id": 11,
+                                                                                                                             "script": "51",
+                                                                                                                             "leafVersion": 192
+                                                                                                                            }
+                                                                                                                           ],
+                                                                                                                           {
+                                                                                                                            "id": 12,
+                                                                                                                            "script": "51",
+                                                                                                                            "leafVersion": 192
+                                                                                                                           }
+                                                                                                                          ],
+                                                                                                                          {
+                                                                                                                           "id": 13,
+                                                                                                                           "script": "51",
+                                                                                                                           "leafVersion": 192
+                                                                                                                          }
+                                                                                                                         ],
+                                                                                                                         {
+                                                                                                                          "id": 14,
+                                                                                                                          "script": "51",
+                                                                                                                          "leafVersion": 192
+                                                                                                                         }
+                                                                                                                        ],
+                                                                                                                        {
+                                                                                                                         "id": 15,
+                                                                                                                         "script": "51",
+                                                                                                                         "leafVersion": 192
+                                                                                                                        }
+                                                                                                                       ],
+                                                                                                                       {
+                                                                                                                        "id": 16,
+                                                                                                                        "script": "51",
+                                                                                                                        "leafVersion": 192
+                                                                                                                       }
+                                                                                                                      ],
+                                                                                                                      {
+                                                                                                                       "id": 17,
+                                                                                                                       "script": "51",
+                                                                                                                       "leafVersion": 192
+                                                                                                                      }
+                                                                                                                     ],
+                                                                                                                     {
+                                                                                                                      "id": 18,
+                                                                                                                      "script": "51",
+                                                                                                                      "leafVersion": 192
+                                                                                                                     }
+                                                                                                                    ],
+                                                                                                                    {
+                                                                                                                     "id": 19,
+                                                                                                                     "script": "51",
+                                                                                                                     "leafVersion": 192
+                                                                                                                    }
+                                                                                                                   ],
+                                                                                                                   {
+                                                                                                                    "id": 20,
+                                                                                                                    "script": "51",
+                                                                                                                    "leafVersion": 192
+                                                                                                                   }
+                                                                                                                  ],
+                                                                                                                  {
+                                                                                                                   "id": 21,
+                                                                                                                   "script": "51",
+                                                                                                                   "leafVersion": 192
+                                                                                                                  }
+                                                                                                                 ],
+                                                                                                                 {
+                                                                                                                  "id": 22,
+                                                                                                                  "script": "51",
+                                                                                                                  "leafVersion": 192
+                                                                                                                 }
+                                                                                                                ],
+                                                                                                                {
+                                                                                                                 "id": 23,
+                                                                                                                 "script": "51",
+                                                                                                                 "leafVersion": 192
+                                                                                                                }
+                                                                                                               ],
+                                                                                                               {
+                                                                                                                "id": 24,
+                                                                                                                "script": "51",
+                                                                                                                "leafVersion": 192
+                                                                                                               }
+                                                                                                              ],
+                                                                                                              {
+                                                                                                               "id": 25,
+                                                                                                               "script": "51",
+                                                                                                               "leafVersion": 192
+                                                                                                              }
+                                                                                                             ],
+                                                                                                             {
+                                                                                                              "id": 26,
+                                                                                                              "script": "51",
+                                                                                                              "leafVersion": 192
+                                                                                                             }
+                                                                                                            ],
+                                                                                                            {
+                                                                                                             "id": 27,
+                                                                                                             "script": "51",
+                                                                                                             "leafVersion": 192
+                                                                                                            }
+                                                                                                           ],
+                                                                                                           {
+                                                                                                            "id": 28,
+                                                                                                            "script": "51",
+                                                                                                            "leafVersion": 192
+                                                                                                           }
+                                                                                                          ],
+                                                                                                          {
+                                                                                                           "id": 29,
+                                                                                                           "script": "51",
+                                                                                                           "leafVersion": 192
+                                                                                                          }
+                                                                                                         ],
+                                                                                                         {
+                                                                                                          "id": 30,
+                                                                                                          "script": "51",
+                                                                                                          "leafVersion": 192
+                                                                                                         }
+                                                                                                        ],
+                                                                                                        {
+                                                                                                         "id": 31,
+                                                                                                         "script": "51",
+                                                                                                         "leafVersion": 192
+                                                                                                        }
+                                                                                                       ],
+                                                                                                       {
+                                                                                                        "id": 32,
+                                                                                                        "script": "51",
+                                                                                                        "leafVersion": 192
+                                                                                                       }
+                                                                                                      ],
+                                                                                                      {
+                                                                                                       "id": 33,
+                                                                                                       "script": "51",
+                                                                                                       "leafVersion": 192
+                                                                                                      }
+                                                                                                     ],
+                                                                                                     {
+                                                                                                      "id": 34,
+                                                                                                      "script": "51",
+                                                                                                      "leafVersion": 192
+                                                                                                     }
+                                                                                                    ],
+                                                                                                    {
+                                                                                                     "id": 35,
+                                                                                                     "script": "51",
+                                                                                                     "leafVersion": 192
+                                                                                                    }
+                                                                                                   ],
+                                                                                                   {
+                                                                                                    "id": 36,
+                                                                                                    "script": "51",
+                                                                                                    "leafVersion": 192
+                                                                                                   }
+                                                                                                  ],
+                                                                                                  {
+                                                                                                   "id": 37,
+                                                                                                   "script": "51",
+                                                                                                   "leafVersion": 192
+                                                                                                  }
+                                                                                                 ],
+                                                                                                 {
+                                                                                                  "id": 38,
+                                                                                                  "script": "51",
+                                                                                                  "leafVersion": 192
+                                                                                                 }
+                                                                                                ],
+                                                                                                {
+                                                                                                 "id": 39,
+                                                                                                 "script": "51",
+                                                                                                 "leafVersion": 192
+                                                                                                }
+                                                                                               ],
+                                                                                               {
+                                                                                                "id": 40,
+                                                                                                "script": "51",
+                                                                                                "leafVersion": 192
+                                                                                               }
+                                                                                              ],
+                                                                                              {
+                                                                                               "id": 41,
+                                                                                               "script": "51",
+                                                                                               "leafVersion": 192
+                                                                                              }
+                                                                                             ],
+                                                                                             {
+                                                                                              "id": 42,
+                                                                                              "script": "51",
+                                                                                              "leafVersion": 192
+                                                                                             }
+                                                                                            ],
+                                                                                            {
+                                                                                             "id": 43,
+                                                                                             "script": "51",
+                                                                                             "leafVersion": 192
+                                                                                            }
+                                                                                           ],
+                                                                                           {
+                                                                                            "id": 44,
+                                                                                            "script": "51",
+                                                                                            "leafVersion": 192
+                                                                                           }
+                                                                                          ],
+                                                                                          {
+                                                                                           "id": 45,
+                                                                                           "script": "51",
+                                                                                           "leafVersion": 192
+                                                                                          }
+                                                                                         ],
+                                                                                         {
+                                                                                          "id": 46,
+                                                                                          "script": "51",
+                                                                                          "leafVersion": 192
+                                                                                         }
+                                                                                        ],
+                                                                                        {
+                                                                                         "id": 47,
+                                                                                         "script": "51",
+                                                                                         "leafVersion": 192
+                                                                                        }
+                                                                                       ],
+                                                                                       {
+                                                                                        "id": 48,
+                                                                                        "script": "51",
+                                                                                        "leafVersion": 192
+                                                                                       }
+                                                                                      ],
+                                                                                      {
+                                                                                       "id": 49,
+                                                                                       "script": "51",
+                                                                                       "leafVersion": 192
+                                                                                      }
+                                                                                     ],
+                                                                                     {
+                                                                                      "id": 50,
+                                                                                      "script": "51",
+                                                                                      "leafVersion": 192
+                                                                                     }
+                                                                                    ],
+                                                                                    {
+                                                                                     "id": 51,
+                                                                                     "script": "51",
+                                                                                     "leafVersion": 192
+                                                                                    }
+                                                                                   ],
+                                                                                   {
+                                                                                    "id": 52,
+                                                                                    "script": "51",
+                                                                                    "leafVersion": 192
+                                                                                   }
+                                                                                  ],
+                                                                                  {
+                                                                                   "id": 53,
+                                                                                   "script": "51",
+                                                                                   "leafVersion": 192
+                                                                                  }
+                                                                                 ],
+                                                                                 {
+                                                                                  "id": 54,
+                                                                                  "script": "51",
+                                                                                  "leafVersion": 192
+                                                                                 }
+                                                                                ],
+                                                                                {
+                                                                                 "id": 55,
+                                                                                 "script": "51",
+                                                                                 "leafVersion": 192
+                                                                                }
+                                                                               ],
+                                                                               {
+                                                                                "id": 56,
+                                                                                "script": "51",
+                                                                                "leafVersion": 192
+                                                                               }
+                                                                              ],
+                                                                              {
+                                                                               "id": 57,
+                                                                               "script": "51",
+                                                                               "leafVersion": 192
+                                                                              }
+                                                                             ],
+                                                                             {
+                                                                              "id": 58,
+                                                                              "script": "51",
+                                                                              "leafVersion": 192
+                                                                             }
+                                                                            ],
+                                                                            {
+                                                                             "id": 59,
+                                                                             "script": "51",
+                                                                             "leafVersion": 192
+                                                                            }
+                                                                           ],
+                                                                           {
+                                                                            "id": 60,
+                                                                            "script": "51",
+                                                                            "leafVersion": 192
+                                                                           }
+                                                                          ],
+                                                                          {
+                                                                           "id": 61,
+                                                                           "script": "51",
+                                                                           "leafVersion": 192
+                                                                          }
+                                                                         ],
+                                                                         {
+                                                                          "id": 62,
+                                                                          "script": "51",
+                                                                          "leafVersion": 192
+                                                                         }
+                                                                        ],
+                                                                        {
+                                                                         "id": 63,
+                                                                         "script": "51",
+                                                                         "leafVersion": 192
+                                                                        }
+                                                                       ],
+                                                                       {
+                                                                        "id": 64,
+                                                                        "script": "51",
+                                                                        "leafVersion": 192
+                                                                       }
+                                                                      ],
+                                                                      {
+                                                                       "id": 65,
+                                                                       "script": "51",
+                                                                       "leafVersion": 192
+                                                                      }
+                                                                     ],
+                                                                     {
+                                                                      "id": 66,
+                                                                      "script": "51",
+                                                                      "leafVersion": 192
+                                                                     }
+                                                                    ],
+                                                                    {
+                                                                     "id": 67,
+                                                                     "script": "51",
+                                                                     "leafVersion": 192
+                                                                    }
+                                                                   ],
+                                                                   {
+                                                                    "id": 68,
+                                                                    "script": "51",
+                                                                    "leafVersion": 192
+                                                                   }
+                                                                  ],
+                                                                  {
+                                                                   "id": 69,
+                                                                   "script": "51",
+                                                                   "leafVersion": 192
+                                                                  }
+                                                                 ],
+                                                                 {
+                                                                  "id": 70,
+                                                                  "script": "51",
+                                                                  "leafVersion": 192
+                                                                 }
+                                                                ],
+                                                                {
+                                                                 "id": 71,
+                                                                 "script": "51",
+                                                                 "leafVersion": 192
+                                                                }
+                                                               ],
+                                                               {
+                                                                "id": 72,
+                                                                "script": "51",
+                                                                "leafVersion": 192
+                                                               }
+                                                              ],
+                                                              {
+                                                               "id": 73,
+                                                               "script": "51",
+                                                               "leafVersion": 192
+                                                              }
+                                                             ],
+                                                             {
+                                                              "id": 74,
+                                                              "script": "51",
+                                                              "leafVersion": 192
+                                                             }
+                                                            ],
+                                                            {
+                                                             "id": 75,
+                                                             "script": "51",
+                                                             "leafVersion": 192
+                                                            }
+                                                           ],
+                                                           {
+                                                            "id": 76,
+                                                            "script": "51",
+                                                            "leafVersion": 192
+                                                           }
+                                                          ],
+                                                          {
+                                                           "id": 77,
+                                                           "script": "51",
+                                                           "leafVersion": 192
+                                                          }
+                                                         ],
+                                                         {
+                                                          "id": 78,
+                                                          "script": "51",
+                                                          "leafVersion": 192
+                                                         }
+                                                        ],
+                                                        {
+                                                         "id": 79,
+                                                         "script": "51",
+                                                         "leafVersion": 192
+                                                        }
+                                                       ],
+                                                       {
+                                                        "id": 80,
+                                                        "script": "51",
+                                                        "leafVersion": 192
+                                                       }
+                                                      ],
+                                                      {
+                                                       "id": 81,
+                                                       "script": "51",
+                                                       "leafVersion": 192
+                                                      }
+                                                     ],
+                                                     {
+                                                      "id": 82,
+                                                      "script": "51",
+                                                      "leafVersion": 192
+                                                     }
+                                                    ],
+                                                    {
+                                                     "id": 83,
+                                                     "script": "51",
+                                                     "leafVersion": 192
+                                                    }
+                                                   ],
+                                                   {
+                                                    "id": 84,
+                                                    "script": "51",
+                                                    "leafVersion": 192
+                                                   }
+                                                  ],
+                                                  {
+                                                   "id": 85,
+                                                   "script": "51",
+                                                   "leafVersion": 192
+                                                  }
+                                                 ],
+                                                 {
+                                                  "id": 86,
+                                                  "script": "51",
+                                                  "leafVersion": 192
+                                                 }
+                                                ],
+                                                {
+                                                 "id": 87,
+                                                 "script": "51",
+                                                 "leafVersion": 192
+                                                }
+                                               ],
+                                               {
+                                                "id": 88,
+                                                "script": "51",
+                                                "leafVersion": 192
+                                               }
+                                              ],
+                                              {
+                                               "id": 89,
+                                               "script": "51",
+                                               "leafVersion": 192
+                                              }
+                                             ],
+                                             {
+                                              "id": 90,
+                                              "script": "51",
+                                              "leafVersion": 192
+                                             }
+                                            ],
+                                            {
+                                             "id": 91,
+                                             "script": "51",
+                                             "leafVersion": 192
+                                            }
+                                           ],
+                                           {
+                                            "id": 92,
+                                            "script": "51",
+                                            "leafVersion": 192
+                                           }
+                                          ],
+                                          {
+                                           "id": 93,
+                                           "script": "51",
+                                           "leafVersion": 192
+                                          }
+                                         ],
+                                         {
+                                          "id": 94,
+                                          "script": "51",
+                                          "leafVersion": 192
+                                         }
+                                        ],
+                                        {
+                                         "id": 95,
+                                         "script": "51",
+                                         "leafVersion": 192
+                                        }
+                                       ],
+                                       {
+                                        "id": 96,
+                                        "script": "51",
+                                        "leafVersion": 192
+                                       }
+                                      ],
+                                      {
+                                       "id": 97,
+                                       "script": "51",
+                                       "leafVersion": 192
+                                      }
+                                     ],
+                                     {
+                                      "id": 98,
+                                      "script": "51",
+                                      "leafVersion": 192
+                                     }
+                                    ],
+                                    {
+                                     "id": 99,
+                                     "script": "51",
+                                     "leafVersion": 192
+                                    }
+                                   ],
+                                   {
+                                    "id": 100,
+                                    "script": "51",
+                                    "leafVersion": 192
+                                   }
+                                  ],
+                                  {
+                                   "id": 101,
+                                   "script": "51",
+                                   "leafVersion": 192
+                                  }
+                                 ],
+                                 {
+                                  "id": 102,
+                                  "script": "51",
+                                  "leafVersion": 192
+                                 }
+                                ],
+                                {
+                                 "id": 103,
+                                 "script": "51",
+                                 "leafVersion": 192
+                                }
+                               ],
+                               {
+                                "id": 104,
+                                "script": "51",
+                                "leafVersion": 192
+                               }
+                              ],
+                              {
+                               "id": 105,
+                               "script": "51",
+                               "leafVersion": 192
+                              }
+                             ],
+                             {
+                              "id": 106,
+                              "script": "51",
+                              "leafVersion": 192
+                             }
+                            ],
+                            {
+                             "id": 107,
+                             "script": "51",
+                             "leafVersion": 192
+                            }
+                           ],
+                           {
+                            "id": 108,
+                            "script": "51",
+                            "leafVersion": 192
+                           }
+                          ],
+                          {
+                           "id": 109,
+                           "script": "51",
+                           "leafVersion": 192
+                          }
+                         ],
+                         {
+                          "id": 110,
+                          "script": "51",
+                          "leafVersion": 192
+                         }
+                        ],
+                        {
+                         "id": 111,
+                         "script": "51",
+                         "leafVersion": 192
+                        }
+                       ],
+                       {
+                        "id": 112,
+                        "script": "51",
+                        "leafVersion": 192
+                       }
+                      ],
+                      {
+                       "id": 113,
+                       "script": "51",
+                       "leafVersion": 192
+                      }
+                     ],
+                     {
+                      "id": 114,
+                      "script": "51",
+                      "leafVersion": 192
+                     }
+                    ],
+                    {
+                     "id": 115,
+                     "script": "51",
+                     "leafVersion": 192
+                    }
+                   ],
+                   {
+                    "id": 116,
+                    "script": "51",
+                    "leafVersion": 192
+                   }
+                  ],
+                  {
+                   "id": 117,
+                   "script": "51",
+                   "leafVersion": 192
+                  }
+                 ],
+                 {
+                  "id": 118,
+                  "script": "51",
+                  "leafVersion": 192
+                 }
+                ],
+                {
+                 "id": 119,
+                 "script": "51",
+                 "leafVersion": 192
+                }
+               ],
+               {
+                "id": 120,
+                "script": "51",
+                "leafVersion": 192
+               }
+              ],
+              {
+               "id": 121,
+               "script": "51",
+               "leafVersion": 192
+              }
+             ],
+             {
+              "id": 122,
+              "script": "51",
+              "leafVersion": 192
+             }
+            ],
+            {
+             "id": 123,
+             "script": "51",
+             "leafVersion": 192
+            }
+           ],
+           {
+            "id": 124,
+            "script": "51",
+            "leafVersion": 192
+           }
+          ],
+          {
+           "id": 125,
+           "script": "51",
+           "leafVersion": 192
+          }
+         ],
+         {
+          "id": 126,
+          "script": "51",
+          "leafVersion": 192
+         }
+        ],
+        {
+         "id": 127,
+         "script": "51",
+         "leafVersion": 192
+        }
+       ],
+       {
+        "id": 128,
+        "script": "51",
+        "leafVersion": 192
+       }
+      ],
+      "leafId": 0,
+      "privkey": "4475d2f1cc81a30369c83ccafc7611a9b1c98ef9c15abba1582a85b07798404e",
+      "hashType": 0,
+      "annex": null
+     },
+     "intermediary": {
+      "leafHash": "8ffbba8dc2562a8affa8a0d0f8b6f0893458c749b51740c9270014f38f566bce",
+      "merkleRoot": "d15412fa20b21faaad02ec28ed1e0c001e9c0a26d41652fa41b9acb7299806c0",
+      "controlBlock": "c1a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675",
+      "sigMsg": "00000200000000000000dac2d10c87ff27c217bf9d4cf034ce5be164dbc10c69e9715f668318a21a6ad1b2d4688c2de9c023c3c0b14b81ad8415d8c45d9cb59e2ceba295d9f9bf2d028dc52ec7508eb595a3faa883f295ef349226147cb9c563ea3f99ff519d3c17a0677227d3dacd64b5b7113e8ee68b80a576e94f9be0a00cb33beef18a4171b978d46235bdd81da747937f892b0309c7e1cbce7d1c1f280e08ff7d749b103d0c17c602050000008ffbba8dc2562a8affa8a0d0f8b6f0893458c749b51740c9270014f38f566bce00ffffffff",
+      "sigHash": "c25821724c4190278a565565e19702f19eaff64f1e1a6d1770c3cd935cc02500"
+     },
+     "expected": {
+      "witness": [
+       "6aabf0fb957adfa8e2c9bd8743f632692296877390b7f7b065e9485d98d34086e1bd18ae61c73e34e5225c8d3b342826455cca0a73a27f3eb543dcf328aa6aa9",
+       "201aa440b85a3daae4415ceb12f0571c4ce4f53482f876f4dca64cd1961a486ddaac",
+       "c1a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675"
+      ]
+     },
+     "comment": "depth-128 leaf: the control block is exactly the maximum 1 + 32*128 bytes"
+    }
+   ],
+   "auxiliary": {
+    "fullySignedTx": "020000000001063dcbe4adeac7da46f817a2736ed551cf039c1821c46096a48ed431654721f0810000000000fdffffff26b41f369a3050a49b6817e9aa203e7adfa376eb7da416351df82c1a5c84b3ed0100000000fdffffffbfd673a06a11bd8eebd420db5bc2a096ce701ee8a4867098bc9e93474d71bdd40200000000fdffffffa382b7978bbdbb3d3bc4582fdfb5bab1d270975bab8718ee4569f1dd4991d94a0300000000fdffffffd53e354b34d4ffa32d229c46565ffe75ae24867d71125f0c428c2a7efa7ba6480400000000fdffffff6fda80b4d409d4d059aedc7a030b55ab9cd31244874ed52817fefeaca5fae7c40500000000fdffffff01483b0900000000001600149b56225c85821fe9adb5abfded9ca33475130ce103403dbd800f2e7869a5df728c79807941e21e9c130de39d6482822e8d4aaf8c2c17ccef5f33776b247f12e1cf0a071860106e6c2b7224e5fe78f302ccee72f4b2eb2220da9e2f49a6ccb36f2b73e424b463ee11c233994da1f38e76762ceb4b587924f2ac21c1c2e1db7e44fea793ef1b6aad64e78d7ef6cae882b5720a3e37ff7b1ad53ba278034139714e2e24224b8a3b4c0dfd3a1c8fe9300eb2c4f4d1f1ed0dd4350c081e1e0982b95c035b55331af6b0f995cb9b7ab0fb1a30b44513395f1be6e30af51eb3fc01222097309ed83e5abb588978f449af6f83f8bab1c16618922a1469ff0d1fca4fff01ac41c1f942e6568a9e3dd96445eab8c6cee7fc087c87d9d468c780513645092d0032dc8ffbba8dc2562a8affa8a0d0f8b6f0893458c749b51740c9270014f38f566bce044056f6533d4c196efcd3c8e84fa24f87dc4348c265a92c9f4d843bf8ddd1c1569b9738611bfe49bb7e48a215bbe2a131c3464c256a0024858e97213d5d7e5368f42220a9746601b2c6a3b4ac2be8976f3f54ea9c6b6308c62eb72ddc643104da26c3f5ac21c1f942e6568a9e3dd96445eab8c6cee7fc087c87d9d468c780513645092d0032dc0b5070326d7220616e6e6578022220b617298552a72ade070667e86ca63b8f5789a9fe8731ef91202a91c9f3459007ac01c102070642495033343121fb8ad69ec7cf41c2a4001fd1f738bf1e505ce2277acdcaa63fe4765192497f47a703406aabf0fb957adfa8e2c9bd8743f632692296877390b7f7b065e9485d98d34086e1bd18ae61c73e34e5225c8d3b342826455cca0a73a27f3eb543dcf328aa6aa922201aa440b85a3daae4415ceb12f0571c4ce4f53482f876f4dca64cd1961a486ddaacfd0110c1a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d67500000000"
+   }
+  }
+ ],
+ "invalidSpending": [
+  {
+   "id": "p2mr_spend_invalid_signature",
+   "given": {
+    "rawTx": "020000000001013dcbe4adeac7da46f817a2736ed551cf039c1821c46096a48ed431654721f0810000000000fdffffff01905f0100000000001600149b56225c85821fe9adb5abfded9ca33475130ce103402e3c0e7e0205603d37c74508d8cced22bb217ce2ee5f75f4e3acc5604783ab7134622eb6042ce6665deca5167aa5cb1c65db9e859868c804610186bbb2ed362a2220da9e2f49a6ccb36f2b73e424b463ee11c233994da1f38e76762ceb4b587924f2ac21c1c2e1db7e44fea793ef1b6aad64e78d7ef6cae882b5720a3e37ff7b1ad53ba27800000000",
+    "utxoSpent": {
+     "scriptPubKey": "522086f6637557256e2690b1b29cc2cbaebc164f1e2d1b6eeb81ebae1e42f5f5b256",
+     "amountSats": 100000
+    }
+   },
+   "expected": {
+    "error": "invalid signature"
+   },
+   "comment": "first byte of an otherwise valid signature flipped"
+  },
+  {
+   "id": "p2mr_spend_tampered_merkle_path",
+   "given": {
+    "rawTx": "020000000001013dcbe4adeac7da46f817a2736ed551cf039c1821c46096a48ed431654721f0810000000000fdffffff01905f0100000000001600149b56225c85821fe9adb5abfded9ca33475130ce103402f3c0e7e0205603d37c74508d8cced22bb217ce2ee5f75f4e3acc5604783ab7134622eb6042ce6665deca5167aa5cb1c65db9e859868c804610186bbb2ed362a2220da9e2f49a6ccb36f2b73e424b463ee11c233994da1f38e76762ceb4b587924f2ac21c1c3e1db7e44fea793ef1b6aad64e78d7ef6cae882b5720a3e37ff7b1ad53ba27800000000",
+    "utxoSpent": {
+     "scriptPubKey": "522086f6637557256e2690b1b29cc2cbaebc164f1e2d1b6eeb81ebae1e42f5f5b256",
+     "amountSats": 100000
+    }
+   },
+   "expected": {
+    "error": "witness program mismatch"
+   },
+   "comment": "one bit of the Merkle path flipped: the computed root no longer matches the witness program"
+  },
+  {
+   "id": "p2mr_spend_control_byte_low_bit_zero",
+   "given": {
+    "rawTx": "020000000001013dcbe4adeac7da46f817a2736ed551cf039c1821c46096a48ed431654721f0810000000000fdffffff01905f0100000000001600149b56225c85821fe9adb5abfded9ca33475130ce103402f3c0e7e0205603d37c74508d8cced22bb217ce2ee5f75f4e3acc5604783ab7134622eb6042ce6665deca5167aa5cb1c65db9e859868c804610186bbb2ed362a2220da9e2f49a6ccb36f2b73e424b463ee11c233994da1f38e76762ceb4b587924f2ac21c0c2e1db7e44fea793ef1b6aad64e78d7ef6cae882b5720a3e37ff7b1ad53ba27800000000",
+    "utxoSpent": {
+     "scriptPubKey": "522086f6637557256e2690b1b29cc2cbaebc164f1e2d1b6eeb81ebae1e42f5f5b256",
+     "amountSats": 100000
+    }
+   },
+   "expected": {
+    "error": "invalid control byte"
+   },
+   "comment": "the control byte's low bit is 0; Script Validation says it 'is unused and must be 1'"
+  },
+  {
+   "id": "p2mr_spend_single_witness_element",
+   "given": {
+    "rawTx": "020000000001013dcbe4adeac7da46f817a2736ed551cf039c1821c46096a48ed431654721f0810000000000fdffffff01905f0100000000001600149b56225c85821fe9adb5abfded9ca33475130ce1012220da9e2f49a6ccb36f2b73e424b463ee11c233994da1f38e76762ceb4b587924f2ac00000000",
+    "utxoSpent": {
+     "scriptPubKey": "522086f6637557256e2690b1b29cc2cbaebc164f1e2d1b6eeb81ebae1e42f5f5b256",
+     "amountSats": 100000
+    }
+   },
+   "expected": {
+    "error": "fewer than two witness elements"
+   },
+   "comment": "a P2MR witness needs at least a script and a control block"
+  },
+  {
+   "id": "p2mr_spend_two_elements_ending_in_annex",
+   "given": {
+    "rawTx": "020000000001013dcbe4adeac7da46f817a2736ed551cf039c1821c46096a48ed431654721f0810000000000fdffffff01905f0100000000001600149b56225c85821fe9adb5abfded9ca33475130ce1022220da9e2f49a6ccb36f2b73e424b463ee11c233994da1f38e76762ceb4b587924f2ac02507800000000",
+    "utxoSpent": {
+     "scriptPubKey": "522086f6637557256e2690b1b29cc2cbaebc164f1e2d1b6eeb81ebae1e42f5f5b256",
+     "amountSats": 100000
+    }
+   },
+   "expected": {
+    "error": "annex with fewer than two remaining witness elements"
+   },
+   "comment": "with exactly two elements the last may not start with 0x50"
+  },
+  {
+   "id": "p2mr_spend_control_block_too_deep",
+   "given": {
+    "rawTx": "020000000001013dcbe4adeac7da46f817a2736ed551cf039c1821c46096a48ed431654721f0810000000000fdffffff01905f0100000000001600149b56225c85821fe9adb5abfded9ca33475130ce103402f3c0e7e0205603d37c74508d8cced22bb217ce2ee5f75f4e3acc5604783ab7134622eb6042ce6665deca5167aa5cb1c65db9e859868c804610186bbb2ed362a2220da9e2f49a6ccb36f2b73e424b463ee11c233994da1f38e76762ceb4b587924f2acfd2110c100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+    "utxoSpent": {
+     "scriptPubKey": "522086f6637557256e2690b1b29cc2cbaebc164f1e2d1b6eeb81ebae1e42f5f5b256",
+     "amountSats": 100000
+    }
+   },
+   "expected": {
+    "error": "invalid control block size"
+   },
+   "comment": "a Merkle path of 129 elements exceeds the maximum depth of 128"
+  },
+  {
+   "id": "p2mr_spend_empty_witness",
+   "given": {
+    "rawTx": "02000000013dcbe4adeac7da46f817a2736ed551cf039c1821c46096a48ed431654721f0810000000000fdffffff01905f0100000000001600149b56225c85821fe9adb5abfded9ca33475130ce100000000",
+    "utxoSpent": {
+     "scriptPubKey": "522086f6637557256e2690b1b29cc2cbaebc164f1e2d1b6eeb81ebae1e42f5f5b256",
+     "amountSats": 100000
+    }
+   },
+   "expected": {
+    "error": "empty witness"
+   },
+   "comment": "a witness program needs a witness"
+  },
+  {
+   "id": "p2mr_spend_empty_control_block",
+   "given": {
+    "rawTx": "020000000001013dcbe4adeac7da46f817a2736ed551cf039c1821c46096a48ed431654721f0810000000000fdffffff01905f0100000000001600149b56225c85821fe9adb5abfded9ca33475130ce103402f3c0e7e0205603d37c74508d8cced22bb217ce2ee5f75f4e3acc5604783ab7134622eb6042ce6665deca5167aa5cb1c65db9e859868c804610186bbb2ed362a2220da9e2f49a6ccb36f2b73e424b463ee11c233994da1f38e76762ceb4b587924f2ac0000000000",
+    "utxoSpent": {
+     "scriptPubKey": "522086f6637557256e2690b1b29cc2cbaebc164f1e2d1b6eeb81ebae1e42f5f5b256",
+     "amountSats": 100000
+    }
+   },
+   "expected": {
+    "error": "invalid control block size"
+   },
+   "comment": "the control block must carry at least the control byte"
+  },
+  {
+   "id": "p2mr_spend_control_block_bad_length",
+   "given": {
+    "rawTx": "020000000001013dcbe4adeac7da46f817a2736ed551cf039c1821c46096a48ed431654721f0810000000000fdffffff01905f0100000000001600149b56225c85821fe9adb5abfded9ca33475130ce103402f3c0e7e0205603d37c74508d8cced22bb217ce2ee5f75f4e3acc5604783ab7134622eb6042ce6665deca5167aa5cb1c65db9e859868c804610186bbb2ed362a2220da9e2f49a6ccb36f2b73e424b463ee11c233994da1f38e76762ceb4b587924f2ac22c1c2e1db7e44fea793ef1b6aad64e78d7ef6cae882b5720a3e37ff7b1ad53ba2780000000000",
+    "utxoSpent": {
+     "scriptPubKey": "522086f6637557256e2690b1b29cc2cbaebc164f1e2d1b6eeb81ebae1e42f5f5b256",
+     "amountSats": 100000
+    }
+   },
+   "expected": {
+    "error": "invalid control block size"
+   },
+   "comment": "control block length must be 1 + 32*m: 34 bytes is not"
+  }
+ ]
+}


### PR DESCRIPTION
BIP 360's vectors stop at construction: a script tree goes in, leaf hashes, Merkle root, scriptPubKey, address and control blocks come out. There is nothing to spend, unlike BIP 341's wallet-test-vectors.json, so every implementation ends up writing its own spend coverage. This adds the spend-path vectors offered in the Delving write-up (https://delvingbitcoin.org/t/bip-360-p2mr-implemented-in-bitcoin-core-on-regtest-vector-results-measurements-spec-feedback/2751).

The schema mirrors bip-0341/wallet-test-vectors.json, adapted to an output type whose only spend path is the script path. One transaction with six inputs carries the valid cases, per-input `given`/`intermediary`/`expected` with the sighash midstates at group level. `invalidSpending` holds nine standalone transactions that must fail; `error` is a spec-level description for implementations to map onto their own codes, and several deliberately collapse onto one code in ours. Inputs spent without a signature have privkey/hashType/annex/sigMsg/sigHash null rather than absent.

Valid:

- depth-1 leaf, SIGHASH_DEFAULT
- depth-2 leaf of a three-leaf tree, SIGHASH_ALL (65-byte signature)
- annex, covered by the signature
- `p2mr_single_leaf_script_tree` at depth 0, no signature: the v0.12.0 anyone-can-spend rule
- `p2mr_different_version_leaves` through its 0xfa leaf: unknown leaf versions are unencumbered
- depth-128 leaf, control block at its 4097-byte maximum: the accepting side of the depth limit

Invalid: flipped signature, tampered Merkle path, control byte with the last bit 0, single-element witness, two-element witness ending in an annex, no witness at all, and control blocks of 0, 34 and 4129 bytes, which is one too short for the control byte, one that is not `1 + 32*m`, and one at `m = 129`.

Both named trees come from p2mr_construction.json and are asserted against it when the file is generated, so the two files cross-check each other. Keys and prevout txids are derived deterministically and signing is BIP 340 with an all-zero aux, so the file regenerates from scratch.

One case takes a position the spec leaves open: `p2mr_spend_control_byte_low_bit_zero` expects failure when the last bit of `c[0]` is 0. Script Validation says that bit "is unused and must be 1" and the footnote says a faulty deserialization "will cause an immediate error", but that bullet states no failure condition, while the length rule above it does. If non-enforcement is the intended reading I am happy to drop the vector and the footnote could be reworded; either way it would help to have it explicit.

Verified against a Bitcoin Core implementation of the BIP: every valid input passes VerifyScript and every invalid case fails with the expected script error (https://github.com/jeanpablojp/bitcoin/tree/p2mr-regtest, src/test/p2mr_vector_tests.cpp). The generator is test/functional/tool_p2mr_spend_vectors.py on the same branch.