### PR TITLE
BIP 110: update status to Closed

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -631,13 +631,13 @@ users (see also: [https://en.bitcoin.it/wiki/Economic_majority economic majority
 | Gavin Andresen
 | Specification
 | Closed
-|- style="background-color: #ffffcf"
+|- style="background-color: #ffcfcf"
 | [[bip-0110.mediawiki|110]]
 | Consensus (soft fork)
 | Reduced Data Temporary Softfork
 | Dathon Ohm
 | Specification
-| Complete
+| Closed
 |- style="background-color: #cfffcf"
 | [[bip-0111.mediawiki|111]]
 | Peer Services

--- a/bip-0110.mediawiki
+++ b/bip-0110.mediawiki
@@ -3,11 +3,12 @@
   Layer: Consensus (soft fork)
   Title: Reduced Data Temporary Softfork
   Authors: Dathon Ohm <dathonohm+bip@proton.me>
-  Status: Complete
+  Status: Closed
   Type: Specification
   Assigned: 2025-12-03
   License: BSD-3-Clause
   Discussion: https://groups.google.com/g/bitcoindev/c/nOZim6FbuF8
+  Version: 1.0.1
 </pre>
 
 ==Abstract==
@@ -367,6 +368,8 @@ Original draft and advice: Luke-Jr
 
 ==Changelog==
 
+* '''1.0.1''' (2026-08-09):
+** Mark as Closed, following a chain split with stalled mining
 * '''1.0.0''' (2026-06-25):
 ** Advance to Complete
 * '''0.0.4''' (2026-02-04):


### PR DESCRIPTION
BIP 110 was released on mainnet by Knots and entered its mandatory signaling period today (8th August 2026), rejecting non-signaling blocks. It split to a new chain and stalled.