### PR TITLE
scripts: validate the first Comments-URI entry

### DIFF
--- a/scripts/buildtable.pl
+++ b/scripts/buildtable.pl
@@ -197,7 +197,7 @@ while (++$bipnum <= $topbip) {
 				die "Unacceptable license $val in $fn" unless exists $AcceptableLicenses{$val} or ($val eq 'PD' and exists $GrandfatheredPD{$bipnum}) or ($val eq 'CC-BY-SA-4.0' and exists $GrandfatheredCCBySA{$bipnum});
 			}
 		} elsif ($field eq 'Comments-URI') {
-			if ($found{'Comments-URI'}) {
+			if (not $found{'Comments-URI'}) {
 				my $first_comments_uri = sprintf('https://github.com/bitcoin/bips/wiki/Comments:BIP-%04d', $bipnum);
 				die "First Comments-URI must be exactly \"$first_comments_uri\" in $fn" unless $val eq $first_comments_uri;
 			}


### PR DESCRIPTION
The `Comments-URI` validation condition was reversed when the field was made optional.

`$found{'Comments-URI'}` is incremented only after the current header line has been processed. As a result, the existing condition skipped validation for the first entry and applied it to continuation entries instead.

This allowed a nonstandard first `Comments-URI` to pass, while rejecting a valid external discussion URI following the standard Comments wiki URI.

Restore the original condition so that only the first entry must match:

    https://github.com/bitcoin/bips/wiki/Comments:BIP-NNNN

Additional continuation entries remain unrestricted.