### PR TITLE
BIP370: add Input Finalizer section; BIP371: remove finalizer clause from an output field

### DIFF
--- a/bip-0370.mediawiki
+++ b/bip-0370.mediawiki
@@ -278,6 +278,11 @@ If the Signer added a signature that does not use SIGHASH_ANYONECANPAY, the Inpu
 If the Signer added a signature that does not use SIGHASH_NONE, the Outputs Modifiable flag must be set to False.
 If the Signer added a signature that uses SIGHASH_SINGLE, the Has SIGHASH_SINGLE flag must be set to True.
 
+===Input Finalizer===
+
+For PSBTv2s, when the Input Finalizer clears a finalized input's fields as BIP 174 asks, it must keep PSBT_IN_PREVIOUS_TXID, PSBT_IN_OUTPUT_INDEX, PSBT_IN_SEQUENCE, PSBT_IN_REQUIRED_TIME_LOCKTIME and PSBT_IN_REQUIRED_HEIGHT_LOCKTIME.
+The Transaction Extractor constructs the transaction from these fields, and an input missing either PSBT_IN_PREVIOUS_TXID or PSBT_IN_OUTPUT_INDEX is invalid.
+
 ===Transaction Extractor===
 
 For PSBTv2s, the transaction is constructed using the PSBTv2 fields.

--- a/bip-0371.mediawiki
+++ b/bip-0371.mediawiki
@@ -142,7 +142,7 @@ The new per-output types are defined as follows:
 | <tt><32 byte xonlypubkey></tt>
 | A 32 byte X-only public key involved in this output. It may be the output key, the internal key, or a key present in a leaf script.
 | <tt><compact size uint number of hashes> <32 byte leaf hash>* <4 byte fingerprint> <32-bit little endian uint path element>*</tt>
-| A compact size unsigned integer representing the number of leaf hashes, followed by a list of leaf hashes, followed by the 4 byte master key fingerprint concatenated with the derivation path of the public key. The derivation path is represented as 32-bit little endian unsigned integer indexes concatenated with each other. Public keys are those needed to spend this output. The leaf hashes are of the leaves which involve this public key. The internal key does not have leaf hashes, so can be indicated with a <tt>hashes len</tt> of 0. Finalizers should remove this field after <tt>PSBT_IN_FINAL_SCRIPTWITNESS</tt> is constructed.
+| A compact size unsigned integer representing the number of leaf hashes, followed by a list of leaf hashes, followed by the 4 byte master key fingerprint concatenated with the derivation path of the public key. The derivation path is represented as 32-bit little endian unsigned integer indexes concatenated with each other. Public keys are those needed to spend this output. The leaf hashes are of the leaves which involve this public key. The internal key does not have leaf hashes, so can be indicated with a <tt>hashes len</tt> of 0.
 |
 |
 | 0, 2


### PR DESCRIPTION
Two independent commits.

## BIP370: add an Input Finalizer section

In a version 2 PSBT, the fields that define an input live in the input map: `PSBT_IN_PREVIOUS_TXID`, `PSBT_IN_OUTPUT_INDEX`, `PSBT_IN_SEQUENCE`, and the two required-locktime fields.

BIP174 tells the Input Finalizer to clear every field of a finalized input except the UTXO and unknown fields. Followed literally on a version 2 input, this deletes the fields above. Without `PSBT_IN_PREVIOUS_TXID` or `PSBT_IN_OUTPUT_INDEX` the PSBT is invalid; without the sequence and locktime fields the Transaction Extractor builds a different transaction.

BIP370 defines every other role for version 2 but has no Input Finalizer section. This adds one, stating that the finalizer keeps those five fields. Bitcoin Core already does this: its input serializer writes them whether or not the input is finalized.

## BIP371: remove a finalizer clause from an output field

`PSBT_OUT_TAP_BIP32_DERIVATION` carries the note "Finalizers should remove this field after `PSBT_IN_FINAL_SCRIPTWITNESS` is constructed".

This is an output field. An output has no `PSBT_IN_FINAL_SCRIPTWITNESS`, and the clause names no input to act on. The two neighbouring output fields carry no such note. This removes it.

Both are minor amendments to Deployed BIPs.
