### PR TITLE
BIP155: mention IPv4-in-IPv6 range MUST NOT be sent within IPV6

### DIFF
--- a/bip-0155.mediawiki
+++ b/bip-0155.mediawiki
@@ -7,7 +7,7 @@
   Type: Specification
   Assigned: 2019-02-27
   License: BSD-2-Clause
-  Version: 2.0.0
+  Version: 2.1.0
 </pre>
 
 ==Introduction==
@@ -131,6 +131,8 @@ Further network ID numbers MUST be reserved in a new BIP document.
 
 Clients SHOULD reject messages that contain addresses that have a different length than specified in this table for a specific network ID, as these are meaningless.
 
+Some ranges of the <code>IPV6</code> address space are reserved for embedding addresses of other networks (for example the IPv4-in-IPv6 range <code>::ffff:0:0/96</code>). Such addresses already have a canonical encoding under their own network ID and MUST NOT be sent with the <code>IPV6</code> network ID. Clients SHOULD ignore <code>IPV6</code> addresses that fall into these reserved ranges on receive, since the same address received under two network IDs would otherwise be treated as two distinct peers.
+
 See the appendices for the address encodings to be used for the various networks.
 
 ==Signaling support and compatibility==
@@ -194,6 +196,8 @@ Yggdrasil addresses are simply IPv6 addresses in the <code>0200::/7</code> range
 
 == Changelog ==
 
+* 2.1.0 (2026-08-03):
+** Document that IPv4-in-IPv6 range MUST NOT be sent with the IPV6 network ID and SHOULD be ignored on receive.
 * 2.0.0 (2025-10-01):
 ** Add note that Tor v2 is no longer operational.
 * 1.0.0 (2019-02-27):


### PR DESCRIPTION
There was a discrepancy between Bitcoin Core and btcd - that I noticed with [bitcoinfuzz](https://github.com/bitcoinfuzz/bitcoinfuzz) - about the rejection of IPv4-in-IPv6 when parsing an `addrv2` message. btcd ended up implemented the same behavior while it raised a discussion about this not being mentioned in the BIP. 

Rejecting this kind of addresses is important for canonical encoding. The whole point of this BIP is having exactly one representation for each network. Besided that, there are other reasons such as reachability accounting, defense against evasion/bypassing address‑type policy, etc. 

That said, this PR changes BIP155 to document the behavior where IPv4 addresses embedded in IPv6 should be rejected.