### PR TITLE
bip8: Fix mediawiki syntax for bold

### DIFF
--- a/bip-0008.mediawiki
+++ b/bip-0008.mediawiki
@@ -277,31 +277,31 @@ A living list of deployment proposals can be found [[bip-0008/assignments.mediaw
 This document is dual licensed as BSD 3-clause, and Creative Commons CC0 1.0 Universal.
 
 ==Changelog==
-* **1.0.0** (2026-08-03):
+* '''1.0.0''' (2026-08-03):
 ** Advance to Complete.
-* **0.3.2** (2021-02-17):
+* '''0.3.2''' (2021-02-17):
 ** Make activation threshold configurable.
 ** Reduce recommended threshold from 95% to 90%.
 ** Update guidance for bit selection and naming conventions.
 ** Clarify economic majority upgrade expectations.
-* **0.3.1** (2021-02-04):
+* '''0.3.1''' (2021-02-04):
 ** Simplify pseudocode for MUST_SIGNAL validation check.
-* **0.3.0** (2021-02-02):
+* '''0.3.0''' (2021-02-02):
 ** Make signaling during LOCKED_IN recommended instead of mandatory.
 ** Allow some blocks to not signal during MUST_SIGNAL as long as threshold is met.
-* **0.2.0** (2020-10-17):
+* '''0.2.0''' (2020-10-17):
 ** Replace FAILING state with MUST_SIGNAL phase.
 ** Require startheight and timeoutheight to be at retarget boundaries.
 ** Require timeoutheight to be at least 4032 blocks after startheight.
 ** Add note about lockinontimeout=true peer connectivity.
-* **0.1.0** (2020-06-26):
+* '''0.1.0''' (2020-06-26):
 ** Return document Draft status.
 ** Fix timeout logic and state transition ordering.
 ** Add minimum_activation_height parameter.
 ** Update GBT section for MUST_SIGNAL state.
 ** Add reference implementation link.
 ** Fix pseudocode initialization bug.
-* **0.0.2** (2020-02-26):
+* '''0.0.2''' (2020-02-26):
 ** Move to Rejected due to 3-year time-out.
-* **0.0.1** (2017-02-01):
+* '''0.0.1''' (2017-02-01):
 ** Initial Draft published.


### PR DESCRIPTION
It’s mediawiki not markdown, so it should be <code>'''</code>, not <code>**</code> for bold…