### PR TITLE
script: allow hyphens in deputy email domains

### DIFF
--- a/scripts/buildtable.pl
+++ b/scripts/buildtable.pl
@@ -205,7 +205,7 @@ while (++$bipnum <= $topbip) {
 			# Enforce date format 20XX-MM-DD, where XX is 00-99, MM is 01-12 and DD is 01-31
 			die "Invalid date format in $fn" unless $val =~ /^20\d{2}\-(?:0[1-9]|1[0-2])\-(?:0[1-9]|[12]\d|30|31)$/;
 		} elsif (exists $EmailField{$field}) {
-			$val =~ m/^(\S[^<@>]*\S) \<[^@>]*\@[\w.]+\.\w+\>$/ or die "Malformed $field line in $fn";
+			$val =~ m/^(\S[^<@>]*\S) \<[^@>]*\@[\w.-]+\.\w+\>$/ or die "Malformed $field line in $fn";
 		} elsif (exists $VersionField{$field}) {
 			$val =~ m/^(\d+\.\d+\.\d+)$/ or die "Malformed $field line in $fn";
 			$version = $val;


### PR DESCRIPTION
BIP 3 specifies that the Deputies header uses the same format as the Authors header, but buildtable.pl currently validates them with slightly different domain patterns.

Authors accepts hyphens in domain names, while the generic email-field check used by Deputies and legacy Editor fields does not. As a result, a valid address such as alice@bitcoin-dev.org is accepted for an author but rejected for a deputy.

This change allows hyphens in the generic email domain matcher as well, keeping the validation consistent with the Authors format.