### PR TITLE
bip-0327: derive extra_in from secrets in the reference self-test

### DIFF
--- a/bip-0327/reference.py
+++ b/bip-0327/reference.py
@@ -7,7 +7,6 @@
 from typing import List, Optional, Tuple, NewType, NamedTuple
 import hashlib
 import secrets
-import time
 
 #
 # The following helper functions were copied from the BIP-340 reference implementation:
@@ -838,9 +837,9 @@ def test_sign_and_verify_random(iters: int) -> None:
         # On even iterations use regular signing algorithm for signer 2,
         # otherwise use deterministic signing algorithm
         if i % 2 == 0:
-            # Use a clock for extra_in
-            t = time.clock_gettime_ns(time.CLOCK_MONOTONIC)
-            secnonce_2, pubnonce_2 = nonce_gen(sk_2, pk_2, aggpk, msg, t.to_bytes(8, 'big'))
+            # Use random extra_in of random length
+            extra_in = secrets.token_bytes(secrets.randbelow(42))
+            secnonce_2, pubnonce_2 = nonce_gen(sk_2, pk_2, aggpk, msg, extra_in)
         else:
             aggothernonce = nonce_agg([pubnonce_1])
             rand = secrets.token_bytes(32)


### PR DESCRIPTION
`bip-0327/reference.py`'s self-test read `time.clock_gettime_ns(time.CLOCK_MONOTONIC)` for `extra_in`. Both symbols are documented "Availability: Unix" in CPython, so `python3 reference.py` raises `AttributeError` on Windows.

Following real-or-random's suggestion, `extra_in` now comes from `secrets`, with a random length in 0..41, so the self-test also exercises variable-length `extra_in`. `time` has no other use in the file, so its import is dropped.

Not tested on Windows; verified against CPython's platform-availability docs.