### PR TITLE
Add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+The preferred approach to report a security vulnerability is to contact the
+respective BIP owners and affected projects that implement a BIP. Should
+attempts to contact the affected parties fail, the report can be sent by email
+to one or more of the BIP Editors listed below. The contacted BIP Editors will
+make their best effort to triage the report and get in touch with the respective
+parties.
+
+* Bryan Bishop ([kanzure@gmail.com](mailto:kanzure@gmail.com))
+* Jon Atack ([jon@atack.com](mailto:jon@atack.com))
+* Mark "Murch" Erhardt ([murch@murch.one](mailto:murch@murch.one))
+* Olaoluwa Osuntokun ([laolu32@gmail.com](mailto:laolu32@gmail.com))
+* Ruben Somsen ([rsomsen@gmail.com](mailto:rsomsen@gmail.com))
+
+Note: These email addresses are exclusively for vulnerability reporting.


### PR DESCRIPTION
This information is already in BIPs 2 and 3, but ISTM that an explicit SECURITY file would conform to current best practice.

I did not include a section about gpg keys to communicate sensitive information; if wanted, it could be added here or later.