### PR TITLE
BIP-324: Update method name in handshake diagram

### DIFF
--- a/bip-0324.mediawiki
+++ b/bip-0324.mediawiki
@@ -190,14 +190,15 @@ As explained before, these messages are sent to set up the connection:
  |                                   y, ellswift_Y = ellswift_create()                              |
  |                                   ecdh_secret = v2_ecdh(                                         |
  |                                                     y, ellswift_X, ellswift_Y, initiating=False) |
- |                                   v2_initialize(initiator, ecdh_secret, initiating=False)        |
+ |                                   initialize_v2_transport(                                       |
+ |                                       initiator, ecdh_secret, initiating=False)                  |
  |                                                                                                  |
  |    <--- ellswift_Y + responder_garbage (responder_garbage_len bytes; max 4095) +                 |
  |             responder_garbage_terminator (16 bytes) +                                            |
  |             v2_enc_packet(initiator, RESPONDER_TRANSPORT_VERSION, aad=responder_garbage) ----    |
  |                                                                                                  |
  | ecdh_secret = v2_ecdh(x, ellswift_Y, ellswift_X, initiating=True)                                |
- | v2_initialize(responder, ecdh_secret, initiating=True)                                           |
+ | initialize_v2_transport(responder, ecdh_secret, initiating=True)                                 |
  |                                                                                                  |
  |     ---- initiator_garbage_terminator (16 bytes) +                                               |
  |              v2_enc_packet(responder, INITIATOR_TRANSPORT_VERSION, aad=initiator_garbage) --->   |


### PR DESCRIPTION
In everywhere except the handshake diagram, the transport initialization method name is `initialize_v2_transport`, but was `v2_initialize` in the diagram.