### PR TITLE
BIP-352: clarify silent payment address length

### DIFF
--- a/bip-0352.mediawiki
+++ b/bip-0352.mediawiki
@@ -207,7 +207,7 @@ A silent payment address is constructed in the following manner:
 *** The character "q", to represent a silent payment address of version 0
 *** The 66-byte concatenation of the receiver's public keys, ''ser<sub>P</sub>(B<sub>scan</sub>) || ser<sub>P</sub>(B<sub>m</sub>)''
 
-Note: [https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki BIP173] imposes a 90 character limit for Bech32 segwit addresses and limits versions to 0 through 16, whereas a silent payment address requires ''at least'' 117 characters<ref name="why_117_chars"> ''' Why do silent payment addresses need at least 117 characters?''' A silent payment address is a bech32m encoding comprised of the following parts:
+Note: [https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki BIP173] imposes a 90 character limit for Bech32 segwit addresses and limits versions to 0 through 16, whereas a silent payment address requires ''at least'' 116 characters<ref name="why_116_chars"> ''' Why do silent payment addresses need at least 116 characters?''' A silent payment address is a bech32m encoding comprised of the following parts:
 
 
 * HRP [2-3 characters]
@@ -217,7 +217,7 @@ Note: [https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki BIP173] im
 * checksum [6 characters]
 
 
-For a silent payments v0 address, this results in a 117-character address when using a 3-character HRP. Future versions of silent payment addresses may add to the payload, which is why a 1023-character limit is suggested.</ref> and allows versions up to 31. Additionally, since higher versions may add to the data field, it is recommended implementations use a limit of 1023 characters (see [https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#checksum-design BIP173: Checksum design] for more details).
+For a silent payments v0 address, this results in a 116-character address when using the 2-character mainnet HRP ("sp"), or a 117-character address when using the 3-character testnet HRP ("tsp"). Future versions of silent payment addresses may add to the payload, which is why a 1023-character limit is suggested.</ref> and allows versions up to 31. Additionally, since higher versions may add to the data field, it is recommended implementations use a limit of 1023 characters (see [https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#checksum-design BIP173: Checksum design] for more details).
 
 === Inputs For Shared Secret Derivation ===
 


### PR DESCRIPTION
the address length note only gave 117 chars as the number to check against, using a 3-char HRP as the example without saying mainnet uses "sp" (2 chars, 116 total).