### PR TITLE
BIP375: validate PSBT_OUT_SP_V0_LABEL length

### DIFF
--- a/bip-0375.mediawiki
+++ b/bip-0375.mediawiki
@@ -274,6 +274,9 @@ Use the provided [[bip-0375/test_runner.py|test runner]] to validate each test v
 | missing PSBT_OUT_SP_V0_INFO field when PSBT_OUT_SP_V0_LABEL set
 |-
 | PSBT Structure
+| incorrect byte length for PSBT_OUT_SP_V0_LABEL field
+|-
+| PSBT Structure
 | incorrect byte length for PSBT_OUT_SP_V0_INFO field
 |-
 | PSBT Structure

--- a/bip-0375/bip375_test_vectors.json
+++ b/bip-0375/bip375_test_vectors.json
@@ -14,6 +14,11 @@
       "supplementary": {}
     },
     {
+      "description": "psbt structure: incorrect byte length for PSBT_OUT_SP_V0_LABEL field",
+      "psbt": "cHNidP8B+wQCAAAAAQIEAgAAAAEEAQEBBQECAQYBAAABDiAYpxdmOwurFLEqGncTI/8eQHndUy5d0T4o6hCBxwCYSgEPBAAAAAABAR8goQcAAAAAABYAFCKactNKZFvTSWu79Qu7gckGP0+UIgICyBe7dSGvw16pbzv7Jw5utQ3f+lVgYnuWH+wA8pllCL9IMEUCIQCspcmETsmSLIHmcIF+My2i3RXSxdOpRiq21l5TtoKJXgIgTfMs6jgucsQ8BYQE/a5wWVHmuj3jPYM8g6lbsBg4CscBAQMEAQAAACIGAsgXu3Uhr8NeqW87+ycObrUN3/pVYGJ7lh/sAPKZZQi/CAAAAIAAAAAAARAE/v///yIdAnpIf8Gft2mHe4dC1uoYEY88TnKx6oxt5gKnrUpB2+BoIQPspP8Rtyji4PYM5iIpQ6b/VbnZX2J7+amdCEvIctUKWyIeAnpIf8Gft2mHe4dC1uoYEY88TnKx6oxt5gKnrUpB2+BoQIoTs5hVRfcr1uiXFK65CbPjVKhCqbuLVs0O3tId+KGZWYsxIopJ4L1+lc4QU/fFsorLVDpocHYA486Jgi7jICEAAQMIoIYBAAAAAAABBCJRICJoz1KZWfMKyPelRxykxnU2pR8OWxaK8D7tRxXtzHLgAQlCAnpIf8Gft2mHe4dC1uoYEY88TnKx6oxt5gKnrUpB2+BoA+qPIovitxbaze/LKBAHKHTwCkdvXAe9BRkXEmzGSz3vAQoBAQABAwhw8wUAAAAAAAEEFgAUOMGPNd2AY+OApw/+tPmP9O80gXciAgLIF7t1Ia/DXqlvO/snDm61Dd/6VWBie5Yf7ADymWUIvwwAAAAAAAAAAAAAAAEA",
+      "supplementary": {}
+    },
+    {
       "description": "psbt structure: incorrect byte length for PSBT_OUT_SP_V0_INFO field",
       "psbt": "cHNidP8B+wQCAAAAAQIEAgAAAAEEAQEBBQEBAQYBAAABDiAYpxdmOwurFLEqGncTI/8eQHndUy5d0T4o6hCBxwCYSgEPBAAAAAABAR+ghgEAAAAAABYAFCKactNKZFvTSWu79Qu7gckGP0+UIgICyBe7dSGvw16pbzv7Jw5utQ3f+lVgYnuWH+wA8pllCL9HMEQCIAkHemqmSsFK56GqT+aMAqziBsnqxyNJBhrnYDkAuSJuAiBvFDKlePjjMK8LkAJWdGvJ9OUqoujMeQKdyOdqPClLBgEBAwQBAAAAIgYCyBe7dSGvw16pbzv7Jw5utQ3f+lVgYnuWH+wA8pllCL8IAAAAgAAAAAABEAT+////Ih0Cekh/wZ+3aYd7h0LW6hgRjzxOcrHqjG3mAqetSkHb4GghA+yk/xG3KOLg9gzmIilDpv9VudlfYnv5qZ0IS8hy1QpbIh4Cekh/wZ+3aYd7h0LW6hgRjzxOcrHqjG3mAqetSkHb4GhAihOzmFVF9yvW6JcUrrkJs+NUqEKpu4tWzQ7e0h34oZlZizEiikngvX6VzhBT98WyistUOmhwdgDjzomCLuMgIQABAwgYcwEAAAAAAAEEIlEgMm31D+Cge3rLcgcL6ztjLrmtFbppXMHlqmqgB7YUb9gBCUECekh/wZ+3aYd7h0LW6hgRjzxOcrHqjG3mAqetSkHb4GgDYeGx6d5eQssgB/fKVLng1X7ROTj61W0/GeV1E6j84AA=",
       "supplementary": {}

--- a/bip-0375/validator/validate_psbt.py
+++ b/bip-0375/validator/validate_psbt.py
@@ -46,6 +46,7 @@ def validate_psbt_structure(psbt: PSBT) -> Tuple[bool, str]:
     Checks:
     - Each output must have PSBT_OUT_SCRIPT or PSBT_OUT_SP_V0_INFO
     - PSBT_OUT_SP_V0_LABEL requires PSBT_OUT_SP_V0_INFO
+    - SP_V0_LABEL must be 4 bytes (32-bit little-endian uint)
     - SP_V0_INFO must be 66 bytes (33-byte scan key + 33-byte spend key)
     - ECDH shares must be 33 bytes
     - DLEQ proofs must be 64 bytes
@@ -72,6 +73,15 @@ def validate_psbt_structure(psbt: PSBT) -> Tuple[bool, str]:
                 False,
                 f"Output {i} has PSBT_OUT_SP_V0_LABEL but missing PSBT_OUT_SP_V0_INFO",
             )
+
+        # Validate SP_V0_LABEL field length
+        if has_sp_label:
+            sp_label = output_map[PSBT_OUT_SP_V0_LABEL]
+            if len(sp_label) != 4:
+                return (
+                    False,
+                    f"Output {i} PSBT_OUT_SP_V0_LABEL has wrong length ({len(sp_label)} bytes, expected 4)",
+                )
 
         # Validate SP_V0_INFO field length
         if has_sp_info:


### PR DESCRIPTION

This PR updates the BIP-375 reference validator to enforce the serialized length of PSBT_OUT_SP_V0_LABEL.

BIP-375 defines the field value as a 32-bit little-endian unsigned integer, so PSBT_OUT_SP_V0_LABEL must contain exactly 4 bytes. Previously, the validator only checked that PSBT_OUT_SP_V0_LABEL requires PSBT_OUT_SP_V0_INFO, allowing malformed values such as a one-byte label when valid SP_V0_INFO was present.

