### PR TITLE
BIP-67: fix typo

### DIFF
--- a/bip-0067.mediawiki
+++ b/bip-0067.mediawiki
@@ -17,7 +17,7 @@ This BIP describes a method to deterministically generate multi-signature pay-to
 
 ==Motivation==
 
-Pay-to-script-hash (BIP-0011<ref>[https://github.com/bitcoin/bips/blob/master/bip-0011.mediawiki BIP-0011]</ref>) is a transaction type that allows funding of arbitrary scripts, where the recipient carries the cost of fee's associated with using longer, more complex scripts.
+Pay-to-script-hash (BIP-0011<ref>[https://github.com/bitcoin/bips/blob/master/bip-0011.mediawiki BIP-0011]</ref>) is a transaction type that allows funding of arbitrary scripts, where the recipient carries the cost of fees associated with using longer, more complex scripts.
 
 Multi-signature pay-to-script-hash transactions are defined in BIP-0016<ref>[https://github.com/bitcoin/bips/blob/master/bip-0016.mediawiki BIP-0016]</ref>. The redeem script does not require a particular ordering or encoding for public keys.  This means that for a given set of keys and number of required signatures, there are as many as 2(n!) possible standard redeem scripts, each with its separate P2SH address.  Adhering to an ordering and key encoding would ensure that a multi-signature “account” (set of public keys and required signature count) has a canonical P2SH address.
 


### PR DESCRIPTION
This removes an erroneous apostrophe that made a sentence a bit confusing to read: "fee's" -> "fees".

I realize this is ancient history, so feel free to close if this is not a good reason to touch an old BIP.