### PR TITLE
BIP 441: fix typos and changelog date

### DIFF
--- a/bip-0441.mediawiki
+++ b/bip-0441.mediawiki
@@ -79,7 +79,7 @@ elements requires as much stack capacity as there are inputs or outputs.  The
 smallest possible input is 41 bytes (allowing almost 24,390 inputs), and the
 smallest possible output is 9 bytes (allowing almost 111,111 outputs).
 However, empty outputs are rare and not economically interesting.  Thus we
-consider smallest non-OP_RETURN standard output script, which is P2WPKH at 22
+consider the smallest non-OP_RETURN standard output script, which is P2WPKH at 22
 bytes, giving a minimum output size of 31 bytes, allowing 32,258 outputs in a
 maximally-sized transaction.
 
@@ -471,7 +471,7 @@ routine as OP_DOWNSHIFT.
 |OP_MOD
 |151
 |<nowiki>[A B]</nowiki>
-|Replace A with remainder when A divided by (non-zero) B
+|Replace A with the remainder when A is divided by (non-zero) B
 |
 # Pop operands off the stack.
 # Calculate the varops cost of the operation: if it exceeds the remaining budget, fail.
@@ -649,7 +649,7 @@ Work in progress:
 ==Changelog==
 
 * 0.2.2: 2026-06-15: clarify wordspan costs, OP_RIGHT semantics, OP_UPSHIFT unaligned cost, CLTV/CSV bounds, and final success-check cost.
-* 0.2.1: 2023-03-27: fix OP_MUL cost to round length(B) up
+* 0.2.1: 2026-03-27: fix OP_MUL cost to round length(B) up
 * 0.2.0: 2025-02-21: change costs to match those in varops budget
 * 0.1.0: 2025-09-27: first public posting
 
@@ -712,7 +712,7 @@ For division, the steps break down like so:
 
 # Bit shift both operands to set top bit of B (OP_UPSHIFT, without overflow for B): cost = wordspan(A) * 6 + wordspan(B) * 4
 
-# Trim trailing bytes.  This costs according to the number of byte removed, but since that is subtractive on future costs, we ignore it.
+# Trim trailing bytes.  This costs according to the number of bytes removed, but since that is subtractive on future costs, we ignore it.
 
 # If B is longer, the answer is 0 already.  So assume A is longer from now on (or equal length).
 


### PR DESCRIPTION
## Summary

- fix three grammar errors in BIP 441
- correct the v0.2.1 changelog year from 2023 to 2026

The original v0.2.1 revision was authored on 2026-03-27, confirming that `2023-03-27` was a typo.

## Checks

- `scripts/link-format-chk.sh`
- `scripts/diffcheck.sh`
- `typos`