### PR TITLE
bip-0375: say the version byte belongs to the identifier, not to the field

### DIFF
--- a/bip-0375.mediawiki
+++ b/bip-0375.mediawiki
@@ -146,7 +146,7 @@ If only PSBT_OUT_SCRIPT is present for an output, then the output is not being s
 ===Unique Identification===
 
 Silent payment capable PSBTs can be uniquely identified the same way as PSBTv2s, except when including silent payment outputs. If an output contains the PSBT_OUT_SP_V0_INFO field, it must use that field instead of PSBT_OUT_SCRIPT as the output script when creating the unsigned transaction used for unique identification.<ref name="why_use_sp_info_field"> ''' Why use PSBT_OUT_SP_V0_INFO when serializing for a unique identifier?''' Since the same silent payment capable PSBT is valid whether or not a PSBT_OUT_SCRIPT is included in an output that has PSBT_OUT_SP_V0_INFO set, using the PSBT_OUT_SCRIPT if present for the unique identifier will cause malleability. The identifier will be different depending on whether PSBT_OUT_SCRIPT is present, so always using PSBT_OUT_SP_V0_INFO if it exists makes sure the PSBT is always identified uniquely.</ref>
-The PSBT_OUT_SP_V0_INFO should be serialized as a zero byte for the version, followed by the 33 bytes of the scan key and then 33 bytes for the spend key.
+In that unsigned transaction, the output script of such an output is a zero byte for the version, followed by the 33 bytes of the scan key and then 33 bytes for the spend key; the PSBT_OUT_SP_V0_INFO field itself is the two keys, without the version byte.
 
 
 ==Roles==


### PR DESCRIPTION
One sentence, in the Unique Identification section:

> The PSBT_OUT_SP_V0_INFO should be serialized as a zero byte for the
> version, followed by the 33 bytes of the scan key and then 33 bytes for
> the spend key.

It names the field, and the field is 66 bytes: its table entry is
`<33 byte scan key> <33 byte spend key>`, `bip375_test_vectors.json` carries
66, and `validator/validate_psbt.py` refuses anything else — `invalid[1]`
reports "Output 0 SP_V0_INFO has wrong length (65 bytes, expected 66)".

Read in its section the sentence is not about the field but about the output
script that stands in for a silent payment output when building the unsigned
transaction used for unique identification, where 67 bytes contradicts
nothing. That is also where it came from: `d29e2f8` added it together with
the unique-identification paragraph above it.

Both readings are available to someone reading the sentence alone, and one of
them contradicts three other artefacts. This picks the one that does not,
without changing anything normative.

No changelog entry or version bump: nothing about the format changes, and
leaving them out keeps this from conflicting with
[#2207](https://github.com/bitcoin/bips/pull/2207) or
[#2256](https://github.com/bitcoin/bips/pull/2256), both of which touch the
changelog. Glad to add both if you would rather have them.

`scripts/link-format-chk.sh`, `scripts/buildtable.pl`,
`scripts/diffcheck.sh` and `typos` pass locally.

Noticed while implementing BIP375 in btclib, which serializes the version
byte in the identifier and not in the field:
https://github.com/btclib-org/btclib/issues/768