### PR TITLE
process: Remove Luke from BIP Editors

### DIFF
--- a/bip-0003.md
+++ b/bip-0003.md
@@ -454,7 +454,6 @@ The current BIP Editors are:
 
 * Bryan Bishop ([kanzure@gmail.com](mailto:kanzure@gmail.com))
 * Jon Atack ([jon@atack.com](mailto:jon@atack.com))
-* Luke Dashjr ([luke_bipeditor@dashjr.org](mailto:luke_bipeditor@dashjr.org))
 * Mark "Murch" Erhardt ([murch@murch.one](mailto:murch@murch.one))
 * Olaoluwa Osuntokun ([laolu32@gmail.com](mailto:laolu32@gmail.com))
 * Ruben Somsen ([rsomsen@gmail.com](mailto:rsomsen@gmail.com))


### PR DESCRIPTION
I sent an email to the Bitcoin Developer list, recommending the removal of Luke Dashjr from the BIP Editors (copied below). I open this pull request as a sample implementation of my recommendation.

> Hello everyone,
> 
> I recommend that Luke Dashjr be removed from the position of BIP Editor.
> 
> Over the past several years, Luke has been at the center of many contentious disputes within the Bitcoin ecosystem, and this week a new forkcoin spun out of Bitcoin under his leadership.
> 
> More specifically, Luke was heavily involved in the creation and implementation of BIP110, the proposal that led to the fork. During that process, he also exercised his authority as a BIP Editor inconsistently with the established editorial process unfairly favoring the proposal he was involved in. For example, he attempted to assign a BIP number to the draft publicly on Twitter before the proposal had been discussed on the mailing list, and he merged a PR updating the BIP within minutes of the PR being opened.
> 
> The latter is particularly notable given that Luke has otherwise made hardly any contributions to the day-to-day work of the BIP Editors since the additional editors began serving in April 2024: he left fewer than 1% of the BIP Editor comments in the repository since then, and the merge action of this PR was his first since May 2024.
> 
> Communication between Luke and other BIP Editors had already broken down last year, following a discussion about his attempt to side-step the process by prematurely assigning a BIP number out of band.
> 
> Taken together, I believe these circumstances raise serious concerns about Luke continuing to hold editorial authority. In particular:
> 
> - he has exercised his editorial privileges in a manner that raises conflict-of-interest concerns;
> - he has contributed little to the ongoing workload of the BIP Editors;
> - his recent championing of a contentious soft fork that now appears to evolve into a hard fork represents a complete departure from the Bitcoin development ecosystem; and
> - trust, communication, and coordination with the other BIP Editors have broken down.
> 
> For these reasons, I motion that Luke be removed as a BIP Editor.
> 
> Murch