### PR TITLE
script: allow MIT-0 license

### DIFF
--- a/scripts/buildtable.pl
+++ b/scripts/buildtable.pl
@@ -91,6 +91,7 @@ my %AcceptableLicenses = (
 	'CC0-1.0' => undef,
 	'FSFAP' => undef,
 	'MIT' => undef,
+	'MIT-0' => undef,
 	'CC-BY-4.0' => undef,
 	'Apache-2.0' => undef,
 	'BSL-1.0' => undef,


### PR DESCRIPTION
BIP 3 lists MIT-0 as an acceptable license, but scripts/buildtable.pl does not include it in %AcceptableLicenses. As a result, a BIP using License: MIT-0 would be rejected by the table validator even though the license is explicitly permitted by BIP 3.

Add MIT-0 to the validator's acceptable-license set so the script matches the current BIP process specification.

This is a one-line validator-only change.