### PR TITLE
BIP-379: note that the type properties assume their requirements

### DIFF
--- a/bip-0379.md
+++ b/bip-0379.md
@@ -155,6 +155,10 @@ its type properties in function of those of their subexpressions.
 | `j:X`                        | X is Bn                                               | B           | o=o<sub>X</sub>; n; d; u=u<sub>X</sub>
 | `n:X`                        | X is B                                                | B           | z=z<sub>X</sub>; o=o<sub>X</sub>; n=n<sub>X</sub>; d=d<sub>X</sub>; u
 
+The properties of a fragment assume that the conditions in its "Requires" column are met. They exist
+only to reason about correctness, so they say nothing about an expression that does not meet them:
+such an expression is not valid Miniscript.
+
 #### Timelock Type Mixing
 
 There is one additional correctness property that Miniscript expressions must satisfy:
@@ -206,6 +210,14 @@ The following table lists the malleability properties and requirement of each fr
 | `v:X`                        |                                                                     | s=s<sub>X</sub>; f
 | `j:X`                        |                                                                     | s=s<sub>X</sub>; e=f<sub>X
 | `n:X`                        |                                                                     | s=s<sub>X</sub>; f=f<sub>X</sub>; e=e<sub>X</sub>
+
+As in the correctness table, the properties of a fragment assume that the conditions in its
+"Requires" column are met. They exist only to reason about malleability, so they say nothing about
+an expression that does not meet them: such an expression is malleable, and so is every expression
+containing it.
+
+Implementors of APIs which unconditionally return values for these properties should always return
+false for malleable expressions.
 
 ### Satisfaction
 


### PR DESCRIPTION
The "s", "f" and "e" descriptions in the Security section read as guarantees for every expression, but they only hold for expressions that meet the malleability requirements of the type system.

`thresh` is the clearest case: its rule is `e=all are s`, so `thresh(2,or_i(pk(A),pk(B)),a:or_i(pk(C),pk(D)))` is "e" even though each `or_i` child has two unconditional dissatisfactions, giving the threshold four; the opposite of the "unique unconditional dissatisfaction" the description promises. (Confirmed by spending `or_d(thresh(...),pk(E))` through its second branch: all four witnesses, differing only in the two branch-selector bytes, are accepted by the script engine.)

Nothing is wrong with the rule. Such a threshold fails the "e" requirement that the malleability table imposes for non-malleability, and non-malleability is conjunctive, so the expression and everything containing it is malleable either way; the property value is a don't-care there. This just says so, so that implementations agreeing on those values are not read as contradicting the descriptions.

Prompted by bitcoin/bitcoin#36028 and the [BIP 379 test vector PR](https://github.com/bitcoin/bips/pull/2240), where the type of a malleable expression has to be agreed on as well.

I'm going to create a PR soon that updates `rust-bitcoin` to align with this change and bitcoin/bitcoin#36028 (and https://github.com/btcsuite/btcd/pull/2592 is updated as well).

cc @sipa, @apoelstra

