### PR TITLE
BIP-327: correct PartialSigAgg session-value unpacking and a typo

### DIFF
--- a/bip-0327.mediawiki
+++ b/bip-0327.mediawiki
@@ -10,7 +10,7 @@
   License: BSD-3-Clause
   Discussion: 2022-04-05: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2022-April/020198.html [bitcoin-dev] MuSig2 BIP
               2022-10-11: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2022-October/021000.html [bitcoin-dev] MuSig2 BIP
-  Version: 1.0.3
+  Version: 1.0.4
 </pre>
 
 == Introduction ==
@@ -483,7 +483,7 @@ Algorithm ''PartialSigVerify(psig, pubnonce<sub>1..u</sub>, pk<sub>1..u</sub>, t
 ** The tweaks ''tweak<sub>1..v</sub>'': ''v'' 32-byte arrays
 ** The tweak modes ''is_xonly_t<sub>1..v</sub>'' : ''v'' booleans
 ** The message ''m'': a byte array<ref name="mlen" />
-** The index of the signer ''i'' in the of public nonces and individual public keys with ''0 < i &le; u''
+** The index of the signer ''i'' in the list of public nonces and individual public keys with ''0 < i &le; u''
 * Let ''aggnonce = NonceAgg(pubnonce<sub>1..u</sub>)''; fail if that fails
 * Let ''session_ctx = (aggnonce, u, pk<sub>1..u</sub>, v, tweak<sub>1..v</sub>, is_xonly_t<sub>1..v</sub>, m)''
 * Run ''PartialSigVerifyInternal(psig, pubnonce<sub>i</sub>, pk<sub>i</sub>, session_ctx)''
@@ -513,7 +513,7 @@ Algorithm ''PartialSigAgg(psig<sub>1..u</sub>, session_ctx)'':
 ** The number ''u'' of signatures with ''0 < u < 2^32''
 ** The partial signatures ''psig<sub>1..u</sub>'': ''u'' 32-byte arrays
 ** The ''session_ctx'': a [[#session-context|Session Context]] data structure
-* Let ''(Q, _, tacc, _, _, R, e) = GetSessionValues(session_ctx)''; fail if that fails
+* Let ''(Q, _, tacc, _, R, e) = GetSessionValues(session_ctx)''; fail if that fails
 * For ''i = 1 .. u'':
 ** Let ''s<sub>i</sub> = int(psig<sub>i</sub>)''; fail if ''s<sub>i</sub> &ge; n'' and blame signer ''i'' for invalid partial signature.
 * Let ''g = 1'' if ''has_even_y(Q)'', otherwise let ''g = -1 mod n''
@@ -782,6 +782,8 @@ An exception to this rule is <code>MAJOR</code> version zero (0.y.z) which is fo
 The <code>MINOR</code> version is incremented whenever the inputs or the output of an algorithm changes in a backward-compatible way or new backward-compatible functionality is added.
 The <code>PATCH</code> version is incremented for other changes that are noteworthy (bug fixes, test vectors, important clarifications, etc.).
 
+* '''1.0.4''' (2026-08-19):
+** Fix two minor bugs in the specification of ''PartialSigAgg''.
 * '''1.0.3''' (2026-01-05):
 ** Fix minor bugs in the specification of ''DeterministicSign''.
 * '''1.0.2''' (2024-07-22):

--- a/bip-0327.mediawiki
+++ b/bip-0327.mediawiki
@@ -483,7 +483,7 @@ Algorithm ''PartialSigVerify(psig, pubnonce<sub>1..u</sub>, pk<sub>1..u</sub>, t
 ** The tweaks ''tweak<sub>1..v</sub>'': ''v'' 32-byte arrays
 ** The tweak modes ''is_xonly_t<sub>1..v</sub>'' : ''v'' booleans
 ** The message ''m'': a byte array<ref name="mlen" />
-** The index of the signer ''i'' in the list of public nonces and individual public keys with ''0 < i &le; u''
+** The index of the signer ''i'' in the public nonces and individual public keys with ''0 < i &le; u''
 * Let ''aggnonce = NonceAgg(pubnonce<sub>1..u</sub>)''; fail if that fails
 * Let ''session_ctx = (aggnonce, u, pk<sub>1..u</sub>, v, tweak<sub>1..v</sub>, is_xonly_t<sub>1..v</sub>, m)''
 * Run ''PartialSigVerifyInternal(psig, pubnonce<sub>i</sub>, pk<sub>i</sub>, session_ctx)''


### PR DESCRIPTION
Found during a review of BIP327's normative pseudocode against its reference implementation (`reference.py`).

- `PartialSigAgg` unpacks `GetSessionValues` as a 7-tuple, but the algorithm returns a 6-tuple — cf. the 6-slot unpacks in `Sign` and `PartialSigVerifyInternal`, and the reference implementation itself, which passes all 56 published vector cases with the 6-slot form:

  ```python
  # bip-0327/reference.py
  def get_session_values(session_ctx: SessionContext) -> Tuple[Point, int, int, int, Point, int]:
      ...
      return (Q, gacc, tacc, b, R, e)
  ```

- Fix "in the of public nonces" → "in the list of public nonces".
- Bump Version to 1.0.4 with a changelog entry, per the BIP's PATCH-version convention (precedent: #2071).