### PR TITLE
BIP-39: say what separates two words

### DIFF
--- a/bip-0039.mediawiki
+++ b/bip-0039.mediawiki
@@ -96,6 +96,14 @@ sentence (in UTF-8 NFKD) used as the password and the string "mnemonic" + passph
 in UTF-8 NFKD) used as the salt. The iteration count is set to 2048 and HMAC-SHA512 is used as
 the pseudo-random function. The length of the derived key is 512 bits (= 64 bytes).
 
+Words in a mnemonic sentence are separated by a single space (U+0020), except in
+Japanese, where the ideographic space (U+3000) is used; see
+[[bip-0039/bip-0039-wordlists.md|Wordlists]]. NFKD maps U+3000 to U+0020, so the
+two forms of a Japanese sentence derive the same seed. Software that splits a
+sentence into words, to look them up in the wordlist or to verify the checksum,
+must split it after normalization: splitting on U+0020 beforehand reads a
+Japanese sentence as a single word.
+
 This seed can be later used to generate deterministic wallets using BIP-0032 or
 similar methods.
 


### PR DESCRIPTION
The BIP never says it. The rule exists — the Japanese wordlist page requires
the ideographic space U+3000, added in #130 — but it is not in the BIP text,
and the note there holds a caveat: ASCII and ideographic spaces are
equivalent "as long as your code never shows the user an ASCII space
separated phrase or tries to split the phrase input by the user".

The reference implementation splits the input, on U+0020, and so cannot read
back the Japanese sentences it writes: `to_entropy` raises on all 24
Japanese vectors of its own `vectors.json`. The fix of the reference
implementation is open there: https://github.com/trezor/python-mnemonic/pull/145

This adds three sentences to "From mnemonic to seed": the separator, the
Japanese exception, and what it means for software that splits a sentence
before normalizing it. No test vector changes, and nothing that is correct
today becomes incorrect.

Found downstream in btclib: btclib-org/btclib#258.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
