### PR TITLE
BIP450: Update author email address

### DIFF
--- a/bip-0450.mediawiki
+++ b/bip-0450.mediawiki
@@ -2,7 +2,7 @@
   BIP: 450
   Layer: Applications
   Title: Formosa—Seed encoding by themed mnemonic stories
-  Authors: Yuri S Villas Boas <yuri@t3infosecurity.com>
+  Authors: Yuri S Villas Boas <yurisvb@pm.me>
            André Fidencio Gonçalves <andre7c4@gmail.com>
   Status: Draft
   Type: Specification


### PR DESCRIPTION
# bip-450: update author contact email

The t3infosecurity.com domain is being retired, so mail to the address
listed for the first author will stop being delivered. BIP-3 ties several
process outcomes to author reachability: a Draft may be moved to Closed
unless its authors respond within four weeks of being contacted, and an
applicant asking to take over a BIP is appointed by the Editors if the
authors are unreachable or do not respond in a timely manner.

The new address is the one already behind the discussion threads linked in
this BIP's own preamble, so the contact and the discussion record now agree.