### PR TITLE
BIP-327: fix reference.py type errors failing tests.sh

### DIFF
--- a/bip-0327/reference.py
+++ b/bip-0327/reference.py
@@ -351,8 +351,8 @@ def get_session_key_agg_coeff(session_ctx: SessionContext, P: Point) -> int:
 
 def sign(secnonce: bytearray, sk: bytes, session_ctx: SessionContext) -> bytes:
     (Q, gacc, _, b, R, e) = get_session_values(session_ctx)
-    k_1_ = int_from_bytes(secnonce[0:32])
-    k_2_ = int_from_bytes(secnonce[32:64])
+    k_1_ = int_from_bytes(bytes(secnonce[0:32]))
+    k_2_ = int_from_bytes(bytes(secnonce[32:64]))
     # Overwrite the secnonce argument with zeros such that subsequent calls of
     # sign with the same secnonce raise a ValueError.
     secnonce[:64] = bytearray(b'\x00'*64)
@@ -669,8 +669,8 @@ def test_tweak_vectors() -> None:
     secnonce = bytearray(bytes.fromhex(test_data["secnonce"]))
     pnonce = fromhex_all(test_data["pnonces"])
     # The public nonce corresponding to secnonce is at index 0
-    k_1 = int_from_bytes(secnonce[0:32])
-    k_2 = int_from_bytes(secnonce[32:64])
+    k_1 = int_from_bytes(bytes(secnonce[0:32]))
+    k_2 = int_from_bytes(bytes(secnonce[32:64]))
     R_s1 = point_mul(G, k_1)
     R_s2 = point_mul(G, k_2)
     assert R_s1 is not None and R_s2 is not None


### PR DESCRIPTION
Found during a review of BIP327's reference implementation and its shipped test gate.

`bip-0327/tests.sh` (the BIP's own `set -e` quality gate: `mypy --no-error-summary reference.py && python3 reference.py && python3 gen_vectors_helper.py`) currently fails at its first step under the current mypy (2.3.1), before the vector suite ever runs:

```
reference.py:354: error: Argument 1 to "int_from_bytes" has incompatible type "bytearray"; expected "bytes"  [arg-type]
reference.py:355: error: Argument 1 to "int_from_bytes" has incompatible type "bytearray"; expected "bytes"  [arg-type]
reference.py:672: error: Argument 1 to "int_from_bytes" has incompatible type "bytearray"; expected "bytes"  [arg-type]
reference.py:673: error: Argument 1 to "int_from_bytes" has incompatible type "bytearray"; expected "bytes"  [arg-type]
```

Cause: `sign()` and the tweak-test driver slice `secnonce`, which is a `bytearray` by design (mutable, for in-place zeroization); recent mypy/typeshed no longer accepts `bytearray` for a `bytes` parameter.

Fix: convert to immutable bytes at the four call sites (`int_from_bytes(bytes(secnonce[...]))`). This keeps the `int_from_bytes` helper byte-identical to the BIP-340 reference implementation it was copied from, and is behavior-identical at runtime (`int.from_bytes` already accepts both types).

Verification: full `tests.sh` gate now passes end-to-end in a clean container with mypy 2.3.1 (`mypy` clean + `python3 reference.py` — all vector suites and the randomized self-test — + `gen_vectors_helper.py`).

History: this was accepted in older versions of mypy because it was more relaxed then. But from mypy 2.0, it is stricter per [PEP 688](https://peps.python.org/pep-0688), mypy no longer treats bytearray and memoryview values as assignable to the bytes type. https://github.com/python/mypy/pull/18371