### PR TITLE
bip324: fix handshake pseudocode errors

### DIFF
--- a/bip-0324.mediawiki
+++ b/bip-0324.mediawiki
@@ -323,7 +323,7 @@ def initialize_v2_transport(peer, ecdh_secret, initiating):
         peer.recv_garbage_terminator = initiator_garbage_terminator
 
     # To achieve forward secrecy we must wipe the key material used to initialize the ciphers:
-    memory_cleanse(ecdh_secret, prk, initiator_L, initiator_P, responder_L, responder_K)
+    memory_cleanse(ecdh_secret, prk, initiator_L, initiator_P, responder_L, responder_P)
 </pre>
 
 The session ID uniquely identifies the encrypted channel. v2 clients supporting this proposal may present the entire session ID (encoded as a hex string) to the node operator to allow for manual, out of band comparison with the peer node operator. Future transport versions may introduce optional authentication methods that compare the session ID as seen by the two endpoints in order to bind the encrypted channel to the authentication.
@@ -353,7 +353,7 @@ def respond_v2_handshake(peer, garbage_len):
         if peer.received_prefix[-1] != V1_PREFIX[len(peer.received_prefix) - 1]:
             peer.privkey_ours, peer.ellswift_ours = ellswift_create()
             peer.sent_garbage = rand_bytes(garbage_len)
-            send(peer, ellswift_Y + peer.sent_garbage)
+            send(peer, peer.ellswift_ours + peer.sent_garbage)
             return
     use_v1_protocol()
 </pre>
@@ -363,13 +363,13 @@ Upon receiving the encoded responder public key, the initiator derives the share
 <pre>
 def complete_handshake(peer, initiating, decoy_content_lengths=[]):
     received_prefix = b'' if initiating else peer.received_prefix
-    ellswift_theirs = receive(peer, 64 - len(received_prefix))
+    ellswift_theirs = received_prefix + receive(peer, 64 - len(received_prefix))
     if not initiating and ellswift_theirs[4:16] == V1_PREFIX[4:16]:
         # Looks like a v1 peer from the wrong network.
         disconnect(peer)
     ecdh_secret = v2_ecdh(peer.privkey_ours, ellswift_theirs, peer.ellswift_ours,
                           initiating=initiating)
-    initialize_v2_transport(peer, ecdh_secret, initiating=True)
+    initialize_v2_transport(peer, ecdh_secret, initiating=initiating)
     # Send garbage terminator
     send(peer, peer.send_garbage_terminator)
     # Optionally send decoy packets after garbage terminator.


### PR DESCRIPTION
Fix 4 bugs only in the pseudocode.

1. bip-0324.mediawiki:326: undefined name responder_K

```diff
-    memory_cleanse(ecdh_secret, prk, initiator_L, initiator_P, responder_L, responder_K)
+    memory_cleanse(ecdh_secret, prk, initiator_L, initiator_P, responder_L, responder_P)
```

responder_K is never defined anywhere in the BIP. It should be responder_P.

2. bip-0324.mediawiki:356: undefined name ellswift_Y

```diff
-            send(peer, ellswift_Y + peer.sent_garbage)
+            send(peer, peer.ellswift_ours + peer.sent_garbage)
```

ellswift_Y is not a variable in scope in respond_v2_handshake. The keypair was generated two lines earlier as peer.privkey_ours, peer.ellswift_ours, so use peer.ellswift_ours instead.

3. bip-0324.mediawiki:366: responder drops the already-received prefix bytes

```diff
-    ellswift_theirs = receive(peer, 64 - len(received_prefix))
+    ellswift_theirs = received_prefix + receive(peer, 64 - len(received_prefix))
```

respond_v2_handshake consumes the first 1..16 bytes of the peer's key one at a time while testing them against V1_PREFIX. Those bytes are already off the wire, so discarding them leaves ellswift_theirs short by len(received_prefix) with every byte shifted. received_prefix is computed on line 365 and then never used again, which is the tell. Two consequences:

- the wrong-network check ellswift_theirs[4:16] reads the wrong bytes and silently stops working.
- v2_ecdh hashes a different byte string than the initiator hashed for the same key, so the handshake never completes.

Prepending fixes both, and matches the prose at line 361: "The responder performs very similar steps but includes the earlier received prefix bytes in the public key."

4. bip-0324.mediawiki:372: initiating hardcoded to True

```diff
-    initialize_v2_transport(peer, ecdh_secret, initiating=True)
+    initialize_v2_transport(peer, ecdh_secret, initiating=initiating)
```

Hardcoding True makes the responder encrypt with initiator_P and try to decrypt with responder_P (the initiator's assignment), so neither side can read the other.