### PR TITLE
bip89: advance to deployed

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -512,13 +512,13 @@ users (see also: [https://en.bitcoin.it/wiki/Economic_majority economic majority
 | Dmitry Petukhov
 | Informational
 | Complete
-|-
+|- style="background-color: #cfffcf"
 | [[bip-0089.mediawiki|89]]
 | Applications
 | Chain Code Delegation
 | Jesse Posner, Jurvis Tan
 | Specification
-| Draft
+| Deployed
 |- style="background-color: #cfffcf"
 | [[bip-0090.mediawiki|90]]
 |

--- a/bip-0089.mediawiki
+++ b/bip-0089.mediawiki
@@ -6,11 +6,12 @@
            Jurvis Tan <jurvis@block.xyz>
   Comments-Summary: No comments yet.
   Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0089
-  Status: Draft
+  Status: Deployed
   Type: Specification
   Assigned: 2025-12-03
   License: BSD-3-Clause
   Discussion: https://delvingbitcoin.org/t/chain-code-delegation-private-access-control-for-bitcoin-keys/1837
+  Version: 1.0.0
   Requires: 32, 340, 341
 </pre>
 
@@ -392,6 +393,7 @@ You may also find example code of CCD in action [https://github.com/jurvis/chain
 
 == Changelog ==
 
+* '''1.0.0''' (2026-08-13): Advance to Deployed.
 * '''0.1.3''' (2026-02-02): Upgrade secp256k1lab and add license file; fix type checker and linter issues; clarify Delegator/Delegatee terminology, derivation constraints, signing modes, and verification scope.
 * '''0.1.2''' (2025-12-03): Updated to reflect BIP number assignment.
 * '''0.1.1''' (2025-11-30): Fix acknowledgments spelling, BIP3 formatting, and use "Chain Code" with a space throughout.


### PR DESCRIPTION
Chain code delegation was rolled out and deployed to all Bitkey customers on November 4th, 2025. This PR updates the BIP's status to reflect as such.