### PR TITLE
BIP376: keep PSBT_IN_WITNESS_UTXO after finalization

### DIFF
--- a/bip-0376.mediawiki
+++ b/bip-0376.mediawiki
@@ -110,7 +110,7 @@ The Input Finalizer MUST verify that a <tt>PSBT_IN_TAP_KEY_SIG</tt> field is pre
 
 The Input Finalizer MUST construct the <tt>PSBT_IN_FINAL_SCRIPTWITNESS</tt> containing the single witness element from <tt>PSBT_IN_TAP_KEY_SIG</tt>, as per the BIP 341 key path spending rule.
 
-The Input Finalizer MUST remove the <tt>PSBT_IN_SP_TWEAK</tt>, <tt>PSBT_IN_SP_SPEND_BIP32_DERIVATION</tt>, <tt>PSBT_IN_TAP_KEY_SIG</tt>, and <tt>PSBT_IN_WITNESS_UTXO</tt> fields for any input where the <tt>PSBT_IN_FINAL_SCRIPTWITNESS</tt> is present.
+The Input Finalizer MUST remove the <tt>PSBT_IN_SP_TWEAK</tt>, <tt>PSBT_IN_SP_SPEND_BIP32_DERIVATION</tt>, and <tt>PSBT_IN_TAP_KEY_SIG</tt> fields for any input where the <tt>PSBT_IN_FINAL_SCRIPTWITNESS</tt> is present.
 
 == Rationale ==
 


### PR DESCRIPTION
BIP 174 says the Input Finalizer keeps the UTXO so the Transaction Extractor can verify the final transaction, and its finalized example PSBT does keep it. This BIP's Finalizer section requires removing PSBT_IN_WITNESS_UTXO. None of the finalizers I checked do that: Core's FinalizePSBT, Sparrow's clearNonFinalFields, rust-psbt's Input::finalize and rust-miniscript all keep it. Removing it also breaks partially finalized PSBTs: BIP 341 sighashes commit to every spent output, so once one input is finalized this way no remaining taproot input can be signed (Core's PrecomputePSBTData fails without all UTXOs).