### PR TITLE
script: catch relative BIP links in mediawiki files

### DIFF
--- a/scripts/link-format-chk.sh
+++ b/scripts/link-format-chk.sh
@@ -9,7 +9,7 @@
 ECODE=0
 MEDIAWIKI_ECODE=0
 while IFS= read -r fname; do
-    GRES=$(grep -nE '\]\((https?://|\.\./bip-|/bip-)' "$fname")
+    GRES=$(grep -nE '\]\((https?://|((\.\.?/)+|/)?bip-)' "$fname")
     if [ "$GRES" != "" ]; then
         if [ $MEDIAWIKI_ECODE -eq 0 ]; then
             >&2 echo "GitHub Mediawiki format writes links as [URL text], not as [text](URL):"


### PR DESCRIPTION
The current MediaWiki link check misses a few Markdown-style relative BIP links, for example:

* `[text](bip-0340.mediawiki)`
* `[text](./bip-0340.mediawiki)`
* `[text](../../bip-0340.mediawiki)`

Because of that, these links can pass CI even though they use Markdown syntax inside a `.mediawiki` file.

This updates the existing regex so relative BIP links are caught consistently, including `./`, `../`, deeper parent paths, and root-relative paths.

Valid MediaWiki links are unaffected.
