### PR TITLE
bip-0375: assign k in output index order

### DIFF
--- a/bip-0375.mediawiki
+++ b/bip-0375.mediawiki
@@ -10,7 +10,7 @@
   Assigned: 2025-01-08
   License: BSD-2-Clause
   Discussion: https://groups.google.com/g/bitcoindev/c/5G5wzqUXyk4
-  Version: 0.1.1
+  Version: 0.1.2
   Requires: 352, 370, 374
 </pre>
 
@@ -237,8 +237,8 @@ Using [https://github.com/bitcoin/bips/blob/master/bip-0374.mediawiki#dleq-proof
 ====Computing the Output Scripts====
 
 Compute the PSBT_OUT_SCRIPT using the procedure in [https://github.com/bitcoin/bips/blob/master/bip-0352.mediawiki#creating-outputs BIP352] but substituting ''a·B<sub>scan</sub>'' with the PSBT_GLOBAL_SP_ECDH_SHARE for that scan key if available, or the sum of all PSBT_IN_SP_ECDH_SHAREs from eligible inputs for that scan key.
-If there are multiple silent payment codes with the same scan key, sort the codes lexicographically in ascending order to determine the ordering of the ''k'' value.
-If there are multiple silent payment codes with both the same scan and spend keys, sort the subgroup by output index in ascending order.
+If there are multiple silent payment codes with the same scan key, the ''k'' values are assigned in ascending output index order: the first of those outputs has ''k'' = 0, the next ''k'' = 1, and so on.
+The counter is per scan key and counts only the outputs sharing that scan key, so it is not the output index itself.
 
 ===Transaction Extractor===
 
@@ -331,7 +331,7 @@ Use the provided [[bip-0375/test_runner.py|test runner]] to validate each test v
 | PSBT_OUT_SCRIPT does not match derived sp output
 |-
 | Output Scripts
-| two sp outputs (same scan / different spend keys) not sorted lexicographically by spend key
+| k values swapped between two sp outputs (same scan key / different spend keys)
 |-
 | Output Scripts
 | k values assigned to wrong output indices with three sp outputs (same scan / spend keys)
@@ -368,7 +368,7 @@ Use the provided [[bip-0375/test_runner.py|test runner]] to validate each test v
 | one input / two sp outputs - output 0 has no label / output 1 uses label=0 convention for sp change
 |-
 | Can Finalize
-| two sp outputs - output 0 uses label=3 / output 1 uses label=1
+| two sp outputs (same scan key) with spend keys in descending order - output 0 uses label=3 / output 1 uses label=1, k follows output index
 |-
 | Can Finalize
 | two inputs using per-input ECDH shares - only eligible inputs contribute shares (P2SH excluded)
@@ -403,6 +403,8 @@ Use the provided [[bip-0375/test_runner.py|test runner]] to validate each test v
 
 == Changelog ==
 
+* '''0.1.2''' (2026-08-14):
+** State that the ''k'' values follow output index order, as the test vectors and the reference validator do.
 * '''0.1.1''' (2026-04-16):
 ** Add test vectors and reference for validating Sending Silent Payments with PSBTs.
 * '''0.1.0''' (2025-01-13):

--- a/bip-0375/bip375_test_vectors.json
+++ b/bip-0375/bip375_test_vectors.json
@@ -477,7 +477,7 @@
       }
     },
     {
-      "description": "output scripts: two sp outputs (same scan / different spend keys) not sorted lexicographically by spend key",
+      "description": "output scripts: k values swapped between two sp outputs (same scan key / different spend keys)",
       "psbt": "cHNidP8B+wQCAAAAAQIEAgAAAAEEAQEBBQECAQYBAAABDiAYpxdmOwurFLEqGncTI/8eQHndUy5d0T4o6hCBxwCYSgEPBAAAAAABAR+ghgEAAAAAABYAFCKactNKZFvTSWu79Qu7gckGP0+UIgICyBe7dSGvw16pbzv7Jw5utQ3f+lVgYnuWH+wA8pllCL9HMEQCID9iBcRocGpGJF8XE6u4uLmjp7/YOsdF98ByDUQxtM38AiBxWKv7gg8r9a1nRfVvwHCcmVzMrP4XCY2KobYfjJ/y/wEBAwQBAAAAIgYCyBe7dSGvw16pbzv7Jw5utQ3f+lVgYnuWH+wA8pllCL8IAAAAgAAAAAABEAT+////Ih0Cekh/wZ+3aYd7h0LW6hgRjzxOcrHqjG3mAqetSkHb4GghA+yk/xG3KOLg9gzmIilDpv9VudlfYnv5qZ0IS8hy1QpbIh4Cekh/wZ+3aYd7h0LW6hgRjzxOcrHqjG3mAqetSkHb4GhAihOzmFVF9yvW6JcUrrkJs+NUqEKpu4tWzQ7e0h34oZlZizEiikngvX6VzhBT98WyistUOmhwdgDjzomCLuMgIQABAwiQXwEAAAAAAAEEIlEgdUe4Fj1bvFSYQL5MwUaq0JUgc2e565RwbeZwjUCPk/kBCUICekh/wZ+3aYd7h0LW6hgRjzxOcrHqjG3mAqetSkHb4GgCi4D5lDNIleEbx2x1q254/iwluzMvIXshHEAXvx9nfYYAAQMIECcAAAAAAAABBCJRIGziw1OV8XDyS20tgNCkDEb0a6S0hD9qsxGpNLMcXYTcAQlCAnpIf8Gft2mHe4dC1uoYEY88TnKx6oxt5gKnrUpB2+BoA6r4Yq7amM+SU5r33DN10dpfsGsSHvCh8DGp9zgv1T27AA==",
       "supplementary": {
         "inputs": [
@@ -983,7 +983,7 @@
       }
     },
     {
-      "description": "can finalize: two sp outputs - output 0 uses label=3 / output 1 uses label=1",
+      "description": "can finalize: two sp outputs (same scan key) with spend keys in descending order - output 0 uses label=3 / output 1 uses label=1, k follows output index",
       "psbt": "cHNidP8B+wQCAAAAAQIEAgAAAAEEAQEBBQECAQYBAAABDiAYpxdmOwurFLEqGncTI/8eQHndUy5d0T4o6hCBxwCYSgEPBAAAAAABAR/gkwQAAAAAABYAFCKactNKZFvTSWu79Qu7gckGP0+UIgICyBe7dSGvw16pbzv7Jw5utQ3f+lVgYnuWH+wA8pllCL9HMEQCICJa45kPVF365uoUKpN0arSqgSfjyBNY63wha08anrtiAiBl42BSGRArJQdeOVXz80zjvPKjXR4QFd1dw7/tPs81qQEBAwQBAAAAIgYCyBe7dSGvw16pbzv7Jw5utQ3f+lVgYnuWH+wA8pllCL8IAAAAgAAAAAABEAT+////Ih0Ci3kOCYf96fDRI5jra+MMc3Z5PGR4ZaKgLy78lg2WZWghAlWBv6pzMVb2uY5xom9w/XazZ4ZJ9isfxed7jpq45hBQIh4Ci3kOCYf96fDRI5jra+MMc3Z5PGR4ZaKgLy78lg2WZWhAeUCBnrbp8ljBWDh8CmTMFvUXx+9ECRIszqqU9OL/U3bEJHv8Fw2bJjsOPSBrZoyH6Us03ur6AKF5KwR614h1uwABAwighgEAAAAAAAEEIlEgyvcy9B51UZCclKM10VeOp7dmAnuIbN0cFwHZv8a3hIgBCUICi3kOCYf96fDRI5jra+MMc3Z5PGR4ZaKgLy78lg2WZWgDliRhtuNd91TQDUhtw53swgJxhFB2YU5cDtLJDyPT6b4BCgQDAAAAAAEDCDDmAgAAAAAAAQQiUSBNB6DTsPYafF7+NsLDxYfItphBhUYAjPgZu9pM4xgSIQEJQgKLeQ4Jh/3p8NEjmOtr4wxzdnk8ZHhloqAvLvyWDZZlaANaVzfUxngmF8xrDElrsrxiVVoyslQkT7ycnANd9GnlqwEKBAEAAAAA",
       "supplementary": {
         "inputs": [

--- a/bip-0375/validator/validate_psbt.py
+++ b/bip-0375/validator/validate_psbt.py
@@ -313,7 +313,8 @@ def validate_output_scripts(psbt: PSBT) -> Tuple[bool, str]:
             output_index = struct.unpack("<I", output_index_bytes)[0]
             outpoints.append(COutPoint(txid_int, output_index))
 
-    # Track k values per scan key
+    # Track k values per scan key: k is assigned in output index order among
+    # the outputs sharing a scan key (BIP375, Computing the Output Scripts)
     scan_key_k_values = {}
 
     # Validate each SP output


### PR DESCRIPTION
BIP375 states one rule for assigning `k` to the silent payment outputs of a
transaction, and its test vectors and reference validator implement another.
This amends the prose to the rule the shipped artefacts follow.

### The discrepancy

`bip-0375.mediawiki` L240-241 asks for the codes sharing a scan key to be
sorted lexicographically, with a tie-break by output index for codes sharing
both keys. `bip-0375/validator/validate_psbt.py` does not sort: it tracks `k`
per scan key while walking `enumerate(psbt.o)`. The vectors were generated the
same way.

Measured with `bip-0375/test_runner.py` on Python 3.12, at `60f5b33b`:

| tree | result |
| --- | --- |
| master, unchanged | 41 passed, 0 failed |
| master, validator patched to assign `k` by ascending `PSBT_OUT_SP_V0_INFO`, ties by output index | 40 passed, **1 failed**: `valid[8]`, "two sp outputs - output 0 uses label=3 / output 1 uses label=1" |

That vector's two spend keys are in descending order, so a lexicographic sort
gives `k = 0` to output 1, and the scripts the file publishes are the ones
index order derives. No invalid vector changes verdict under either rule; the
two invalid vectors named after ordering do not discriminate, since in one the
spend keys are already ascending and in the other all three codes are
identical.

### Why index order rather than the reverse fix

[#2207](https://github.com/bitcoin/bips/pull/2207) closes the same gap the
other way, by correcting the vectors and the validator to the prose. Both work.
This one is proposed because the rule is cheaper to state and to implement:

- lexicographic order needs a canonical encoding of a "code" and a total order
  on it. "The codes" admits at least three readings — the 66-byte
  `PSBT_OUT_SP_V0_INFO`, the bech32m address string, or the `(scan, spend)`
  pair — and the BIP names none of them. Output indices are already in the
  psbt and already agreed by both parties;
- the property a code-based order would buy, invariance under output
  reordering, is unavailable here: a Signer that sets any missing
  `PSBT_OUT_SCRIPT` must clear the Inputs Modifiable and Outputs Modifiable
  flags (L185), and a psbt carrying a script with `PSBT_GLOBAL_TX_MODIFIABLE`
  non-zero is invalid. The outputs cannot be reordered once the scripts exist;
- what the rule has to buy appears to be inter-party determinism only. A
  BIP352 receiver scans by deriving `P_k` for k = 0, 1, 2 … and matching
  against the transaction's outputs, so it never learns which output was
  assigned which `k`; and permuting `k` within a scan-key group still pays
  each recipient the same amount, since an output's script is derived from its
  own spend key. If that is right, any deterministic rule is correct and the
  choice is one of cost.

If the owners prefer #2207's direction, this should be closed in its favour —
the two are alternatives on the ordering question, and #2207's other half, the
labeled spend key in `PSBT_OUT_SP_V0_INFO`, is independent of it and looks
right either way.

### The second sentence

Dropping it is not a loss: one counter per scan key covers codes sharing both
keys with no tie-break. What it left unsaid is added in its place, because it
is the part an implementer gets wrong — the counter counts the outputs of that
scan key, not the output index, which the vector "three sp outputs (same scan
key) / two regular outputs - k values assigned independently of output index"
exercises.

### Checks

`scripts/link-format-chk.sh`, `scripts/buildtable.pl`, `scripts/diffcheck.sh`
and `typos` all pass locally. The version header and the changelog entry are
the first thing to rebase if #2207 lands first.

Found while implementing BIP375 in btclib, which follows the vectors:
https://github.com/btclib-org/btclib/issues/768